### PR TITLE
Desktop > Workspaces: Add miscellaneous section

### DIFF
--- a/cosmic-settings/src/pages/desktop/workspaces.rs
+++ b/cosmic-settings/src/pages/desktop/workspaces.rs
@@ -23,6 +23,7 @@ pub enum Message {
     SetShowName(bool),
     SetShowNumber(bool),
     MinOpenWorkspaces(spin_button::Message),
+    RemoveEmptyWorkspaces(bool),
 }
 
 pub struct Page {
@@ -32,6 +33,7 @@ pub struct Page {
     show_workspace_name: bool,
     show_workspace_number: bool,
     min_open_workspaces: u8,
+    remove_empty_workspaces: bool,
 }
 
 impl Default for Page {
@@ -66,6 +68,7 @@ impl Default for Page {
             show_workspace_name,
             show_workspace_number,
             min_open_workspaces: Self::MIN_OPEN_WORKSPACES,
+            remove_empty_workspaces: true,
         }
     }
 }
@@ -134,6 +137,9 @@ impl Page {
                     }
                 }
             },
+            Message::RemoveEmptyWorkspaces(value) => {
+                self.remove_empty_workspaces = value;
+            }
         }
     }
 }
@@ -210,6 +216,7 @@ fn misc() -> Section<crate::pages::Message> {
     let mut descriptions = Slab::new();
 
     let opened_workspaces = descriptions.insert(fl!("workspaces-misc", "min-open"));
+    let shift_workspaces = descriptions.insert(fl!("workspaces-misc", "empty-workspaces"));
 
     Section::default()
         .title(fl!("workspaces-misc"))
@@ -226,6 +233,10 @@ fn misc() -> Section<crate::pages::Message> {
                             Message::MinOpenWorkspaces,
                         ),
                     ),
+                )
+                .add(
+                    settings::item::builder(&descriptions[shift_workspaces])
+                        .toggler(page.remove_empty_workspaces, Message::RemoveEmptyWorkspaces),
                 )
                 .apply(Element::from)
                 .map(crate::pages::Message::DesktopWorkspaces)

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -308,6 +308,9 @@ workspaces-orientation = Workspaces Orientation
     .vertical = Vertical
     .horizontal = Horizontal
 
+workspaces-misc = Miscellaneous
+    .min-open = Minimum open workspaces
+
 hot-corner = Hot Corner
     .top-left-corner = Enable top-left hot corner for Workspaces
 

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -310,6 +310,7 @@ workspaces-orientation = Workspaces Orientation
 
 workspaces-misc = Miscellaneous
     .min-open = Minimum open workspaces
+    .empty-workspaces = Shift workspaces to lower workspaces if there's an empty workspace inbetween
 
 hot-corner = Hot Corner
     .top-left-corner = Enable top-left hot corner for Workspaces


### PR DESCRIPTION
I couldn't find any guide of how to start contributing so I just started and tried it out.

This PR adds two more options to the `Desktop > Workspaces` page (look at the bottom):

![image](https://github.com/user-attachments/assets/1f5d53d2-fd0c-4f08-92a7-e8f82245b863)

- `Minimum open workspaces`: Users can set a minimal amount of workspaces which should be open during a session, even if they are empty. (Fixes https://github.com/pop-os/cosmic-settings/issues/664)
- Well, the second option already includes a description but is for the following use case:
    Assuming you have at least 3 workspaces: `1 [2] 3` where `[...]` symbolizes the current focussed workspace. If this option is set to `false` and you move to `workspace 1`, the content of workspace 3 doesn't move to workspace 2 automatically.