### PR TITLE
chore: reorder pages to match the design

### DIFF
--- a/cosmic-settings/src/pages/networking/mod.rs
+++ b/cosmic-settings/src/pages/networking/mod.rs
@@ -28,8 +28,8 @@ impl page::AutoBind<crate::pages::Message> for Page {
     fn sub_pages(
         page: cosmic_settings_page::Insert<crate::pages::Message>,
     ) -> cosmic_settings_page::Insert<crate::pages::Message> {
-        page.sub_page::<wired::Page>()
-            .sub_page::<wifi::Page>()
+        page.sub_page::<wifi::Page>()
+            .sub_page::<wired::Page>()
             .sub_page::<vpn::Page>()
     }
 }

--- a/cosmic-settings/src/pages/system/mod.rs
+++ b/cosmic-settings/src/pages/system/mod.rs
@@ -18,8 +18,8 @@ impl page::Page<crate::pages::Message> for Page {
 
 impl page::AutoBind<crate::pages::Message> for Page {
     fn sub_pages(page: page::Insert<crate::pages::Message>) -> page::Insert<crate::pages::Message> {
-        page.sub_page::<users::Page>()
-            .sub_page::<about::Page>()
+        page.sub_page::<about::Page>()
+            .sub_page::<users::Page>()
             .sub_page::<firmware::Page>()
     }
 }


### PR DESCRIPTION
This is based on the assumptions that these are accidental deviations and that the design is being followed strictly