### PR TITLE
fix: set the margin of the panel when setting anchor gap

### DIFF
--- a/app/src/pages/desktop/panel/mod.rs
+++ b/app/src/pages/desktop/panel/mod.rs
@@ -426,6 +426,12 @@ impl Page {
 
                 panel_config.anchor_gap = enabled;
 
+                if enabled {
+                    panel_config.margin = 4;
+                } else {
+                    panel_config.margin = 0;
+                }
+
                 _ = panel_config.write_entry(helper);
             }
             Message::PanelSize(size) => {


### PR DESCRIPTION
I'm not sure what would be the best default here, but I've gone with 4 for now.