### PR TITLE
system/about: Improve memory and disk capacity display

### DIFF
--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -209,7 +209,8 @@ pub fn read_to_string<'a, P: AsRef<OsStr>>(
 }
 
 fn format_size(size: u64) -> String {
-    byte_unit::Byte::from_u64(size)
-        .get_appropriate_unit(byte_unit::UnitType::Binary)
-        .to_string()
+    format!(
+        "{:.2}",
+        byte_unit::Byte::from_u64(size).get_appropriate_unit(byte_unit::UnitType::Binary)
+    )
 }

--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -210,6 +210,6 @@ pub fn read_to_string<'a, P: AsRef<OsStr>>(
 
 fn format_size(size: u64) -> String {
     byte_unit::Byte::from_u64(size)
-        .get_appropriate_unit(byte_unit::UnitType::Decimal)
+        .get_appropriate_unit(byte_unit::UnitType::Binary)
         .to_string()
 }


### PR DESCRIPTION
This PR fixes the two issues brought up in #164 with how memory and disk capacity are displayed:

- The values are now displayed in binary units (GiB, TiB, etc.) instead of decimal/metric units (GB, TB, etc.)
- The values are now rounded to two decimal places

| Before | After |
| --- | --- |
| ![Memory: 33.555890176 GB, Disk Capacity: 13.800913174528 TB](https://github.com/pop-os/cosmic-settings/assets/76545554/24cfe401-a0f7-4e68-8b0d-0569841e8cfa) | ![Memory: 31.25 GiB, Disk Capacity: 12.55 TiB](https://github.com/pop-os/cosmic-settings/assets/76545554/8a6558b2-2b3e-468d-b60f-66d1f046154c) |

Previously this page was displaying metric/decimal units, which is why the capacity seemed overstated.

I also rounded to two decimals places, instead of truncating, as recommended by the original issue. This is mostly because it requires less code, although it seems like the original issue suggested truncating to prevent showing more than the advertised memory/disk space. This should no longer be an issue now that binary units are displayed, and all the other tools I checked (htop, KDE System Monitor, Mission Centre) show a rounded up value.