### PR TITLE
fix: make sub page view scrollable height Fill

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -859,7 +859,7 @@ impl SettingsApp {
             )
             .spacing(theme.cosmic().space_s())
             .padding(0)
-            .apply(|widget| scrollable(self.page_container(widget)))
+            .apply(|widget| scrollable(self.page_container(widget)).height(Length::Fill))
             .apply(Element::from)
             .map(Message::Page);
 


### PR DESCRIPTION
This allows the flex layout to shrink the scrollable and make room for the title. Otherwise the title might disappear when the window height is small. fixes #449 