### PR TITLE
Reload display config after randr change

### DIFF
--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -314,6 +314,11 @@ impl Page {
             Message::RandrResult(result) => {
                 if let Some(Err(why)) = Arc::into_inner(result) {
                     tracing::error!(?why, "cosmic-randr error");
+                } else {
+                    // Reload display info
+                    return cosmic::command::future(async move {
+                        crate::Message::PageMessage(on_enter().await)
+                    });
                 }
             }
 


### PR DESCRIPTION
When changing the position, scale, orientation, etc. of a display, reload the output configuration from cosmic-randr. This will make sure the UI is up to date with the changes. It also re-centers the displays in the arrangement.

This fixes #298.

It also fixes the issues described in the first  comment of #296. However, adjusting the display scaling can still cause displays to overlap or spread apart. Solving this problem for all possible display arrangements is non-trivial. At least with this change, you'll notice the problem in the UI immediately without having to go to another settings page and back.