### PR TITLE
[Shortcuts] Add switch to workspace

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/mod.rs
@@ -329,6 +329,7 @@ fn shortcuts() -> Section<crate::pages::Message> {
                 .on_clear(Message::Search(String::new()))
                 .on_input(Message::Search)
                 .apply(widget::container)
+                .padding([2, 0, 0, 0])
                 .center_x()
                 .width(Length::Fill);
 

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/nav.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/nav.rs
@@ -88,6 +88,15 @@ pub const fn actions() -> &'static [Action] {
         Action::SwitchOutput(Direction::Right),
         Action::SwitchOutput(Direction::Up),
         Action::SwitchOutput(Direction::Down),
+        Action::Workspace(1),
+        Action::Workspace(2),
+        Action::Workspace(3),
+        Action::Workspace(4),
+        Action::Workspace(5),
+        Action::Workspace(6),
+        Action::Workspace(7),
+        Action::Workspace(8),
+        Action::Workspace(9),
     ]
 }
 


### PR DESCRIPTION
Closes #512.
Adds the Switch to workspace [number] entries to the Navigation section.