### PR TITLE
Adding dialog to confirm display changes.

### DIFF
--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -118,6 +118,12 @@ orientation = Orientation
 scheduling = Scheduling
     .manual = Manual schedule
 
+dialog = Dialog
+    .title = Keep These Display Settings?
+    .keep-changes = Keep Changes
+    .change-prompt = Settings changes will automatically revert in { $time } seconds.
+    .revert-settings = Revert Settings
+
 ## Desktop: Notifications
 
 notifications = Notifications


### PR DESCRIPTION
Resolves #365 
This feature adds a confirmation prompt with a countdown once a setting is changed. The settings will automatically revert if the timer runs to 0.

The dialog will appear for orientation or scale changes, and the enabling/disabling of a display. It is currently not implemented for display position, resolution, nor refresh rate changes. For any setting change in which someone wishes to add the dialog, I have added a macro to make implementing the dialog simple.

I am not sure if the design choice I made for closing the dialog after timeout was a good one. I made a Widget which just sends a continuous stream of a single message. If that was a good choice, then I am not sure if it is okay to be a private struct at the bottom of the file, or if it should be public or have its own file somewhere else within the repository.