### PR TITLE
fix(desktop-file-validate): use `Application` instead of `Settings` f…

### DIFF
--- a/resources/com.system76.CosmicSettings.desktop
+++ b/resources/com.system76.CosmicSettings.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=COSMIC Settings
 Name[pl]=Ustawienia COSMIC
-Type=Settings
+Type=Application
 Exec=cosmic-settings
 Terminal=false
 Categories=COSMIC


### PR DESCRIPTION
…or type

```desktop-file-validate /builddir/build/BUILD/cosmic-settings-0.1.0__20240723.002155git4908e38-build/BUILDROOT/usr/share/applications/com.system76.CosmicSettings.desktop
/builddir/build/BUILD/cosmic-settings-0.1.0__20240723.002155git4908e38-build/BUILDROOT/usr/share/applications/com.system76.CosmicSettings.desktop: error: value "Settings" for key "Type" in group "Desktop Entry" is not a registered type value ("Application", "Link" and "Directory")
/builddir/build/BUILD/cosmic-settings-0.1.0__20240723.002155git4908e38-build/BUILDROOT/usr/share/applications/com.system76.CosmicSettings.desktop: hint: value "COSMIC" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu```