### PR TITLE
perf(desktop): reduce disk usage when reading and writing configs

### DIFF
--- a/cosmic-settings/src/pages/desktop/panel/mod.rs
+++ b/cosmic-settings/src/pages/desktop/panel/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cosmic::cosmic_config::CosmicConfigEntry;
+use cosmic::{cosmic_config::CosmicConfigEntry, Command};
 use cosmic_panel_config::{CosmicPanelConfig, CosmicPanelContainerConfig};
 use cosmic_settings_page::{self as page, section, Section};
 use slotmap::SlotMap;
@@ -22,8 +22,12 @@ pub struct Page {
 pub struct Message(pub inner::Message);
 
 impl Page {
-    pub fn update(&mut self, message: Message) {
-        self.inner.update(message.0);
+    pub fn update(&mut self, message: Message) -> Command<crate::app::Message> {
+        self.inner
+            .update(message.0)
+            .map(Message)
+            .map(crate::pages::Message::Panel)
+            .map(crate::app::Message::PageMessage)
     }
 }
 


### PR DESCRIPTION
- Opacity slider updates on the dock and panel pages will be written after a delay
- Theme builder configs are now set explicitly on message updates
- Themes are only built if a theme builder config set reported that the config changed
- Moved file export serialization into command
- Update dock and panel border radius on a tokio thread
- Build new themes from the theme builder on tokio thread
- Theme builder changes shared between modes are now synced on a tokio thread
-  Improved command handling in the appearance settings page

Closes #474 