### PR TITLE
Add density to reset to default

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -13,7 +13,7 @@ use cosmic::config::CosmicTk;
 use cosmic::cosmic_config::{Config, ConfigSet, CosmicConfigEntry};
 use cosmic::cosmic_theme::palette::{FromColor, Hsv, Srgb, Srgba};
 use cosmic::cosmic_theme::{
-    CornerRadii, Density, Theme, ThemeBuilder, ThemeMode, DARK_THEME_BUILDER_ID,
+    CornerRadii, Density, Spacing, Theme, ThemeBuilder, ThemeMode, DARK_THEME_BUILDER_ID,
     LIGHT_THEME_BUILDER_ID,
 };
 use cosmic::iced_core::{alignment, Background, Color, Length};
@@ -681,18 +681,17 @@ impl Page {
                     _ = config.set("header_size", density);
                 }
 
-                let Some(config) = self.theme_builder_config.as_ref() else {
-                    return Command::none();
-                };
+                let spacing: Spacing = density.into();
 
-                let spacing = density.into();
+                let light_config = Theme::light_config().ok();
+                let dark_config = Theme::dark_config().ok();
 
-                if self
-                    .theme_builder
-                    .set_spacing(config, spacing)
-                    .unwrap_or_default()
-                {
-                    self.theme_config_write("spacing", spacing);
+                // Update both light and dark theme configs
+                if let Some(config) = light_config {
+                    _ = config.set("spacing", spacing);
+                }
+                if let Some(config) = dark_config {
+                    _ = config.set("spacing", spacing);
                 }
 
                 tokio::task::spawn(async move {

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -768,6 +768,10 @@ impl Page {
                 if let Some(config) = self.theme_builder_config.as_ref() {
                     _ = self.theme_builder.write_entry(config);
                 };
+                if let Some(config) = self.tk_config.as_mut() {
+                    _ = config.set("interface_density", Density::Standard);
+                    _ = config.set("header_size", Density::Standard);
+                }
 
                 let config = if self.theme_mode.is_dark {
                     Theme::dark_config()
@@ -784,6 +788,7 @@ impl Page {
                 let r = self.roundness;
                 tokio::task::spawn(async move {
                     Self::update_panel_radii(r);
+                    Self::update_panel_spacing(Density::Standard);
                 });
 
                 self.reload_theme_mode();

--- a/cosmic-settings/src/pages/input/keyboard/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/mod.rs
@@ -509,8 +509,7 @@ impl Page {
             .on_input(Message::InputSourceSearch)
             .on_clear(Message::InputSourceSearch(String::new()));
 
-        let toggler = widget::toggler(
-            fl!("show-extended-input-sources"),
+        let toggler = settings::item::builder(fl!("show-extended-input-sources")).toggler(
             self.show_extended_input_sources,
             Message::SetShowExtendedInputSources,
         );


### PR DESCRIPTION
This is to reset the related CosmicTk configs to the defaults.
Also fixes the styling of the extended input sources toggle.
Not entirely sure about the second commit, but it seems to work/behave the same as roundness.