### PR TITLE
Fix centering displays in arrangement

### DIFF
--- a/cosmic-settings/src/pages/display/arrangement.rs
+++ b/cosmic-settings/src/pages/display/arrangement.rs
@@ -124,8 +124,8 @@ impl<'a, Message: Clone> Widget<Message, cosmic::Theme, Renderer> for Arrangemen
 
         let state = tree.state.downcast_mut::<State>();
         state.max_dimensions = (
-            max_dimensions.0 as f32 * 1.25 / UNIT_PIXELS,
-            max_dimensions.1 as f32 * 1.25 / UNIT_PIXELS,
+            max_dimensions.0 as f32 / UNIT_PIXELS,
+            max_dimensions.1 as f32 / UNIT_PIXELS,
         );
 
         let limits = limits


### PR DESCRIPTION
I don't know what the reason was to multiply the max dimensions by 1.25, but it causes the displays to not be centered properly in the arrangement section for me.

This is what it looks like for me when multiplying by 1.25
![screenshot-2024-05-31-22-21-19](https://github.com/pop-os/cosmic-settings/assets/1126521/e60f0a59-2a89-4129-9ac1-2627fb28d49b)

This is what it looks like when I remove it
![screenshot-2024-05-31-22-25-19](https://github.com/pop-os/cosmic-settings/assets/1126521/1739b2a7-de46-47db-9480-6b934c066c08)
