### PR TITLE
Remove "Related settings" from Settings > About

### DIFF
--- a/cosmic-settings/src/pages/system/about.rs
+++ b/cosmic-settings/src/pages/system/about.rs
@@ -34,7 +34,6 @@ impl page::Page<crate::pages::Message> for Page {
             sections.insert(device()),
             sections.insert(hardware()),
             sections.insert(os()),
-            sections.insert(related()),
         ])
     }
 
@@ -185,16 +184,17 @@ fn os() -> Section<crate::pages::Message> {
         })
 }
 
-fn related() -> Section<crate::pages::Message> {
-    Section::default()
-        .title(fl!("about-related"))
-        .descriptions(vec![fl!("about-related", "support").into()])
-        .view::<Page>(|_binder, _page, section| {
-            settings::view_section(&section.title)
-                .add(settings::item(&*section.descriptions[0], text("TODO")))
-                .into()
-        })
-}
+// Related settings: for 2nd COSMIC release
+// fn related() -> Section<crate::pages::Message> {
+//     Section::default()
+//         .title(fl!("about-related"))
+//         .descriptions(vec![fl!("about-related", "support").into()])
+//         .view::<Page>(|_binder, _page, section| {
+//             settings::view_section(&section.title)
+//                 .add(settings::item(&*section.descriptions[0], text("TODO")))
+//                 .into()
+//         })
+// }
 
 // fn page(app: &crate::SettingsApp) -> &Page {
 //     app.pages


### PR DESCRIPTION
Fixes #216.
Removed `sections.insert(related())` since it's short and looks messy when commented.
Didn't change i18n files, since they can be used later.
Edit: This probably doesn't do what it's supposed to, since more extensive changes are required to keep "Get support" while removing Related settings. Should the Related section be renamed to Support, with appropriate edits in i18n? Otherwise, feel free to close this.