### PR TITLE
Improve icon theme spacing

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance.rs
+++ b/cosmic-settings/src/pages/desktop/appearance.rs
@@ -483,7 +483,7 @@ impl Page {
                         .collect(),
                 )
                 .row_spacing(theme.space_xs())
-                .column_spacing(theme.space_xxxs())
+                .column_spacing(theme.space_xs())
                 .into()
             ])
             .spacing(theme.space_xxs())
@@ -1814,7 +1814,7 @@ fn icon_theme_button(
                                 // TODO: Maybe allow choosable sizes/zooming
                                 .map(|handle| handle.icon().size(ICON_THUMB_SIZE)),
                         )
-                        .spacing(theme.space_xxs())
+                        .spacing(theme.space_xxxs())
                         .into(),
                     cosmic::widget::row()
                         .extend(
@@ -1825,15 +1825,15 @@ fn icon_theme_button(
                                 // TODO: Maybe allow choosable sizes/zooming
                                 .map(|handle| handle.icon().size(ICON_THUMB_SIZE)),
                         )
-                        .spacing(theme.space_xxs())
+                        .spacing(theme.space_xxxs())
                         .into(),
                 ])
-                .spacing(theme.space_xs()),
+                .spacing(theme.space_xxxs()),
                 None,
             )
             .on_press(Message::IconTheme(id))
             .selected(selected)
-            .padding(theme.space_xxs())
+            .padding([theme.space_xs(), theme.space_xs() + 1])
             // Image button's style mostly works, but it needs a background to fit the design
             .style(button::Style::Custom {
                 active: Box::new(move |focused, theme| {
@@ -1884,6 +1884,6 @@ fn icon_theme_button(
             })
             .width(Length::Fixed((ICON_THUMB_SIZE * 3) as _)),
         )
-        .spacing(theme.space_xs())
+        .spacing(theme.space_xxs())
         .into()
 }


### PR DESCRIPTION
This tweaks the spacing values in the icon theme selection grid, to more closely match designs.
Before: 
![screenshot-2024-07-25-19-49-10](https://github.com/user-attachments/assets/7a00175e-35e4-4196-88db-ddf3a034b7dd)
After:
![screenshot-2024-07-25-19-47-56](https://github.com/user-attachments/assets/c585d834-f8a1-4f81-ba89-681ce0f9f24e)

The slightly horrible `theme.space_xs() + 1` is required for the grid to fit evenly (equal padding on both sides) in the ContextDrawer. This could maybe be improved in the future with flexible spacing, so that it always fits evenly (e.g. when the window is shrunk horizontally).
A minor difference from the designs is that the column_spacing is space_xs/12, instead of 10 (I couldn't make it so that it fits evenly with 10).