### PR TITLE
fix: Duplicate color wallpaper previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,12 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 [[package]]
 name = "accesskit"
 version = "0.12.2"
-source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#5f9b61c8264000d001499c902562422e13efa7a8"
+source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#26f729169cd849970af02be62289606c63572d2d"
 
 [[package]]
 name = "accesskit_consumer"
 version = "0.17.0"
-source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#5f9b61c8264000d001499c902562422e13efa7a8"
+source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#26f729169cd849970af02be62289606c63572d2d"
 dependencies = [
  "accesskit",
 ]
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "accesskit_unix"
 version = "0.7.1"
-source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#5f9b61c8264000d001499c902562422e13efa7a8"
+source = "git+https://github.com/wash2/accesskit.git?branch=winit-0.29#26f729169cd849970af02be62289606c63572d2d"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "cosmic-bg-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-bg#2259f5ac81099a8215d5ff69cba1ec0d1fd850d1"
+source = "git+https://github.com/pop-os/cosmic-bg#f83d9f4c8e4b47bea3ef16e4894982919fef6b9a"
 dependencies = [
  "colorgrad",
  "cosmic-config",
@@ -1364,7 +1364,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#5c6fa840f4e75ce94075cb1c8d22623077821193"
+source = "git+https://github.com/pop-os/libcosmic#41d1f4a7cdafd0bf15d7a8213697932a2dc6e8ba"
 dependencies = [
  "atomicwrites",
  "calloop 0.14.0",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#5c6fa840f4e75ce94075cb1c8d22623077821193"
+source = "git+https://github.com/pop-os/libcosmic#41d1f4a7cdafd0bf15d7a8213697932a2dc6e8ba"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1723,7 +1723,7 @@ version = "0.19.0"
 source = "git+https://github.com/gfx-rs/wgpu?rev=20fda69#20fda698341efbdc870b8027d6d49f5bf3f36109"
 dependencies = [
  "bitflags 2.5.0",
- "libloading 0.8.3",
+ "libloading 0.7.4",
  "winapi",
 ]
 
@@ -1898,7 +1898,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.3",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -2747,7 +2747,7 @@ dependencies = [
  "bitflags 2.5.0",
  "com",
  "libc",
- "libloading 0.8.3",
+ "libloading 0.7.4",
  "thiserror",
  "widestring",
  "winapi",
@@ -2918,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#5c6fa840f4e75ce94075cb1c8d22623077821193"
+source = "git+https://github.com/pop-os/libcosmic#41d1f4a7cdafd0bf15d7a8213697932a2dc6e8ba"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#5c6fa840f4e75ce94075cb1c8d22623077821193"
+source = "git+https://github.com/pop-os/libcosmic#41d1f4a7cdafd0bf15d7a8213697932a2dc6e8ba"
 dependencies = [
  "bitflags 2.5.0",
  "dnd",
@@ -2949,7 +2949,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.12.0"
-source = "git+https://github.com/pop-os/libcosmic#5c6fa840f4e75ce94075cb1c8d22623077821193"
+source = "git+https://github.com/pop-os/libcosmic#41d1f4a7cdafd0bf15d7a8213697932a2dc6e8ba"
 dependencies = [
  "futures",
  "iced_core",
@@ -6911,7 +6911,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.3",
+ "libloading 0.7.4",
  "log",
  "metal",
  "naga",


### PR DESCRIPTION
Closes: #348

This fix can be simplified by deriving `PartialOrd` for [cosmic_settings_wallpaper::Color](https://github.com/pop-os/cosmic-bg/blob/2259f5ac81099a8215d5ff69cba1ec0d1fd850d1/config/src/lib.rs#L101).  Let me know if I should open a PR for that followed by revising this PR to be a bit simpler.