### PR TITLE
Return early from panel PageInner::update function if no panel_config

### DIFF
--- a/app/src/pages/desktop/panel/inner.rs
+++ b/app/src/pages/desktop/panel/inner.rs
@@ -324,7 +324,9 @@ impl PageInner {
     #[allow(clippy::too_many_lines)]
     pub fn update(&mut self, message: Message) {
         let helper = self.config_helper.as_ref().unwrap();
-        let mut panel_config = self.panel_config.as_mut().unwrap();
+        let Some(mut panel_config) = self.panel_config.as_mut() else {
+            return
+        };
 
         match message {
             Message::AutoHidePanel(enabled) => {


### PR DESCRIPTION
This fixes a potential panic if the dock or panel configs are not defined.