### PR TITLE
Wallpaper improvements and fixes

### DIFF
--- a/app/src/pages/desktop/wallpaper/widgets.rs
+++ b/app/src/pages/desktop/wallpaper/widgets.rs
@@ -15,6 +15,7 @@ const COLUMN_SPACING: u16 = 12;
 const ROW_SPACING: u16 = 16;
 
 /// A button for selecting a color or gradient.
+#[must_use]
 pub fn color_button(
     color: wallpaper::Color,
     removable: bool,
@@ -36,6 +37,7 @@ pub fn color_button(
 }
 
 /// A sized container that's filled with a color or gradient.
+#[must_use]
 pub fn color_image<'a, M: 'a>(
     color: wallpaper::Color,
     width: u16,
@@ -78,6 +80,7 @@ pub fn color_image<'a, M: 'a>(
 }
 
 /// Color selection list
+#[must_use]
 pub fn color_select_options(
     context: &super::Context,
     selected: Option<&wallpaper::Color>,
@@ -106,22 +109,26 @@ pub fn color_select_options(
 }
 
 /// Background selection list
+#[must_use]
 pub fn wallpaper_select_options(
     page: &super::Page,
     selected: Option<DefaultKey>,
+    show_custom_images: bool,
 ) -> Element<Message> {
     let mut vec = Vec::with_capacity(page.selection.selection_handles.len());
 
-    // Place removable custom images first
-    for id in page.selection.custom_images.iter().rev() {
-        let handle = &page.selection.selection_handles[*id];
+    if show_custom_images {
+        // Place removable custom images first
+        for id in page.selection.custom_images.iter().rev() {
+            let handle = &page.selection.selection_handles[*id];
 
-        vec.push(wallpaper_button(
-            handle,
-            *id,
-            true,
-            selected.map_or(false, |selection| id == &selection),
-        ));
+            vec.push(wallpaper_button(
+                handle,
+                *id,
+                true,
+                selected.map_or(false, |selection| id == &selection),
+            ));
+        }
     }
 
     // Then place non-removable images from the current folder

--- a/i18n/cs/cosmic_settings.ftl
+++ b/i18n/cs/cosmic_settings.ftl
@@ -112,7 +112,6 @@ all-displays = Všechny monitory
 colors = Barvy
 fit-to-screen = Vyplnit obrazovku
 stretch = Roztáhnout
-system-backgrounds = Systémové pozadí
 zoom = Přiblížení
 
 x-minutes = { $number } minut

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -144,24 +144,25 @@ panel-missing = Panel Configuration is Missing
 ## Desktop: Wallpaper
 
 wallpaper = Wallpaper
-    .desc = Background images, colors, and slideshow options.
-    .same = Same background on all displays
-    .fit = Background fit
-    .slide = Slideshow
     .change = Change image every
+    .desc = Wallpaper images, colors, and slideshow options.
+    .fit = Wallpaper fit
+    .folder-dialog = Choose wallpaper folder
+    .image-dialog = Choose wallpaper image
+    .plural = Wallpapers
+    .same = Same wallpaper on all displays
+    .slide = Slideshow
 
 add-color = Add color
 add-image = Add image
 all-displays = All Displays
 colors = Colors
+dialog-add = _Add
 fit-to-screen = Fit to Screen
+open-new-folder = Open new folder
 recent-folders = Recent Folders
 stretch = Stretch
-system-backgrounds = System backgrounds
 zoom = Zoom
-
-wallpaper-dialog-image = Choose wallpaper image
-    .accept = _Add
 
 x-minutes = { $number } minutes
 x-hours = { $number ->

--- a/i18n/it/cosmic_settings.ftl
+++ b/i18n/it/cosmic_settings.ftl
@@ -107,7 +107,6 @@ all-displays = Tutti gli Schermi
 colors = Colori
 fit-to-screen = Adatta allo Schermo
 stretch = Allarga
-system-backgrounds = Sfondi di sistema
 zoom = Zoom
 
 x-minutes = { $number } minuti

--- a/i18n/ru/cosmic_settings.ftl
+++ b/i18n/ru/cosmic_settings.ftl
@@ -155,7 +155,6 @@ all-displays = Все экраны
 colors = Цвета
 fit-to-screen = Подгонять под экран
 stretch = Растянуть
-system-backgrounds = Системные фоны
 zoom = Увеличить
 
 x-minutes = { $number } минут

--- a/i18n/sr-Cyrl/cosmic_settings.ftl
+++ b/i18n/sr-Cyrl/cosmic_settings.ftl
@@ -155,7 +155,6 @@ all-displays = Сви екрани
 colors = Боје
 fit-to-screen = Уклопи у екран
 stretch = Развуци
-system-backgrounds = Системске позадине
 zoom = Увећај
 
 x-minutes = { $number } мин.

--- a/i18n/sr-Latn/cosmic_settings.ftl
+++ b/i18n/sr-Latn/cosmic_settings.ftl
@@ -155,7 +155,6 @@ all-displays = Svi ekrani
 colors = Boje
 fit-to-screen = Uklopi u ekran
 stretch = Razvuci
-system-backgrounds = Sistemske pozadine
 zoom = Uvećaj
 
 x-minutes = { $number } min.

--- a/i18n/tr/cosmic_settings.ftl
+++ b/i18n/tr/cosmic_settings.ftl
@@ -108,7 +108,6 @@ all-displays = Tüm Ekranlar
 colors = Renkler
 fit-to-screen = Ekrana Sığdır
 stretch = Uzat
-system-backgrounds = Sistem duvar kağıtları
 zoom = Yakınlaştır
 
 x-minutes = { $number } dakika

--- a/i18n/zh-TW/cosmic_settings.ftl
+++ b/i18n/zh-TW/cosmic_settings.ftl
@@ -148,7 +148,6 @@ all-displays = 所有顯示器
 colors = 顏色
 fit-to-screen = 延伸至全螢幕
 stretch = 延伸
-system-backgrounds = 系統背景
 zoom = 縮放
 
 x-minutes = { $number } 分鐘

--- a/pages/desktop/src/wallpaper.rs
+++ b/pages/desktop/src/wallpaper.rs
@@ -69,12 +69,6 @@ pub fn config() -> (Config, HashMap<String, String>) {
 
 pub fn set(config: &mut Config, entry: Entry) {
     if let Ok(context) = Config::helper() {
-        tracing::debug!(
-            output = entry.output.to_string(),
-            source = ?entry.source,
-            "setting wallpaper",
-        );
-
         let _res = Config::set_same_on_all(&context, config.same_on_all);
 
         if let Err(why) = config.set_entry(&context, entry) {

--- a/resources/com.system76.CosmicSettings.desktop
+++ b/resources/com.system76.CosmicSettings.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Cosmic Settings
+Name=COSMIC Settings
 Type=Application
 Exec=cosmic-settings
 Terminal=false


### PR DESCRIPTION
- Added "Open new folder" dropdown menu list option
    - Replaces behavior when adding images
    - Adds a new dialog for choosing a folder
- Fixed custom images disappearing when switching to the system wallpaper option
- Changed "System backgrounds" option to "Wallpapers"
- Changed text referencing "background" to "wallpaper"
- Added symbolic file icon when a recent folder is selected
- Custom images and the "Add image" button are hidden when showing a recent folder
- Fixed possible duplicates in the wallpaper background selection view
- Culls missing paths from config if config contained paths that no longer exists