### PR TITLE
chore: add upower_dbus to cosmic-settings dependencies lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "udev 0.9.0",
+ "upower_dbus",
  "url",
  "xkb-data",
  "zbus 4.4.0",


### PR DESCRIPTION
This wasn't added to the `Cargo.lock` file which caused the NixOS builds to fail.