### PR TITLE
Display refresh rates as integers

### DIFF
--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -1109,7 +1109,7 @@ pub fn display_configuration() -> Section<crate::pages::Message> {
 fn cache_rates(cached_rates: &mut Vec<String>, rates: &[u32]) {
     *cached_rates = rates
         .iter()
-        .map(|&rate| format!("{:>3}.{:02} Hz", rate / 1000, rate % 1000))
+        .map(|&rate| format!("{} Hz", rate / 1000))
         .collect();
 }
 

--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -1109,7 +1109,7 @@ pub fn display_configuration() -> Section<crate::pages::Message> {
 fn cache_rates(cached_rates: &mut Vec<String>, rates: &[u32]) {
     *cached_rates = rates
         .iter()
-        .map(|&rate| format!("{} Hz", rate / 1000))
+        .map(|&rate| format!("{} Hz", (rate as f32 / 1000.0).round() as u32))
         .collect();
 }
 


### PR DESCRIPTION
Display the refresh rates as integers to match design.

Before:
![image](https://github.com/user-attachments/assets/6166b007-ed93-4876-b4ff-ab848cd93c66)

After:
![image](https://github.com/user-attachments/assets/f3a5a1a6-9407-4f88-9d5e-83780982bdbb)

