### PR TITLE
Fallback to default XDG_DATA_DIRS for icon search

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance.rs
+++ b/cosmic-settings/src/pages/desktop/appearance.rs
@@ -1499,14 +1499,14 @@ async fn fetch_icon_themes() -> Message {
         .or_else(dirs::home_dir)
         .map(|dir| dir.join(".local/share/icons"));
 
-    let xdg_data_dirs = std::env::var("XDG_DATA_DIRS");
+    let xdg_data_dirs = std::env::var("XDG_DATA_DIRS").ok();
 
     let xdg_data_dirs = xdg_data_dirs
-        .as_ref()
-        .ok()
+        .as_deref()
+        // Default from the XDG Base Directory Specification
+        .or(Some("/usr/local/share/:/usr/share/"))
         .into_iter()
-        .flat_map(|data_dirs| data_dirs.split_terminator(':'))
-        .map(|dir| Path::new(dir).join("icons"));
+        .flat_map(|arg| std::env::split_paths(arg).map(|dir| dir.join("icons")));
 
     for icon_dir in xdg_data_dirs.chain(xdg_data_home) {
         let Ok(read_dir) = std::fs::read_dir(&icon_dir) else {


### PR DESCRIPTION
According to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), `XDG_DATA_DIRS` should default to `/usr/local/share/:/usr/share/` if empty.

I've found that the variable is inconsistently set across environments. I couldn't find any reason as to why it's sometimes unset, but it seems like defaulting to the above is expected behavior.

Besides that, I switched the code that manually split the env arg with a function in the standard library that does the same.