### PR TITLE
Display page improvements

### DIFF
--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -624,9 +624,16 @@ impl SettingsApp {
             let section = &self.pages.sections[id];
             let model = &self.pages.page[self.active_page];
 
-            column_widgets.push(
-                (section.view_fn)(&self.pages, model.as_ref(), section).map(Message::PageMessage),
-            );
+            if section
+                .show_while
+                .as_ref()
+                .map_or(true, |func| func(model.as_ref()))
+            {
+                column_widgets.push(
+                    (section.view_fn)(&self.pages, model.as_ref(), section)
+                        .map(Message::PageMessage),
+                );
+            }
         }
 
         settings::view_column(column_widgets).into()
@@ -680,12 +687,18 @@ impl SettingsApp {
                 sections.push(search_header(&self.pages, page));
             }
 
-            let section = (section.view_fn)(&self.pages, model.as_ref(), section)
-                .map(Message::PageMessage)
-                .apply(iced::widget::container)
-                .padding([0, 0, 0, cosmic::theme::active().cosmic().space_xl()]);
+            if section
+                .show_while
+                .as_ref()
+                .map_or(true, |func| func(model.as_ref()))
+            {
+                let section = (section.view_fn)(&self.pages, model.as_ref(), section)
+                    .map(Message::PageMessage)
+                    .apply(iced::widget::container)
+                    .padding([0, 0, 0, cosmic::theme::active().cosmic().space_xl()]);
 
-            sections.push(section.into());
+                sections.push(section.into());
+            }
         }
 
         settings::view_column(sections).into()

--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -149,7 +149,7 @@ impl cosmic::Application for SettingsApp {
         } else {
             icon::from_name("system-search-symbolic")
                 .apply(button::icon)
-                .padding([0, 16])
+                .padding([0, cosmic::theme::active().cosmic().space_s()])
                 .on_press(Message::SearchActivate)
                 .into()
         });
