### PR TITLE
Make entire length of radio list items clickable

### DIFF
--- a/cosmic-settings/src/pages/desktop/workspaces.rs
+++ b/cosmic-settings/src/pages/desktop/workspaces.rs
@@ -5,6 +5,7 @@
 
 use cosmic::{
     cosmic_config::{self, ConfigGet, ConfigSet},
+    iced::Length,
     widget::{radio, settings, text},
     Apply, Element,
 };
@@ -140,6 +141,7 @@ fn multi_behavior() -> Section<crate::pages::Message> {
                     Some(page.comp_workspace_config.workspace_mode),
                     Message::SetWorkspaceMode,
                 )
+                .width(Length::Fill)
                 .into()]))
                 .add(settings::item_row(vec![radio(
                     text::body(&descriptions[separate]),
@@ -147,6 +149,7 @@ fn multi_behavior() -> Section<crate::pages::Message> {
                     Some(page.comp_workspace_config.workspace_mode),
                     Message::SetWorkspaceMode,
                 )
+                .width(Length::Fill)
                 .into()]))
                 .apply(Element::from)
                 .map(crate::pages::Message::DesktopWorkspaces)
@@ -171,6 +174,7 @@ fn workspace_orientation() -> Section<crate::pages::Message> {
                     Some(page.comp_workspace_config.workspace_layout),
                     Message::SetWorkspaceLayout,
                 )
+                .width(Length::Fill)
                 .into()]))
                 .add(settings::item_row(vec![radio(
                     text::body(&descriptions[horizontal]),
@@ -178,6 +182,7 @@ fn workspace_orientation() -> Section<crate::pages::Message> {
                     Some(page.comp_workspace_config.workspace_layout),
                     Message::SetWorkspaceLayout,
                 )
+                .width(Length::Fill)
                 .into()]))
                 .apply(Element::from)
                 .map(crate::pages::Message::DesktopWorkspaces)

--- a/cosmic-settings/src/pages/input/keyboard/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/mod.rs
@@ -230,6 +230,7 @@ fn special_char_radio_row<'a>(
     settings::item_row(vec![radio(desc, value, Some(current_value), |_| {
         Message::SpecialCharacterSelect(value)
     })
+    .width(Length::Fill)
     .into()])
     .into()
 }

--- a/cosmic-settings/src/pages/input/touchpad.rs
+++ b/cosmic-settings/src/pages/input/touchpad.rs
@@ -156,6 +156,7 @@ fn click_behavior() -> Section<crate::pages::Message> {
                     page.input_touchpad.click_method,
                     |option| Message::SetSecondaryClickBehavior(Some(option), true),
                 )
+                .width(Length::Fill)
                 .into()]))
                 // Secondary and middle-click via button areas.
                 .add(settings::item_row(vec![widget::radio(
@@ -164,6 +165,7 @@ fn click_behavior() -> Section<crate::pages::Message> {
                     page.input_touchpad.click_method,
                     |option| Message::SetSecondaryClickBehavior(Some(option), true),
                 )
+                .width(Length::Fill)
                 .into()]))
                 .add(
                     settings::item::builder(&descriptions[tap_to_click]).toggler(
@@ -209,6 +211,7 @@ fn scrolling() -> Section<crate::pages::Message> {
                         .and_then(|x| x.method),
                     |option| Message::SetScrollMethod(Some(option), true),
                 )
+                .width(Length::Fill)
                 .into()]))
                 // Edge scrolling toggle
                 .add(settings::item_row(vec![widget::radio(
@@ -220,6 +223,7 @@ fn scrolling() -> Section<crate::pages::Message> {
                         .and_then(|x| x.method),
                     |option| Message::SetScrollMethod(Some(option), true),
                 )
+                .width(Length::Fill)
                 .into()]))
                 // Scroll speed slider
                 .add(settings::item(&descriptions[scroll_speed], {

--- a/cosmic-settings/src/pages/power/mod.rs
+++ b/cosmic-settings/src/pages/power/mod.rs
@@ -4,6 +4,7 @@ use self::backend::{GetCurrentPowerProfile, SetPowerProfile};
 use backend::{Battery, PowerProfile};
 
 use chrono::TimeDelta;
+use cosmic::iced::Length;
 use cosmic::iced_widget::row;
 use cosmic::widget::{self, column, radio, settings, text};
 use cosmic::Apply;
@@ -125,6 +126,7 @@ fn profiles() -> Section<crate::pages::Message> {
                             Some(current_profile),
                             Message::PowerProfileChange,
                         )
+                        .width(Length::Fill)
                         .into()])
                     })
                     .fold(section, settings::Section::add);


### PR DESCRIPTION
This is likely temporary until a more global change to make entire list items with a radio or toggle clickable (including the internal list item padding; similar to the highest level subpage buttons, e.g. Appearance), but considerably enhances the radio list item UX for now.
Couldn't quite figure out how to do the same for toggle list items, but their UX is slightly better than radio buttons before this change, regardless.