### PR TITLE
Use `byte_unit` to display memory and disk space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3348673602e04848647fffaa8e9a861e7b5d5cae6570727b41bde0f722514484"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "bytecheck"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +547,7 @@ name = "cosmic-settings-system"
 version = "0.1.0"
 dependencies = [
  "bumpalo",
+ "byte-unit",
  "concat-in-place",
  "const_format",
  "memchr",
@@ -3825,6 +3835,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "valuable"

--- a/pages/system/Cargo.lock
+++ b/pages/system/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3348673602e04848647fffaa8e9a861e7b5d5cae6570727b41bde0f722514484"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +66,7 @@ name = "cosmic-settings-system"
 version = "0.1.0"
 dependencies = [
  "bumpalo",
+ "byte-unit",
  "concat-in-place",
  "const_format",
  "memchr",
@@ -239,6 +249,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "winapi"

--- a/pages/system/Cargo.toml
+++ b/pages/system/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+byte-unit = { version = "4.0.18", default-features = false }
 const_format = "0.2.30"
 concat-in-place = "1.1.0"
 sysinfo = "0.27.7"

--- a/pages/system/src/lib.rs
+++ b/pages/system/src/lib.rs
@@ -55,13 +55,13 @@ impl Info {
             total_capacity += disk.total_space();
         }
 
-        info.disk_capacity = format!("{} GB", (total_capacity / 1_000_000_000));
+        info.disk_capacity = format_size(total_capacity);
 
         if let Some(name) = sys.host_name() {
             info.device_name = name;
         }
 
-        info.memory = format!("{} GB", (sys.total_memory() / 1_000_000_000 + 1));
+        info.memory = format_size(sys.total_memory());
 
         if let Ok(mut session) = std::env::var("XDG_SESSION_TYPE") {
             if let Some(first) = session.get_mut(0..1) {
@@ -199,4 +199,10 @@ pub fn read_to_string<'a, P: AsRef<OsStr>>(
     }
 
     std::str::from_utf8(buffer.as_slice()).ok()
+}
+
+fn format_size(size: u64) -> String {
+    byte_unit::Byte::from_bytes(size)
+        .get_appropriate_unit(true)
+        .to_string()
 }


### PR DESCRIPTION
I noticed it was showing in GB, when it should probably use GiB. This handles that, and also shows in TiB, MiB, etc. as needed.