### PR TITLE
WiFi scanning improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "once_cell",
  "os-release",
  "relm4-macros",
+ "slotmap",
  "sysinfo",
  "tokio",
  "tokio-stream",
@@ -1542,6 +1543,15 @@ name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
+name = "slotmap"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio-stream = "0.1.8"
 zvariant = "3.0.0"
 anyhow = "1.0.52"
 relm4-macros = "0.4.1"
+slotmap = "1.0.6"
 
 [build-dependencies]
 grass = "0.10.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate cascade;
 extern crate relm4_macros;
 
 mod sections;
+mod task;
 mod ui;
 mod widgets;
 

--- a/src/sections/wifi/visible_networks.rs
+++ b/src/sections/wifi/visible_networks.rs
@@ -230,7 +230,7 @@ impl SettingsGroup for VisibleNetworks {
 		});
 
 		let target = target.downgrade();
-		glib::MainContext::default().spawn_local(async move {
+		crate::task::spawn_local(async move {
 			let mut aps = SlotMap::new();
 
 			while let Some(event) = net_rx.recv().await {
@@ -252,7 +252,7 @@ impl SettingsGroup for VisibleNetworks {
 								.text(&format!("TODO {}", ap.ssid))
 								.build();
 
-							glib::MainContext::default().spawn_local(async move {
+							crate::task::spawn_local(async move {
 								dialog.run_future().await;
 								dialog.close();
 							});

--- a/src/sections/wifi/visible_networks.rs
+++ b/src/sections/wifi/visible_networks.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use crate::{sections::SettingsGroup, ui::SettingsGui, RT};
+use crate::{sections::SettingsGroup, ui::SettingsGui};
 use cosmic_dbus_networkmanager::{
 	device::SpecificDevice, interface::enums::ApSecurityFlags, nm::NetworkManager,
 };
@@ -213,7 +213,7 @@ impl SettingsGroup for VisibleNetworks {
 
 		let cancel = Arc::new(AtomicBool::new(false));
 
-		RT.get().unwrap().spawn({
+		crate::task::spawn({
 			let cancel = cancel.clone();
 			let tx = net_tx.clone();
 			async move {

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,5 @@
+use std::future::Future;
+
+pub fn spawn_local<F: Future<Output = ()> + 'static>(future: F) {
+	gtk4::glib::MainContext::default().spawn_local(future);
+}

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,5 +1,13 @@
 use std::future::Future;
 
+pub fn spawn<O, F>(future: F) -> tokio::task::JoinHandle<O>
+where
+	F: Future<Output = O> + Send + 'static,
+	O: Send + 'static,
+{
+	crate::RT.get().unwrap().spawn(future)
+}
+
 pub fn spawn_local<F: Future<Output = ()> + 'static>(future: F) {
 	gtk4::glib::MainContext::default().spawn_local(future);
 }


### PR DESCRIPTION
Something like this should work effectively for handling GTK events in Rust without the need for much reference counting.

- Uses an event loop in a `glib::MainContext::default()` spawned local future for handling events to the WiFi widget and managing all WiFi-related state.
- Sends events using a `tokio::sync::mpsc::UnboundedSender` so it doesn't block widget signals
- AP info stored in a `SlotMap` so they can be referenced by an ID across events.
- Added dummy dialog to respond to configure signals
- Convenience function `task::spawn_local` for spawning tasks locally on GLib.
- `task::spawn` for spawning tasks in the background on Tokio.