### PR TITLE
feat: Add alt-shift-tab reverse window switcher shortcut

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/mod.rs
@@ -658,6 +658,7 @@ fn localize_action(action: &Action) -> String {
             SystemAction::VolumeRaise => fl!("system-shortcut", "volume-raise"),
             SystemAction::WebBrowser => fl!("system-shortcut", "web-browser"),
             SystemAction::WindowSwitcher => fl!("system-shortcut", "window-switcher"),
+            SystemAction::WindowSwitcherReverse => fl!("system-shortcut", "window-switcher-reverse"),
             SystemAction::WorkspaceOverview => fl!("system-shortcut", "workspace-overview"),
         },
 

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/system.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/system.rs
@@ -77,6 +77,7 @@ pub const fn actions() -> &'static [Action] {
         Action::System(SystemAction::Launcher),
         Action::System(SystemAction::WorkspaceOverview),
         Action::System(SystemAction::WindowSwitcher),
+        Action::System(SystemAction::WindowSwitcherReverse),
         Action::System(SystemAction::LockScreen),
         Action::System(SystemAction::VolumeLower),
         Action::System(SystemAction::VolumeRaise),

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -627,6 +627,7 @@ system-shortcut = System
     .volume-raise = Increase audio output volume
     .web-browser = Opens a web browser
     .window-switcher = Switch between open windows
+    .window-switcher-reverse = Switch backwards between open windows
     .workspace-overview = Open the workspace overview
 
 window-tiling = Window tiling


### PR DESCRIPTION
This is part of https://github.com/pop-os/cosmic-launcher/issues/173

I only added English due to not knowing how to translate into the rest of the languages.