### PR TITLE
[Networking] Match page list item to design

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -931,6 +931,7 @@ impl SettingsApp {
                     page_list.push(crate::widget::page_list_item(
                         sub_page.title.as_str(),
                         sub_page.description.as_str(),
+                        "",
                         &sub_page.icon_name,
                         entity,
                     ))

--- a/cosmic-settings/src/pages/desktop/appearance.rs
+++ b/cosmic-settings/src/pages/desktop/appearance.rs
@@ -1783,16 +1783,16 @@ pub fn interface_density() -> Section<crate::pages::Message> {
             settings::section()
                 .title(&section.title)
                 .add(settings::item_row(vec![radio(
-                    text::body(&descriptions[comfortable]),
-                    Density::Standard,
+                    text::body(&descriptions[compact]),
+                    Density::Compact,
                     Some(page.density),
                     Message::Density,
                 )
                 .width(Length::Fill)
                 .into()]))
                 .add(settings::item_row(vec![radio(
-                    text::body(&descriptions[compact]),
-                    Density::Compact,
+                    text::body(&descriptions[comfortable]),
+                    Density::Standard,
                     Some(page.density),
                     Message::Density,
                 )

--- a/cosmic-settings/src/widget/mod.rs
+++ b/cosmic-settings/src/widget/mod.rs
@@ -121,6 +121,7 @@ pub fn display_container<'a, Message: 'a>(widget: Element<'a, Message>) -> Eleme
 pub fn page_list_item<'a, Message: 'static + Clone>(
     title: impl Into<Cow<'a, str>>,
     description: impl Into<Cow<'a, str>>,
+    info: impl Into<Cow<'a, str>>,
     icon: &'a str,
     message: Message,
 ) -> Element<'a, Message> {
@@ -135,13 +136,21 @@ pub fn page_list_item<'a, Message: 'static + Clone>(
 
     let description = description.into();
 
+    let info = info.into();
+
     if !description.is_empty() {
         builder = builder.description(description);
     }
 
     builder
         .icon(icon::from_name(icon).size(20))
-        .control(icon::from_name("go-next-symbolic").size(20))
+        .control(
+            row::with_capacity(2)
+                .padding([8, 0]) // fixed value to set minimum height to 36
+                .spacing(space_xxs)
+                .push(text::body(info))
+                .push(icon::from_name("go-next-symbolic").size(20)),
+        )
         .padding([0, space_xxs])
         .spacing(space_s)
         .apply(container)

--- a/debian/install
+++ b/debian/install
@@ -11,6 +11,7 @@
 /usr/share/applications/com.system76.CosmicSettings.Input.desktop
 /usr/share/applications/com.system76.CosmicSettings.Keyboard.desktop
 /usr/share/applications/com.system76.CosmicSettings.Mouse.desktop
+/usr/share/applications/com.system76.CosmicSettings.Network.desktop
 /usr/share/applications/com.system76.CosmicSettings.Notifications.desktop
 /usr/share/applications/com.system76.CosmicSettings.Panel.desktop
 /usr/share/applications/com.system76.CosmicSettings.Power.desktop

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -80,6 +80,28 @@ wifi = Wi-Fi
 online-accounts = Online Accounts
     .desc = Add accounts, IMAP and SMTP, enterprise logins
 
+# Bluetooth
+
+bluetooth = Bluetooth
+    .desc = Manage Bluetooth devices
+    .status = This system is visible as { $aliases } while Bluetooth settings are open.
+    .connected = Connected
+    .connecting = Connecting
+    .disconnecting = Disconnecting
+    .connect = Connect
+    .disconnect = Disconnect
+    .forget = Forget
+    .dbus-error = An error has occurred while interacting with DBus: { $why }
+    .show-device-without-name = Show devices without name
+
+bluetooth-paired = Previously Connected Devices
+    .connect = Connect
+    .battery = { $percentage }% battery
+
+bluetooth-available = Nearby Devices
+
+bluetooth-adapters = Bluetooth Adapters
+
 ## Desktop
 
 desktop = Desktop
@@ -689,25 +711,3 @@ firmware = Firmware
 
 users = Users
     .desc = Authentication and user accounts.
-
-# Bluetooth
-
-bluetooth = Bluetooth
-    .desc = Manage Bluetooth devices
-    .status = This system is visible as { $aliases } while the Bluetooth settings is open.
-    .connected = Connected
-    .connecting = Connecting
-    .disconnecting = Disconnecting
-    .connect = Connect
-    .disconnect = Disconnect
-    .forget = Forget
-    .dbus-error = An error has occurred while interacting with DBus: { $why }
-    .show-device-without-name = Show device without name
-
-bluetooth-paired = Previously Connected Devices
-    .connect = Connect
-    .battery = { $percentage }% battery
-
-bluetooth-available = Nearby Devices
-
-bluetooth-adapters = Bluetooth Adapters

--- a/justfile
+++ b/justfile
@@ -36,6 +36,7 @@ entry-firmware := appid + '.Firmware.desktop'
 entry-input := appid + '.Input.desktop'
 entry-keyboard := appid + '.Keyboard.desktop'
 entry-mouse := appid + '.Mouse.desktop'
+entry-network := appid + '.Network.desktop'
 entry-notifications := appid + '.Notifications.desktop'
 entry-panel := appid + '.Panel.desktop'
 entry-power := appid + '.Power.desktop'
@@ -70,6 +71,7 @@ install-desktop-entries:
     install -Dm0644 'resources/{{entry-input}}' '{{appdir}}/{{entry-input}}'
     install -Dm0644 'resources/{{entry-keyboard}}' '{{appdir}}/{{entry-keyboard}}'
     install -Dm0644 'resources/{{entry-mouse}}' '{{appdir}}/{{entry-mouse}}'
+    install -Dm0644 'resources/{{entry-network}}' '{{appdir}}/{{entry-network}}'
     install -Dm0644 'resources/{{entry-notifications}}' '{{appdir}}/{{entry-notifications}}'
     install -Dm0644 'resources/{{entry-panel}}' '{{appdir}}/{{entry-panel}}'
     install -Dm0644 'resources/{{entry-power}}' '{{appdir}}/{{entry-power}}'
@@ -116,6 +118,7 @@ uninstall:
         '{{appdir}}/{{entry-input}}' \
         '{{appdir}}/{{entry-keyboard}}' \
         '{{appdir}}/{{entry-mouse}}' \
+        '{{appdir}}/{{entry-network}}' \
         '{{appdir}}/{{entry-notifications}}' \
         '{{appdir}}/{{entry-panel}}' \
         '{{appdir}}/{{entry-power}}' \

--- a/resources/com.system76.CosmicSettings.Network.desktop
+++ b/resources/com.system76.CosmicSettings.Network.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
-Name=Bluetooth
-Comment=Manage Bluetooth devices
+Name=Network & Wireless
+Comment=Manage network connections
 Type=Settings
-Exec=cosmic-settings bluetooth
+Exec=cosmic-settings network
 Terminal=false
 Categories=COSMIC
 Keywords=COSMIC
 NoDisplay=true
 OnlyShowIn=COSMIC
-Icon=preferences-bluetooth
+Icon=preferences-network-and-wireless
 StartupNotify=true


### PR DESCRIPTION
Adds an `info` argument to `page_list_item` that displays next to the arrow. `min_height` wasn't used for the container because it includes padding, so I added 8px vertical padding to a fixed size (20) component, to set it to 36 to match designs.
It would probably be better if padding around the icons could be set, since that would eliminate the need for a few `.padding` calls.
It has minor text wrapping issues, in that the text on the left doesn't wrap reliably if it doesn't have a description (not sure how to fix).
![screenshot-2024-09-25-13-47-26](https://github.com/user-attachments/assets/63671a15-a24b-4399-b253-f13a744a818f)
Should the "Connected", etc. text display only when there are multiple adapters of a type, rather than always?
Also includes various minor fixes.

Edit: Fixes #627 (order checked with Maria).