### PR TITLE
Match window corner radius switching to other components

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance.rs
+++ b/cosmic-settings/src/pages/desktop/appearance.rs
@@ -326,7 +326,7 @@ impl From<Roundness> for CornerRadii {
             },
             Roundness::SlightlyRound => CornerRadii {
                 radius_0: [0.0; 4],
-                radius_xs: [2.0; 4],
+                radius_xs: [4.0; 4],
                 radius_s: [8.0; 4],
                 radius_m: [8.0; 4],
                 radius_l: [8.0; 4],


### PR DESCRIPTION
Closes #295.
This makes the window corners change in sync with e.g. the NavBar.