### PR TITLE
Display input speed (mouse + touchpad) range as [1,100]

### DIFF
--- a/cosmic-settings/src/pages/input/mouse.rs
+++ b/cosmic-settings/src/pages/input/mouse.rs
@@ -67,14 +67,14 @@ fn mouse() -> Section<crate::pages::Message> {
                             .acceleration
                             .as_ref()
                             .map_or(0.0, |x| x.speed)
-                            + 1.0)
-                            * 50.0;
+                            + 0.81)
+                            * 70.71;
 
-                        let slider = widget::slider(10.0..=80.0, value, |value| {
-                            Message::SetMouseSpeed((value / 50.0) - 1.0, false)
+                        let slider = widget::slider(0.0..=100.0, value, |value| {
+                            Message::SetMouseSpeed((value / 70.71) - 0.81, false)
                         })
                         .width(250.0)
-                        .breakpoints(&[45.0]);
+                        .breakpoints(&[50.0]);
 
                         row::with_capacity(2)
                             .align_items(Alignment::Center)

--- a/cosmic-settings/src/pages/input/touchpad.rs
+++ b/cosmic-settings/src/pages/input/touchpad.rs
@@ -64,14 +64,14 @@ fn touchpad() -> Section<crate::pages::Message> {
                             .acceleration
                             .as_ref()
                             .map_or(0.0, |x| x.speed)
-                            + 1.0)
-                            * 50.0;
+                            + 0.81)
+                            * 70.71;
 
-                        let slider = widget::slider(10.0..=80.0, value, |value| {
-                            Message::SetMouseSpeed((value / 50.0) - 1.0, true)
+                        let slider = widget::slider(1.0..=100.0, value, |value| {
+                            Message::SetMouseSpeed((value / 70.71) - 0.81, true)
                         })
                         .width(250.0)
-                        .breakpoints(&[45.0]);
+                        .breakpoints(&[50.0]);
 
                         row::with_capacity(2)
                             .align_items(Alignment::Center)


### PR DESCRIPTION
Display input speed (mouse + touchpad) range as [1,100]. The minimum and maximum values of the selectable range should result in the same value being passed to libinput as before.

Fixes #285 