### PR TITLE
chore: move add applets page to context drawer

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -3,8 +3,7 @@
 
 use crate::config::Config;
 use crate::pages::desktop::{
-    self, appearance,
-    dock::{self, applets::ADD_DOCK_APPLET_DIALOGUE_ID},
+    self, appearance, dock,
     panel::{
         self,
         applets_inner::{self, AppletsPage, APPLET_DND_ICON_ID},
@@ -168,22 +167,6 @@ impl cosmic::Application for SettingsApp {
         widgets
     }
 
-    fn on_close_requested(&self, id: window::Id) -> Option<Self::Message> {
-        let message = if id == *applets_inner::ADD_PANEL_APPLET_DIALOGUE_ID {
-            Message::PageMessage(crate::pages::Message::PanelApplet(
-                applets_inner::Message::ClosedAppletDialog,
-            ))
-        } else if id == *ADD_DOCK_APPLET_DIALOGUE_ID {
-            Message::PageMessage(crate::pages::Message::DockApplet(dock::applets::Message(
-                applets_inner::Message::ClosedAppletDialog,
-            )))
-        } else {
-            return None;
-        };
-
-        Some(message)
-    }
-
     fn on_escape(&mut self) -> Command<Self::Message> {
         if self.search_active {
             self.search_active = false;
@@ -343,9 +326,7 @@ impl cosmic::Application for SettingsApp {
 
                 crate::pages::Message::PanelApplet(message) => {
                     if let Some(page) = self.pages.page_mut::<applets_inner::Page>() {
-                        return page
-                            .update(message, *applets_inner::ADD_PANEL_APPLET_DIALOGUE_ID)
-                            .map(cosmic::app::Message::App);
+                        return page.update(message).map(cosmic::app::Message::App);
                     }
                 }
 
@@ -375,10 +356,7 @@ impl cosmic::Application for SettingsApp {
 
                 if let Some(page) = self.pages.page_mut::<applets_inner::Page>() {
                     return page
-                        .update(
-                            applets_inner::Message::PanelConfig(config),
-                            *applets_inner::ADD_PANEL_APPLET_DIALOGUE_ID,
-                        )
+                        .update(applets_inner::Message::PanelConfig(config))
                         .map(cosmic::app::Message::App);
                 }
             }
@@ -410,10 +388,7 @@ impl cosmic::Application for SettingsApp {
                 );
                 if let Some(page) = self.pages.page_mut::<applets_inner::Page>() {
                     return page
-                        .update(
-                            applets_inner::Message::Applets(info_list),
-                            *applets_inner::ADD_PANEL_APPLET_DIALOGUE_ID,
-                        )
+                        .update(applets_inner::Message::Applets(info_list))
                         .map(cosmic::app::Message::App);
                 }
             }
@@ -490,32 +465,6 @@ impl cosmic::Application for SettingsApp {
         {
             return page.dnd_icon();
         }
-
-        if let Some(Some(page)) = (id == *applets_inner::ADD_PANEL_APPLET_DIALOGUE_ID)
-            .then(|| self.pages.page::<applets_inner::Page>())
-        {
-            return page.add_applet_view(crate::pages::Message::PanelApplet);
-        }
-
-        if let Some(Some(page)) =
-            (id == *ADD_DOCK_APPLET_DIALOGUE_ID).then(|| self.pages.page::<dock::applets::Page>())
-        {
-            return page.inner().add_applet_view(|msg| {
-                crate::pages::Message::DockApplet(dock::applets::Message(msg))
-            });
-        }
-
-        // if let Some(Some(page)) = (id == *keyboard::ADD_INPUT_SOURCE_DIALOGUE_ID)
-        //     .then(|| self.pages.page::<input::Page>())
-        // {
-        //     return page.add_input_source_view();
-        // }
-
-        // if let Some(Some(page)) = (id == *keyboard::SPECIAL_CHARACTER_DIALOGUE_ID)
-        //     .then(|| self.pages.page::<input::Page>())
-        // {
-        //     return page.special_character_key_view();
-        // }
 
         if let Some(page) = self.pages.page::<desktop::wallpaper::Page>() {
             if id == page.color_dialog {

--- a/cosmic-settings/src/pages/desktop/dock/applets.rs
+++ b/cosmic-settings/src/pages/desktop/dock/applets.rs
@@ -1,4 +1,4 @@
-use cosmic::{cosmic_config::CosmicConfigEntry, iced::window, iced_runtime::Command};
+use cosmic::{cosmic_config::CosmicConfigEntry, iced::window, iced_runtime::Command, Element};
 use cosmic_panel_config::CosmicPanelConfig;
 use cosmic_settings_page::{self as page, section, Section};
 use once_cell::sync::Lazy;
@@ -9,11 +9,11 @@ use crate::{
     app,
     pages::{
         self,
-        desktop::panel::applets_inner::{self, lists, AppletsPage, ReorderWidgetState},
+        desktop::panel::applets_inner::{
+            self, lists, AppletsPage, ContextDrawer, ReorderWidgetState,
+        },
     },
 };
-
-pub static ADD_DOCK_APPLET_DIALOGUE_ID: Lazy<window::Id> = Lazy::new(window::Id::unique);
 
 pub(crate) struct Page {
     inner: applets_inner::Page,
@@ -38,7 +38,7 @@ impl Default for Page {
                 current_config,
                 reorder_widget_state: ReorderWidgetState::default(),
                 search: String::new(),
-                has_dialog: false,
+                context: None,
             },
         }
     }
@@ -59,7 +59,7 @@ pub struct Message(pub applets_inner::Message);
 
 impl Page {
     pub fn update(&mut self, message: Message) -> Command<app::Message> {
-        self.inner.update(message.0, *ADD_DOCK_APPLET_DIALOGUE_ID)
+        self.inner.update(message.0)
     }
 }
 
@@ -76,7 +76,16 @@ impl page::Page<crate::pages::Message> for Page {
 
     fn info(&self) -> page::Info {
         page::Info::new("dock_applets", "preferences-dock-symbolic")
-        // .title(fl!("applets"))
+    }
+
+    fn context_drawer(&self) -> Option<Element<crate::pages::Message>> {
+        Some(match self.inner.context {
+            Some(ContextDrawer::AddApplet) => self
+                .inner
+                .add_applet_view(|msg| crate::pages::Message::DockApplet(Message(msg))),
+
+            None => return None,
+        })
     }
 }
 


### PR DESCRIPTION
This PR moves the add applets page to context drawer, removing the extra window.

@mmstick I couldn't find the multi-window feature flag anywhere.