### PR TITLE
fix: disable display of settings page entries

### DIFF
--- a/resources/com.system76.CosmicSettings.About.desktop
+++ b/resources/com.system76.CosmicSettings.About.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings about
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Appearance.desktop
+++ b/resources/com.system76.CosmicSettings.Appearance.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings appearance
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.DateTime.desktop
+++ b/resources/com.system76.CosmicSettings.DateTime.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings date-time
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Desktop.desktop
+++ b/resources/com.system76.CosmicSettings.Desktop.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings desktop-panel
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Displays.desktop
+++ b/resources/com.system76.CosmicSettings.Displays.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings displays
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Firmware.desktop
+++ b/resources/com.system76.CosmicSettings.Firmware.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings firmware
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Keyboard.desktop
+++ b/resources/com.system76.CosmicSettings.Keyboard.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings keyboard
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Mouse.desktop
+++ b/resources/com.system76.CosmicSettings.Mouse.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings mouse
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Notifications.desktop
+++ b/resources/com.system76.CosmicSettings.Notifications.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings notifications
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.RegionLanguage.desktop
+++ b/resources/com.system76.CosmicSettings.RegionLanguage.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings region-language
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Sound.desktop
+++ b/resources/com.system76.CosmicSettings.Sound.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings sound
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Touchpad.desktop
+++ b/resources/com.system76.CosmicSettings.Touchpad.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings touchpad
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Users.desktop
+++ b/resources/com.system76.CosmicSettings.Users.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings users
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Wallpaper.desktop
+++ b/resources/com.system76.CosmicSettings.Wallpaper.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings wallpaper
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/resources/com.system76.CosmicSettings.Workspaces.desktop
+++ b/resources/com.system76.CosmicSettings.Workspaces.desktop
@@ -6,6 +6,7 @@ Exec=cosmic-settings workspaces
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
+NoDisplay=true
 OnlyShowIn=COSMIC
 Icon=com.system76.CosmicSettings
 StartupNotify=true

--- a/scripts/cargo.just
+++ b/scripts/cargo.just
@@ -27,7 +27,6 @@ linker-arg := if clang-path != '' {
 export RUSTFLAGS := linker-arg + env_var_or_default('RUSTFLAGS', '')
 
 # Compile with debug profile
-[no-cd]
 build-debug *args:
     cargo build {{args}}
 


### PR DESCRIPTION
This will prevent them from displaying in the app library, while preserving them in the launcher.

Closes #214 