### PR TITLE
Wallpaper settings improvements

### DIFF
--- a/app/src/pages/desktop/wallpaper/mod.rs
+++ b/app/src/pages/desktop/wallpaper/mod.rs
@@ -48,8 +48,8 @@ use image::{ImageBuffer, Rgba};
 use slotmap::{DefaultKey, SecondaryMap, SlotMap};
 use static_init::dynamic;
 
-const FIT: usize = 0;
-const ZOOM: usize = 1;
+const ZOOM: usize = 0;
+const FIT: usize = 1;
 
 const SIMULATED_WIDTH: u16 = 300;
 const SIMULATED_HEIGHT: u16 = 169;


### PR DESCRIPTION
- The Fill and Fit to Screen options in the interface were flipped
- Changing between outputs will no longer flip wallpapers, and will also select that wallpaper's active background

All that remains is to improve handling of toggling the slideshow feature.