### PR TITLE
[Keyboard]: option to remap keys to caps lock

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/mod.rs
@@ -40,6 +40,13 @@ static ALTERNATE_CHARACTER_OPTIONS: &[(&str, &str)] = &[
     // ("Print Screen", "lv3"), XXX
 ];
 
+static CAPS_LOCK_OPTIONS: &[(&str, &str)] = &[
+    ("Escape", "caps:escape"),
+    ("Swap with Escape", "caps:swapescape"),
+    ("Backspace", "caps:backspace"),
+    ("Super", "caps:super"),
+];
+
 const STR_ORDER: &str = "`str` is always comparable";
 
 #[derive(Clone, Debug)]
@@ -110,6 +117,7 @@ enum Context {
 pub enum SpecialKey {
     AlternateCharacters,
     Compose,
+    CapsLock,
 }
 
 impl SpecialKey {
@@ -117,6 +125,7 @@ impl SpecialKey {
         match self {
             Self::Compose => "Compose".to_string(),
             Self::AlternateCharacters => "Alternate Characters".to_string(),
+            Self::CapsLock => "Caps Lock".to_string(),
         }
     }
 
@@ -124,6 +133,7 @@ impl SpecialKey {
         match self {
             Self::Compose => "compose:",
             Self::AlternateCharacters => "lv3:",
+            Self::CapsLock => "caps:",
         }
     }
 }
@@ -518,6 +528,7 @@ impl Page {
         let options = match special_key {
             SpecialKey::Compose => COMPOSE_OPTIONS,
             SpecialKey::AlternateCharacters => ALTERNATE_CHARACTER_OPTIONS,
+            SpecialKey::CapsLock => CAPS_LOCK_OPTIONS,
         };
         let prefix = special_key.prefix();
         let current = self
@@ -606,6 +617,7 @@ fn special_character_entry() -> Section<crate::pages::Message> {
 
     let alternate = descriptions.insert(fl!("keyboard-special-char", "alternate"));
     let compose = descriptions.insert(fl!("keyboard-special-char", "compose"));
+    let caps = descriptions.insert(fl!("keyboard-special-char", "caps"));
 
     Section::default()
         .title(fl!("keyboard-special-char"))
@@ -621,6 +633,10 @@ fn special_character_entry() -> Section<crate::pages::Message> {
                 .add(crate::widget::go_next_item(
                     &*descriptions[compose],
                     Message::OpenSpecialCharacterContext(SpecialKey::Compose),
+                ))
+                .add(crate::widget::go_next_item(
+                    &*descriptions[caps],
+                    Message::OpenSpecialCharacterContext(SpecialKey::CapsLock),
                 ))
                 .apply(cosmic::Element::from)
                 .map(crate::pages::Message::Keyboard)

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -442,6 +442,7 @@ keyboard-sources = Input Sources
 keyboard-special-char = Special Character Entry
     .alternate = Alternate characters key
     .compose = Compose key
+    .caps = Caps Lock key
 
 keyboard-typing-assist = Typing
     .repeat-rate = Repeat rate


### PR DESCRIPTION
Adds option to remap different keys to caps lock like super, escape or backspace as well as swap caps lock and escape.

