### PR TITLE
i18n(tr): add Turkish language

### DIFF
--- a/i18n/tr/cosmic_settings.ftl
+++ b/i18n/tr/cosmic_settings.ftl
@@ -1,0 +1,223 @@
+app = COSMIC Ayarları
+
+unknown = Bilinmiyor
+
+number = { $number }
+
+## Desktop
+
+desktop = Masaüstü
+
+## Desktop: Appearance
+
+appearance = Görünüm
+    .desc = Ana renkler ve COSMIC temaları.
+
+## Desktop: Notifications
+
+notifications = Bildirimler
+    .desc = Rahatsız Etme, kilit ekranı bildirimleri, ve uygulama başına ayarlar.
+
+
+## Desktop: Options
+
+desktop-panel-options = Masaüstü ve Panel
+    .desc = Logo Tuşu eylemi, hızlı köşeler, pencere kontrol seçenekleri.
+
+super-key-action = Logo Tuşu Eylemi
+    .launcher = Başlatıcı
+    .workspaces = Çalışma Alanları
+    .applications = Uygulamalar
+
+hot-corner = Hızlı Köşe
+    .top-left-corner = Çalışma Alanları için sol-üst hızlı köşeyi etkinleştir
+
+top-panel = Üst Panel
+    .workspaces = Çalışma Alanları tuşunu göster
+    .applications = Uygulamalar tuşunu göster
+
+window-controls = Pencere Seçenekleri
+    .minimize = Küçültme tuşunu göster
+    .maximize = Büyültme tuşunu göster
+
+desktop-panels-and-applets = Masaüstü Panelleri ve Eklentiler
+
+
+dock = Görev Çubuğu
+    .desc = Sabitlenmiş uygulamaların bulunduğu panel.
+
+## Desktop: Panel
+panel = Panel
+    .desc = Masaüstü seçeneklerin ve menülerin bulunduğu üst panel.
+
+panel-behavior-and-position = Davranış ve Konumlar
+    .autohide = Otomatik olarak paneli gizle
+    .position = Ekrandaki konum
+    .display = Ekranda göster
+
+panel-top = Yukarı
+panel-bottom = Aşağı
+panel-left = Sol
+panel-right = Sağ
+
+panel-appearance = Görünüm
+    .match = Masaüstü ile aynı
+    .light = Açık
+    .dark = Koyu
+
+panel-style = Stil
+    .anchor-gap = Ekran kenarları ve panel arasındaki boşluk
+    .extend = Paneli ekran kenarlarına uzat
+    .appearance = Görünüm
+    .size = Boyut
+    .background-opacity = Arkaplan şeffaflığı
+
+small = Küçük
+large = Büyük
+
+panel-applets = Yapılandırma
+    .desc = Panel eklentilerini yapılandır.
+
+panel-missing = Panel Yapılandırması Eksik
+    .desc = Panel yapılandırma dosyası, özel bir yapılandırmadan veya bozulduğundan dolayı eksik.
+    .fix = Varsayılana sıfırla
+
+applets = Eklentiler
+start-segment = Baş Kısım
+center-segment = Orta Kısım
+end-segment = Son Kısım
+
+add = Ekle
+add-applet = Eklenti Ekle
+search-applets = Eklenti ara...
+no-applets-found = Eklenti bulunamadı...
+all = Tümü
+
+drop-here = Eklentileri buraya bırak
+
+## Desktop: Wallpaper
+
+wallpaper = Duvar Kağıdı
+    .desc = Arkaplan resimleri, renkler, ve slayt seçenekleri.
+    .same = Tüm ekranlarda aynı resim
+    .fit = Resmi sığdır
+    .slide = Slayt gösterisi
+    .change = Resmi şu sürede bir değiştir
+
+all-displays = Tüm Ekranlar
+colors = Renkler
+fit-to-screen = Ekrana Sığdır
+stretch = Uzat
+system-backgrounds = Sistem duvar kağıtları
+zoom = Yakınlaştır
+
+x-minutes = { $number } dakika
+x-hours = { $number ->
+    [1] 1 saat
+    *[other] { $number } saat
+}
+
+## Desktop: Workspaces
+
+workspaces = Çalışma Alanları
+    .desc = Çalışma alan sayısını, davranışını, ve yerini değiştir.
+
+workspaces-behavior = Çalışma Alanı Davranışı
+    .dynamic = Kendiliğinden çalışma alanı
+    .fixed = Sabit sayıda çalışma alanı
+
+workspaces-multi-behavior = Çoklu-ekran Davranışı
+    .span = Çalışma alanı ekranlara yayılsın
+    .separate = Her ekran için ayrı çalışma alanı
+
+## Networking: Wired
+
+wired = Kablolu
+    .desc = Kablolu bağlantı, bağlantı profilleri
+
+## Networking: Online Accounts
+
+online-accounts = Çevrim İçi Hesaplar
+    .desc = Hesap ekle, IMAP ve SMTP, kurumsal girişler
+
+## Time & Language
+
+time = Zaman & Dil
+    .desc = N/A
+
+time-date = Tarih & Saat
+    .desc = Saat dilimi, otomatik saat ayarları ve zaman formatı.
+    .auto = Otomatik ayarla
+
+time-zone = Saat Dilimi
+    .auto = Otomatik saat dilimi
+    .auto-info = Konum servisleri ve internet erişimine ihtiyaç duyar
+
+time-format = Tarih & Saat Formatı
+    .twenty-four = 24-saat biçimi
+    .first = Haftanın ilk günü
+
+time-region = Bölge & Dil
+    .desc = Bölgenize göre tarih, saat ve sayıların biçimi
+
+## Sound
+
+sound = Ses
+    .desc = N/A
+
+sound-output = Çıkış
+    .volume = Çıkış sesi
+    .device = Çıkış aygıtı
+    .level = Çıkış seviyesi
+    .config = Yapılandırma
+    .balance = Denge
+
+sound-input = Giriş
+    .volume = Giriş sesi
+    .device = Giriş aygıtı
+    .level = Giriş seviyesi
+
+sound-alerts = Uyarılar
+    .volume = Uyarı seviyesi
+    .sound = Uyarı sesi
+
+sound-applications = Uygulamalar
+    .desc = Uygulama sesleri ve ayarları
+
+## System
+
+system = Sistem & Hesaplar
+
+## System: About
+
+about = Hakkında
+    .desc = Cihaz adı, donanım bilgisi, işletim sistemi varsayılanları.
+
+about-device = Cihaz adı
+    .desc = Bu isim, bluetooth cihazlarına ve ağdaki diğer cihazlara gözükür.
+
+about-hardware = Donanım
+    .model = Donanım modeli
+    .memory = Bellek
+    .processor = İşlemci
+    .graphics = Grafik
+    .disk-capacity = Disk Kapasitesi
+
+about-os = İşletim Sistemi
+    .os = İşletim sistemi
+    .os-architecture = İşletim sistemi mimarisi
+    .desktop-environment = Masaüstü ortamı
+    .windowing-system = Pencere sistemi
+
+about-related = İlgili ayarlar
+    .support = Destek al
+
+## System: Firmware
+
+firmware = Yazılım
+    .desc = Yazılım detayları.
+
+## System: Users
+
+users = Kullanıcılar
+    .desc = Yetkilendirme ve giriş, kilit ekranı.


### PR DESCRIPTION
Added Turkish language.

"Applets" are translated as "Extensions", because there is no exact translation of "applet" in Turkish, the closest word could be "uygulamacık" (means "tiny-apps", "mini-apps"), but "uygulamacık" sounded too silly to me and I thought it could be confused with the actual apps that you install on the system.

I'm also hoping to translate the new strings once they added!