### PR TITLE
fix(appearance): theme mode settings not applied when changing theme mode

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance.rs
+++ b/cosmic-settings/src/pages/desktop/appearance.rs
@@ -449,7 +449,10 @@ impl Page {
                     if let Err(err) = self.theme_mode.set_is_dark(config, enabled) {
                         tracing::error!(?err, "Error setting dark mode");
                     }
+
+                    self.reload_theme_mode();
                 }
+
                 Command::none()
             }
             Message::Autoswitch(enabled) => {


### PR DESCRIPTION
Fixes the dark theme color palette being applied when selecting theme options on the light theme, and light theme colors being applied to the dark theme when switching from the light theme.