### PR TITLE
Input/Touchpad: Add tap-to-click setting

### DIFF
--- a/app/src/pages/input/mod.rs
+++ b/app/src/pages/input/mod.rs
@@ -6,7 +6,7 @@ use cosmic::{
     iced_widget::core::layout,
 };
 use cosmic_comp_config::{
-    input::{AccelProfile, InputConfig},
+    input::{AccelProfile, InputConfig, TapButtonMap, TapConfig},
     XkbConfig,
 };
 use cosmic_settings_page as page;
@@ -25,6 +25,9 @@ pub enum Message {
     SetDoubleClickSpeed(u32, bool),
     SetMouseSpeed(f64, bool),
     PrimaryButtonSelected(cosmic::widget::segmented_button::Entity, bool),
+    // Tapping and Pinching
+    TapToClick(bool, bool),
+    PinchToZoom(bool, bool),
     // seperate close message, to make sure another isn't closed?
     ExpandInputSourcePopover(Option<String>),
     OpenSpecialCharacterDialog(keyboard::SpecialKey),
@@ -155,6 +158,14 @@ impl Page {
                 let left_entity = select_model.entity_at(1).unwrap();
                 let left_handed = select_model.active() == left_entity;
                 self.update_input(touchpad, |x| x.left_handed = Some(left_handed));
+            }
+            Message::TapToClick(value, touchpad) => self.update_input(touchpad, |x| {
+                x.tap_config
+                .get_or_insert(TapConfig { enabled: true, button_map: Some(TapButtonMap::LeftRightMiddle), drag: true, drag_lock: false })
+                .enabled = value
+            }),
+            Message::PinchToZoom(value, touchpad) => {
+                // TODO
             }
             Message::ExpandInputSourcePopover(value) => {
                 self.expanded_source_popover = value;

--- a/app/src/pages/input/touchpad.rs
+++ b/app/src/pages/input/touchpad.rs
@@ -18,6 +18,7 @@ impl page::Page<crate::pages::Message> for Page {
     ) -> Option<page::Content> {
         Some(vec![
             sections.insert(touchpad()),
+            sections.insert(tapping_and_pinching()),
             sections.insert(scrolling()),
         ])
     }
@@ -84,6 +85,39 @@ fn touchpad() -> Section<crate::pages::Message> {
                         .control(widget::slider(0..=100, 0, |x| {
                             Message::SetDoubleClickSpeed(x, true)
                         })),
+                )
+                .apply(Element::from)
+                .map(crate::pages::Message::Input)
+        })
+}
+
+fn tapping_and_pinching() -> Section<crate::pages::Message> {
+    Section::default()
+        .title(fl!("tapping-and-pinching"))
+        .descriptions(vec![
+            fl!("touchpad", "tap-to-click"),
+            fl!("touchpad", "tap-to-click-desc"),
+            fl!("touchpad", "pinch-to-zoom"),
+            fl!("touchpad", "pinch-to-zoom-desc"),
+        ])
+        .view::<Page>(|binder, _page, section| {
+            let descriptions = &section.descriptions;
+
+            let input = binder.page::<super::Page>().expect("input page not found");
+
+            settings::view_section(&section.title)
+                .add(
+                    settings::item::builder(&descriptions[0])
+                        .description(&descriptions[1])
+                        .toggler(
+                            input
+                                .input_touchpad
+                                .tap_config
+                                .as_ref()
+                                .and_then(|x| Some(x.enabled))
+                                .unwrap_or(false),
+                            |x: bool| Message::TapToClick(x, true),
+                        ),
                 )
                 .apply(Element::from)
                 .map(crate::pages::Message::Input)

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -400,6 +400,8 @@ mouse-scrolling = Scrolling
 
 ## Input: Touchpad
 
+tapping-and-pinching = Tapping and Pinching
+
 touchpad = Touchpad
     .desc = Touchpad speed, click options, gestures.
     .primary-button = Primary button
@@ -410,3 +412,7 @@ touchpad = Touchpad
     .acceleration-desc = Automatically adjusts tracking sensitivty based on speed.
     .double-click-speed = Double-click speed
     .double-click-speed-desc = Changes how fast double-clicks have to be to register.
+    .tap-to-click = Tap to click
+    .tap-to-click-desc = Enables single-finger tap for primary click, two-finger tap for secondary click, and three-finger tap for middle click.
+    .pinch-to-zoom = Pinch to zoom
+    .pinch-to-zoom-desc = Use two fingers to zoom innto content, for applications that support zoom.


### PR DESCRIPTION
This PR adds a tap-to-click setting in Input > Touchpad, based on designs from https://github.com/pop-os/cosmic-settings/issues/35 . The PR also adds a stub for the other setting to be implemented in the "Tapping and Pinching" section (Pinch to zoom).

Fixes: https://github.com/pop-os/cosmic-settings/issues/155

I used a comment from @Drakulix to derive the configuration needed as "default": https://github.com/pop-os/cosmic-comp/issues/312#issuecomment-1948177942

Some question(s):

* Will tap-to-click be enabled by default? What do I need to do to ensure this input setting gets a default setting to begin with?
* Is this the cleanest way I can implement this? I'm learning rust as I go so I'd like feedback on the methodology used.