### PR TITLE
fix: remove no-cd from install to fix epoch sysext

### DIFF
--- a/scripts/common.just
+++ b/scripts/common.just
@@ -1,12 +1,12 @@
 # Installation command
-[no-cd, private]
+[private]
 install-cmd options src dest:
     install {{options}} {{src}} {{dest}}
 
-[no-cd, private]
+[private]
 install-bin src dest: (install-cmd '-Dm0755' src dest)
 
-[no-cd, private]
+[private]
 install-file src dest: (install-cmd '-Dm0644' src dest)
 
 # Check if required dependencies are installed on the system


### PR DESCRIPTION
- I noticed that `just sysext` over in https://github.com/pop-os/cosmic-epoch was failing because it was looking for target/release/cosmic-settings inside the cosmic-epoch/ directory instead of in the cosmic-epoch/cosmic-settings/ directory
- I've dropped the `[no-cd]` attribute from the install tasks in just to fix this
- alternatively, I could have made the tasks themselves use absolute paths internally, but this seemed simpler