### PR TITLE
app: Disable sound page until it is more functional

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -137,7 +137,7 @@ impl cosmic::Application for SettingsApp {
         let desktop_id = app.insert_page::<desktop::Page>().id();
         app.insert_page::<input::Page>();
         app.insert_page::<display::Page>();
-        app.insert_page::<sound::Page>();
+        //app.insert_page::<sound::Page>();
         app.insert_page::<system::Page>();
         app.insert_page::<time::Page>();
         app.insert_page::<power::Page>();


### PR DESCRIPTION
Disables (completely non-functional) the sound page for now for alpha 1.