@@ -420,6 +420,8 @@ impl cosmic::Application for SettingsApp {
     }
 
     fn view(&self) -> Element<Message> {
+        let theme = cosmic::theme::active();
+
         let page_view = if self.search_active {
             self.search_view()
         } else if let Some(content) = self.pages.content(self.active_page) {
@@ -430,14 +432,18 @@ impl cosmic::Application for SettingsApp {
             panic!("page without sub-pages or content");
         };
 
-        let padding = if self.core.is_condensed() { 0 } else { 64 };
+        let padding = if self.core.is_condensed() {
+            0
+        } else {
+            theme.cosmic().space_l()
+        };
 
         container(page_view)
             .max_width(800)
             .width(Length::Fill)
             .apply(container)
             .center_x()
-            .padding([0, padding])
+            .padding([theme.cosmic().space_xxs(), padding])
             .width(Length::Fill)
             .apply(scrollable)
             .into()
@@ -601,9 +607,10 @@ impl SettingsApp {
                 Message::Page(parent),
             );
 
-            let mut page_header_content = row::with_capacity(2)
-                .align_items(iced::Alignment::End)
-                .push(page_header);
+            let mut page_header_content: cosmic::iced_widget::Row<'_, Message, Theme> =
+                row::with_capacity(2)
+                    .align_items(iced::Alignment::End)
+                    .push(page_header);
 
             if let Some(element) = page.header_view() {
                 page_header_content = page_header_content.push(element.map(Message::from));
@@ -622,7 +629,7 @@ impl SettingsApp {
             );
         }
 
-        settings::view_column(column_widgets).padding(0).into()
+        settings::view_column(column_widgets).into()
     }
 
     fn search_changed(&mut self, phrase: String) {
@@ -676,7 +683,7 @@ impl SettingsApp {
             let section = (section.view_fn)(&self.pages, model.as_ref(), section)
                 .map(Message::PageMessage)
                 .apply(iced::widget::container)
-                .padding([0, 0, 0, 48]);
+                .padding([0, 0, 0, cosmic::theme::active().cosmic().space_xl()]);
 
             sections.push(section.into());
         }
@@ -686,7 +693,9 @@ impl SettingsApp {
 
     /// Displays the sub-pages view of a page.
     fn sub_page_view(&self, sub_pages: &[page::Entity]) -> cosmic::Element<Message> {
-        let mut page_list = column::with_capacity(sub_pages.len()).spacing(18);
+        let theme = cosmic::theme::active();
+        let mut page_list =
+            column::with_capacity(sub_pages.len()).spacing(theme.cosmic().space_s());
 
         for entity in sub_pages.iter().copied() {
             let sub_page = &self.pages.info[entity];
@@ -701,7 +710,8 @@ impl SettingsApp {
         column::with_capacity(2)
             .push(page_title(&self.pages.info[self.active_page]))
             .push(Element::from(page_list).map(Message::Page))
-            .spacing(24)
+            .spacing(theme.cosmic().space_m())
+            .padding(0)
             .into()
     }
 }

--- a/app/src/pages/display/arrangement.rs
+++ b/app/src/pages/display/arrangement.rs
@@ -448,8 +448,8 @@ fn update_dragged_region(
 
         let center = dragged_region.center();
 
-        let eastward = distance(east_point(&other_region), center) * 1.5;
-        let westward = distance(west_point(&other_region), center) * 1.5;
+        let eastward = distance(east_point(&other_region), center) * 1.25;
+        let westward = distance(west_point(&other_region), center) * 1.25;
         let northward = distance(north_point(&other_region), center);
         let southward = distance(south_point(&other_region), center);
 

--- a/app/src/pages/display/mod.rs
+++ b/app/src/pages/display/mod.rs
@@ -11,6 +11,7 @@ use arrangement::Arrangement;
 use cosmic::iced::Length;
 use cosmic::iced_core::Alignment;
 use cosmic::iced_widget::scrollable::{Direction, Properties};
+use cosmic::prelude::CollectionWidget;
 use cosmic::widget::{
     column, container, dropdown, list_column, segmented_button, toggler, view_switcher,
 };
@@ -179,6 +180,8 @@ impl page::Page<crate::pages::Message> for Page {
                         text::DISPLAY_ARRANGEMENT.clone(),
                         text::DISPLAY_ARRANGEMENT_DESC.clone(),
                     ])
+                    // Show section when there is more than 1 display
+                    .show_while::<Page>(|page| page.list.outputs.len() > 1)
                     .view::<Page>(|_binder, page, _section| page.display_arrangement_view()),
             ),
             // Display configuration
@@ -444,7 +447,11 @@ impl Page {
 
         column()
             .spacing(theme.cosmic().space_m())
-            .push(view_switcher::horizontal(&self.display_tabs).on_activate(Message::Display))
+            .push_maybe(if self.list.outputs.len() > 1 {
+                Some(view_switcher::horizontal(&self.display_tabs).on_activate(Message::Display))
+            } else {
+                None
+            })
             .push(display_meta)
             .push(cosmic::widget::text::heading(&*text::DISPLAY_OPTIONS))
             .push(display_options)

--- a/app/src/pages/display/mod.rs
+++ b/app/src/pages/display/mod.rs
@@ -9,8 +9,7 @@ use crate::{app, pages};
 use apply::Apply;
 use arrangement::Arrangement;
 use cosmic::iced::Length;
-use cosmic::iced_core::Alignment;
-use cosmic::iced_widget::scrollable::{Direction, Properties};
+use cosmic::iced_widget::scrollable::{Direction, Properties, RelativeOffset};
 use cosmic::prelude::CollectionWidget;
 use cosmic::widget::{
     column, container, dropdown, list_column, segmented_button, toggler, view_switcher,
@@ -116,7 +115,6 @@ enum Randr {
 }
 
 /// The page struct for the display settings page.
-#[derive(Default)]
 pub struct Page {
     list: List,
     display_tabs: segmented_button::SingleSelectModel,
@@ -124,6 +122,21 @@ pub struct Page {
     config: Config,
     cache: ViewCache,
     context: Option<ContextDrawer>,
+    display_arrangement_scrollable: cosmic::widget::Id,
+}
+
+impl Default for Page {
+    fn default() -> Self {
+        Self {
+            list: List::default(),
+            display_tabs: segmented_button::SingleSelectModel::default(),
+            active_display: OutputKey::default(),
+            config: Config::default(),
+            cache: ViewCache::default(),
+            context: None,
+            display_arrangement_scrollable: cosmic::widget::Id::unique(),
+        }
+    }
 }
 
 #[derive(Default)]
@@ -360,7 +373,10 @@ impl Page {
             }
         }
 
-        Command::none()
+        cosmic::iced::widget::scrollable::snap_to(
+            self.display_arrangement_scrollable.clone(),
+            RelativeOffset { x: 0.5, y: 0.5 },
+        )
     }
 
     /// View for the display arrangement section.
@@ -379,6 +395,7 @@ impl Page {
                     .on_select(|id| pages::Message::Displays(Message::Display(id)))
                     .on_placement(|id, x, y| pages::Message::Displays(Message::Position(id, x, y)))
                     .apply(cosmic::widget::scrollable)
+                    .id(self.display_arrangement_scrollable.clone())
                     .width(Length::Shrink)
                     .direction(Direction::Horizontal(Properties::new()))
                     .apply(container)

--- a/app/src/pages/display/mod.rs
+++ b/app/src/pages/display/mod.rs
@@ -362,9 +362,14 @@ impl Page {
 
     /// View for the display arrangement section.
     pub fn display_arrangement_view(&self) -> Element<pages::Message> {
+        let theme = cosmic::theme::active();
+
         column()
-            .padding(cosmic::iced::Padding::from([16, 24]))
-            .spacing(10)
+            .padding(cosmic::iced::Padding::from([
+                theme.cosmic().space_s(),
+                theme.cosmic().space_m(),
+            ]))
+            .spacing(theme.cosmic().space_xs())
             .push(cosmic::widget::text::body(&*text::DISPLAY_ARRANGEMENT_DESC))
             .push({
                 Arrangement::new(&self.list, &self.display_tabs)
@@ -383,6 +388,8 @@ impl Page {
 
     /// View for the display configuration section.
     pub fn display_view(&self) -> Element<pages::Message> {
+        let theme = cosmic::theme::active();
+
         let Some(&active_id) = self.display_tabs.active_data::<OutputKey>() else {
             return column().into();
         };
@@ -436,7 +443,7 @@ impl Page {
             ));
 
         column()
-            .spacing(24)
+            .spacing(theme.cosmic().space_m())
             .push(view_switcher::horizontal(&self.display_tabs).on_activate(Message::Display))
             .push(display_meta)
             .push(cosmic::widget::text::heading(&*text::DISPLAY_OPTIONS))
@@ -541,7 +548,7 @@ impl Page {
                 .iter()
                 .filter_map(|&id| self.list.modes.get(id).map(|m| (id, m)))
             {
-                let refresh_rates = self.cache.modes.entry(mode.size).or_insert_with(Vec::new);
+                let refresh_rates = self.cache.modes.entry(mode.size).or_default();
 
                 refresh_rates.push(mode.refresh_rate);
 

--- a/app/src/pages/display/mod.rs
+++ b/app/src/pages/display/mod.rs
@@ -9,6 +9,7 @@ use crate::{app, pages};
 use apply::Apply;
 use arrangement::Arrangement;
 use cosmic::iced::Length;
+use cosmic::iced_core::Alignment;
 use cosmic::iced_widget::scrollable::{Direction, Properties};
 use cosmic::widget::{
     column, container, dropdown, list_column, segmented_button, toggler, view_switcher,
@@ -371,10 +372,7 @@ impl Page {
                     .on_placement(|id, x, y| pages::Message::Displays(Message::Position(id, x, y)))
                     .apply(cosmic::widget::scrollable)
                     .width(Length::Shrink)
-                    .direction(Direction::Both {
-                        horizontal: Properties::new(),
-                        vertical: Properties::new(),
-                    })
+                    .direction(Direction::Horizontal(Properties::new()))
                     .apply(container)
                     .center_x()
                     .width(Length::Fill)


### PR DESCRIPTION
- Adjust size of output based on scale
- Show the display arrangement section only when there's more than one display
- Adjust the display arrangement scrollable to be centered after updates
- Use `cosmic::theme` spacing values around interface

`cosmic-randr` will be patched to automatically adjust positions after display scale changes