### PR TITLE
[Touchpad] Match page to design

### DIFF
--- a/cosmic-settings/src/pages/desktop/mod.rs
+++ b/cosmic-settings/src/pages/desktop/mod.rs
@@ -57,8 +57,8 @@ impl page::AutoBind<crate::pages::Message> for Page {
 
 #[derive(Copy, Clone, Debug)]
 pub enum Message {
-    ShowMinimizeButton(bool),
     ShowMaximizeButton(bool),
+    ShowMinimizeButton(bool),
 }
 
 impl Page {

--- a/cosmic-settings/src/pages/desktop/window_management.rs
+++ b/cosmic-settings/src/pages/desktop/window_management.rs
@@ -107,8 +107,8 @@ pub fn super_key_action() -> Section<crate::pages::Message> {
 pub fn window_controls() -> Section<crate::pages::Message> {
     let mut descriptions = Slab::new();
 
-    let minimize = descriptions.insert(fl!("window-controls", "minimize"));
     let maximize = descriptions.insert(fl!("window-controls", "maximize"));
+    let minimize = descriptions.insert(fl!("window-controls", "minimize"));
 
     Section::default()
         .title(fl!("window-controls"))
@@ -121,19 +121,19 @@ pub fn window_controls() -> Section<crate::pages::Message> {
 
             settings::view_section(&section.title)
                 .add(settings::item(
-                    &descriptions[minimize],
-                    toggler(
-                        None,
-                        desktop.cosmic_tk.show_minimize,
-                        super::Message::ShowMinimizeButton,
-                    ),
-                ))
-                .add(settings::item(
                     &descriptions[maximize],
                     toggler(
                         None,
                         desktop.cosmic_tk.show_maximize,
                         super::Message::ShowMaximizeButton,
+                    ),
+                ))
+                .add(settings::item(
+                    &descriptions[minimize],
+                    toggler(
+                        None,
+                        desktop.cosmic_tk.show_minimize,
+                        super::Message::ShowMinimizeButton,
                     ),
                 ))
                 .apply(Element::from)

--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -76,9 +76,9 @@ pub enum Message {
     /// Configures mirroring status of a display.
     Mirroring(Mirroring),
     /// Handle night light preferences.
-    //  NightLight(NightLight),
+    // NightLight(NightLight),
     /// Show the night light mode context drawer.
-    //  NightLightContext,
+    // NightLightContext,
     /// Set the orientation of a display.
     Orientation(Transform),
     /// Pan the displays view
@@ -128,7 +128,7 @@ pub struct Page {
     background_service: Option<tokio::task::JoinHandle<()>>,
     config: Config,
     cache: ViewCache,
-    //  context: Option<ContextDrawer>,
+    // context: Option<ContextDrawer>,
     display_arrangement_scrollable: widget::Id,
     /// Tracks the last pan status.
     last_pan: f32,
@@ -150,7 +150,7 @@ impl Default for Page {
             background_service: None,
             config: Config::default(),
             cache: ViewCache::default(),
-            //          context: None,
+            // context: None,
             display_arrangement_scrollable: widget::Id::unique(),
             last_pan: 0.5,
             dialog: None,
@@ -163,7 +163,7 @@ impl Default for Page {
 #[derive(Default)]
 struct Config {
     /// Whether night light is enabled.
-    //  night_light_enabled: bool,
+    // night_light_enabled: bool,
     refresh_rate: Option<u32>,
     resolution: Option<(u32, u32)>,
     scale: u32,
@@ -191,15 +191,15 @@ impl page::Page<crate::pages::Message> for Page {
     ) -> Option<page::Content> {
         Some(vec![
             // Night light
-            //            sections.insert(
-            //                Section::default()
-            //                    .descriptions(vec![
-            //                        text::NIGHT_LIGHT.as_str().into(),
-            //                        text::NIGHT_LIGHT_AUTO.as_str().into(),
-            //                        text::NIGHT_LIGHT_DESCRIPTION.as_str().into(),
-            //                    ])
-            //                    .view::<Page>(move |_binder, page, _section| page.night_light_view()),
-            //            ),
+            // sections.insert(
+            //     Section::default()
+            //         .descriptions(vec![
+            //             text::NIGHT_LIGHT.as_str().into(),
+            //             text::NIGHT_LIGHT_AUTO.as_str().into(),
+            //             text::NIGHT_LIGHT_DESCRIPTION.as_str().into(),
+            //         ])
+            //         .view::<Page>(move |_binder, page, _section| page.night_light_view()),
+            // ),
             // Display arrangement
             sections.insert(display_arrangement()),
             // Display configuration
@@ -305,14 +305,14 @@ impl page::Page<crate::pages::Message> for Page {
         })
     }
 
-    //    fn context_drawer(&self) -> Option<Element<pages::Message>> {
-    //        Some(match self.context {
+    // fn context_drawer(&self) -> Option<Element<pages::Message>> {
+    //     Some(match self.context {
 
-    //            Some(ContextDrawer::NightLight) => self.night_light_context_view(),
+    //         Some(ContextDrawer::NightLight) => self.night_light_context_view(),
 
-    //            None => return None,
-    //        })
-    //    }
+    //         None => return None,
+    //     })
+    // }
 
     /// Opens a dialog to confirm the display settings.
     ///
@@ -413,14 +413,14 @@ impl Page {
                 } // Mirroring::ProjectToAll => (),
             },
 
-            //            Message::NightLight(night_light) => {}
+            // Message::NightLight(night_light) => {}
             //
-            //            Message::NightLightContext => {
-            //                self.context = Some(ContextDrawer::NightLight);
-            //                return cosmic::command::message(app::Message::OpenContextDrawer(
-            //                    text::NIGHT_LIGHT.clone().into(),
-            //                ));
-            //            }
+            // Message::NightLightContext => {
+            //     self.context = Some(ContextDrawer::NightLight);
+            //     return cosmic::command::message(app::Message::OpenContextDrawer(
+            //         text::NIGHT_LIGHT.clone().into(),
+            //     ));
+            // }
             Message::Orientation(orientation) => return self.set_orientation(orientation),
 
             Message::Pan(pan) => {
@@ -480,9 +480,9 @@ impl Page {
     }
 
     /// Displays the night light context drawer.
-    //    pub fn night_light_context_view(&self) -> Element<pages::Message> {
-    //        column().into()
-    //    }
+    // pub fn night_light_context_view(&self) -> Element<pages::Message> {
+    //     column().into()
+    // }
 
     /// Reloads the display list, and all information relevant to the active display.
     pub fn update_displays(&mut self, list: List) {

--- a/cosmic-settings/src/pages/input/touchpad.rs
+++ b/cosmic-settings/src/pages/input/touchpad.rs
@@ -302,12 +302,22 @@ fn gestures() -> Section<crate::pages::Message> {
                     .flex_control(text(&descriptions[switch_workspaces])),
                 )
                 // .add(
-                //     settings::item::builder(&descriptions[four_finger_left])
-                //         .flex_control(text(&descriptions[open_workspaces_view])),
+                //     settings::item::builder(
+                //         &descriptions[match page.comp_workspace_config.workspace_layout {
+                //             WorkspaceLayout::Horizontal => four_finger_down,
+                //             WorkspaceLayout::Vertical => four_finger_right,
+                //         }],
+                //     )
+                //     .flex_control(text(&descriptions[open_workspaces_view])),
                 // )
                 // .add(
-                //     settings::item::builder(&descriptions[four_finger_right])
-                //         .flex_control(text(&descriptions[open_application_library])),
+                //     settings::item::builder(
+                //         &descriptions[match page.comp_workspace_config.workspace_layout {
+                //             WorkspaceLayout::Horizontal => four_finger_up,
+                //             WorkspaceLayout::Vertical => four_finger_left,
+                //         }],
+                //     )
+                //     .flex_control(text(&descriptions[open_application_library])),
                 // )
                 .apply(Element::from)
                 .map(crate::pages::Message::Input)

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -312,6 +312,7 @@ input-devices = Input Devices
     .desc = Input Devices
 
 primary-button = Primary button
+    .desc = Sets the order of physical buttons.
     .left = Left
     .right = Right
 
@@ -510,9 +511,11 @@ gestures = Gestures
     .four-finger-up = Four-finger swipe up
     .three-finger-any = Three-finger swipe any direction
 
+switch-workspaces = Switch workspaces
+    .horizontal = Four-finger swipe left/right
+    .vertical = Four-finger swipe up/down
+
 switch-between-windows = Switch between windows
-switch-to-next-workspace = Switch to next workspace
-switch-to-prev-workspace = Switch to prev workspace
 open-application-library = Open Application Library
 open-workspaces-view = Open Workspaces Overview
 

--- a/i18n/sr-Cyrl/cosmic_settings.ftl
+++ b/i18n/sr-Cyrl/cosmic_settings.ftl
@@ -104,7 +104,7 @@ style = Стил
     .square = Четвртаст
 
 # interface density left out for now
-window-management = Управљање прозорима
+window-management-appearance = Управљање прозорима
     .active-hint = Дебљина наговештаја активног прозора
     .gaps = Празнине око сложених прозора
 
@@ -312,6 +312,7 @@ input-devices = Унос
     .desc = Унос
 
 primary-button = Примарно дугме
+    .desc = Одређује редослед физичких дугмади.
     .left = Лево
     .right = Десно
 
@@ -504,15 +505,17 @@ touchpad = Додирна табла
 ## Input: Gestures
 
 swiping = Покрети
-    .four-finger-down = Превуците према доле са четири прста
-    .four-finger-left = Превуците према лево са четири прста
-    .four-finger-right = Превуците према десно са четири прста
-    .four-finger-up = Превуците према горе са четири прста
-    .three-finger-any = Превуците са три прста у било ком смеру
+    .four-finger-down = Превуци према доле са четири прста
+    .four-finger-left = Превуци према лево са четири прста
+    .four-finger-right = Превуци према десно са четири прста
+    .four-finger-up = Превуци према горе са четири прста
+    .three-finger-any = Превуци са три прста у било ком смеру
+
+switch-workspaces = Промени радни простор
+    .horizontal = Превуци према лево/десно са четири прста
+    .vertical = Превуци према горе/доле са четири прста
 
 switch-between-windows = Пребацивање између прозора
-switch-to-next-workspace = Пређи на следећи радни простор
-switch-to-prev-workspace = Пређи на претходни радни простор
 open-application-library = Отвори библиотеку апликација
 open-workspaces-view = Отвори преглед радних простора
 

--- a/i18n/sr-Latn/cosmic_settings.ftl
+++ b/i18n/sr-Latn/cosmic_settings.ftl
@@ -104,7 +104,7 @@ style = Stil
     .square = Četvrtast
 
 # interface density left out for now
-window-management = Upravljanje prozorima
+window-management-appearance = Upravljanje prozorima
     .active-hint = Debljina nagoveštaja aktivnog prozora
     .gaps = Praznine oko složenih prozora
 
@@ -312,6 +312,7 @@ input-devices = Unos
     .desc = Unos
 
 primary-button = Primarno dugme
+    .desc = Određuje redosled fizičkih dugmadi.
     .left = Levo
     .right = Desno
 
@@ -504,15 +505,17 @@ touchpad = Dodirna tabla
 ## Input: Gestures
 
 swiping = Pokreti
-    .four-finger-down = Prevucite prema dole sa četiri prsta
-    .four-finger-left = Prevucite prema levo sa četiri prsta
-    .four-finger-right = Prevucite prema desno sa četiri prsta
-    .four-finger-up = Prevucite prema gore sa četiri prsta
-    .three-finger-any = Prevucite sa tri prsta u bilo kom smeru
+    .four-finger-down = Prevuci prema dole sa četiri prsta
+    .four-finger-left = Prevuci prema levo sa četiri prsta
+    .four-finger-right = Prevuci prema desno sa četiri prsta
+    .four-finger-up = Prevuci prema gore sa četiri prsta
+    .three-finger-any = Prevuci sa tri prsta u bilo kom smeru
+
+switch-workspaces = Promeni radni prostor
+    .horizontal = Prevuci prema levo/desno sa četiri prsta
+    .vertical = Prevuci prema gore/dole sa četiri prsta
 
 switch-between-windows = Prebacivanje između prozora
-switch-to-next-workspace = Pređi na sledeći radni prostor
-switch-to-prev-workspace = Pređi na prethodni radni prostor
 open-application-library = Otvori biblioteku aplikacija
 open-workspaces-view = Otvori pregled radnih prostora
 


### PR DESCRIPTION
Should close #294.
Also fixes the order of the window control button toggles on the Window management page, as well as fix the messy indentation for Night Light comments I left a while back.

A minor issue is that the text doesn't update in the the running instance of Settings when the workspace layout is changed, so relaunching Settings is required to get the correct text after changing the workspace layout. Help on this would be appreciated.