### PR TITLE
[feat] add 'show day name' in time applet toggle

### DIFF
--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -299,6 +299,7 @@ time-format = Date & Time Format
     .twenty-four = 24-hour time
     .first = First day of week
     .show-date = Show Date on Top Panel
+    .show-day-name = Show Day Name on Top Panel
     .friday = Friday
     .saturday = Saturday
     .sunday = Sunday

--- a/i18n/pl/cosmic_settings.ftl
+++ b/i18n/pl/cosmic_settings.ftl
@@ -306,6 +306,7 @@ time-format = Format Daty i Czasu
     .twenty-four = Czas 24-godzinny
     .first = Pierwszy dzień tygodnia
     .show-date = Pokaż Datę w Górnym Panelu
+    .show-day-name = Pokaż nazwe dnia w górnym panelu
     .friday = Piątek
     .saturday = Sobota
     .sunday = Niedziela


### PR DESCRIPTION
Hey,

This PR also with another one to cosmic-applets will introduce new toggle in cosmic-settings. This will enable new format to date to display also day name before day and month in time applet on panel.