### PR TITLE
fix: deduplicate disks when calc disk capacity

### DIFF
--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use bumpalo::Bump;
-use std::{ffi::OsStr, io::Read};
+use std::{collections::HashSet, ffi::OsStr, io::Read};
 
 use concat_in_place::strcat;
 use const_format::concatcp;
@@ -53,7 +53,12 @@ impl Info {
         sys.refresh_memory();
 
         let mut total_capacity = 0;
+        let mut disk_set = HashSet::new();
         for disk in disks.list() {
+            if disk_set.contains(disk.name()) {
+                continue;
+            }
+            disk_set.insert(disk.name());
             total_capacity += disk.total_space();
         }
 


### PR DESCRIPTION
The disk capacity is  wrong when a single file system is mounted multiple times,  like:

```
/dev/mapper/root on /nix type btrfs (rw,relatime,compress=zstd:5,ssd,space_cache=v2,subvolid=263,subvol=/@nix)
/dev/mapper/root on /root type btrfs (rw,relatime,compress=zstd:5,ssd,space_cache=v2,subvolid=258,subvol=/@root)
/dev/mapper/root on /.snapshots type btrfs (rw,relatime,compress=zstd:5,ssd,space_cache=v2,subvolid=264,subvol=/@snapshots)
/dev/mapper/root on /home type btrfs (rw,relatime,compress=zstd:5,ssd,space_cache=v2,subvolid=257,subvol=/@home)
/dev/mapper/root on /srv type btrfs (rw,relatime,compress=zstd:5,ssd,space_cache=v2,subvolid=259,subvol=/@srv)
/dev/mapper/root on /var/cache type btrfs (rw,relatime,compress=zstd:5,ssd,space_cache=v2,subvolid=260,subvol=/@cache)
/dev/mapper/root on /var/lib/machines type btrfs (rw,relatime,compress=zstd:5,ssd,space_cache=v2,subvolid=267,subvol=/@machines)
/dev/mapper/root on /var/log type btrfs (rw,relatime,compress=zstd:5,ssd,space_cache=v2,subvolid=261,subvol=/@log)
```

It shows 16.15 TiB but the actual value should be near 2TB.

This PR fixes it by ignoring duplicated disks when calculating the disk capacity 