### PR TITLE
fix: thorough detection of desktop environment

### DIFF
--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -74,7 +74,13 @@ impl Info {
             info.windowing_system = session;
         }
 
-        if let Ok(mut session) = std::env::var("DESKTOP_SESSION") {
+        // prefer XDG_SESSION_DESKTOP because the value is singular: https://www.freedesktop.org/software/systemd/man/latest/pam_systemd.html
+        if let Ok(mut session) = std::env::var("XDG_SESSION_DESKTOP")
+            // otherwise, XDG_CURRENT_DESKTOP (could be plural): https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
+            .or_else(|_| std::env::var("XDG_CURRENT_DESKTOP"))
+            // fallback to legacy environment variable
+            .or_else(|_| std::env::var("DESKTOP_SESSION"))
+        {
             if let Some(first) = session.get_mut(0..1) {
                 first.make_ascii_uppercase();
             }


### PR DESCRIPTION
- neither `greetd` nor `cosmic-greeter` nor `cosmic-session` set DESKTOP_SESSION, which seems to be a legacy/deprecated variable now, which means the "Desktop environment" field is visually empty
- so this PR updates the detection of desktop environment to check for newer XDG_(SESSION|CURRENT)_DESKTOP variables first
- I've confirmed that this fixes the "Desktop environment" field when running in a COSMIC session started from `cosmic-greeter`, and it also continues to work in COSMIC and GNOME sessions when started from `gdm` (which does set the DESKTOP_SESSION variable)