### PR TITLE
fix: exit on close

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -525,6 +525,16 @@ impl cosmic::Application for SettingsApp {
             .dialog(self.active_page)
             .map(|e| e.map(Message::PageMessage))
     }
+
+    fn on_close_requested(&self, id: window::Id) -> Option<Self::Message> {
+        if id == window::Id::MAIN {
+            std::thread::spawn(|| {
+                std::thread::sleep(tokio::time::Duration::from_millis(100));
+                std::process::exit(0);
+            });
+        }
+        None
+    }
 }
 
 impl SettingsApp {

--- a/cosmic-settings/src/main.rs
+++ b/cosmic-settings/src/main.rs
@@ -116,7 +116,8 @@ pub fn main() -> color_eyre::Result<()> {
     let args = Args::parse();
 
     let settings = cosmic::app::Settings::default()
-        .size_limits(Limits::NONE.min_width(400.0).min_height(300.0));
+        .size_limits(Limits::NONE.min_width(400.0).min_height(300.0))
+        .exit_on_close(false);
 
     cosmic::app::run_single_instance::<app::SettingsApp>(settings, args)?;
 


### PR DESCRIPTION
This is a temporary solution to force the settings app to close when the display background service hangs. Maybe it should eventually be refactored to run in a separate process? Sorta fixes https://github.com/pop-os/cosmic-settings/issues/303