### PR TITLE
vpn: Add WireGuard configuration file support

### DIFF
--- a/cosmic-settings/src/pages/networking/vpn/nmcli.rs
+++ b/cosmic-settings/src/pages/networking/vpn/nmcli.rs
@@ -1,18 +1,19 @@
 // Copyright 2024 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use as_result::IntoResult;
-use std::io;
+use cosmic::Apply;
+use std::process::Stdio;
 
-pub async fn set_username(connection_name: &str, username: &str) -> io::Result<()> {
+pub async fn set_username(connection_name: &str, username: &str) -> Result<(), String> {
     tokio::process::Command::new("nmcli")
         .args(&["con", "mod", connection_name, "vpn.user-name", username])
-        .status()
+        .stderr(Stdio::piped())
+        .output()
         .await
-        .and_then(IntoResult::into_result)
+        .apply(crate::utils::map_stderr_output)
 }
 
-pub async fn set_password_flags_none(connection_name: &str) -> io::Result<()> {
+pub async fn set_password_flags_none(connection_name: &str) -> Result<(), String> {
     tokio::process::Command::new("nmcli")
         .args(&[
             "con",
@@ -21,12 +22,13 @@ pub async fn set_password_flags_none(connection_name: &str) -> io::Result<()> {
             "+vpn.data",
             "password-flags=0",
         ])
-        .status()
+        .stderr(Stdio::piped())
+        .output()
         .await
-        .and_then(IntoResult::into_result)
+        .apply(crate::utils::map_stderr_output)
 }
 
-pub async fn set_password(connection_name: &str, password: &str) -> io::Result<()> {
+pub async fn set_password(connection_name: &str, password: &str) -> Result<(), String> {
     tokio::process::Command::new("nmcli")
         .args(&[
             "con",
@@ -35,15 +37,17 @@ pub async fn set_password(connection_name: &str, password: &str) -> io::Result<(
             "vpn.secrets",
             &format!("password={password}"),
         ])
-        .status()
+        .stderr(Stdio::piped())
+        .output()
         .await
-        .and_then(IntoResult::into_result)
+        .apply(crate::utils::map_stderr_output)
 }
 
-pub async fn connect(connection_name: &str) -> io::Result<()> {
+pub async fn connect(connection_name: &str) -> Result<(), String> {
     tokio::process::Command::new("nmcli")
         .args(&["con", "up", &connection_name])
-        .status()
+        .stderr(Stdio::piped())
+        .output()
         .await
-        .and_then(IntoResult::into_result)
+        .apply(crate::utils::map_stderr_output)
 }

--- a/cosmic-settings/src/pages/networking/wired.rs
+++ b/cosmic-settings/src/pages/networking/wired.rs
@@ -551,7 +551,6 @@ impl Page {
 fn devices_view() -> Section<crate::pages::Message> {
     crate::slab!(descriptions {
         wired_conns_txt = fl!("wired", "connections");
-        wired_devices_txt = fl!("wired", "devices");
         remove_txt = fl!("wired", "remove");
         connect_txt = fl!("connect");
         connected_txt = fl!("connected");

--- a/cosmic-settings/src/utils.rs
+++ b/cosmic-settings/src/utils.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use std::{future::Future, io, process};
 
 use futures::{future::select, StreamExt};
 
@@ -45,6 +45,17 @@ pub fn forward_event_loop<M: 'static + Send, T: Future<Output = ()> + Send + 'st
     });
 
     cancel_tx
+}
+
+/// On process failure, return stderr as `String`.
+pub fn map_stderr_output(result: io::Result<process::Output>) -> Result<(), String> {
+    result.map_err(|why| why.to_string()).and_then(|output| {
+        if !output.status.success() {
+            Err(String::from_utf8(output.stderr).unwrap_or_default())
+        } else {
+            Ok(())
+        }
+    })
 }
 
 /// Creates a slab with predefined items

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -1,5 +1,7 @@
 app = COSMIC Settings
 
+dbus-connection-error = Failed to connect to DBus
+ok = OK
 unknown = Unknown
 
 number = { $number }
@@ -62,8 +64,24 @@ remove-connection-dialog = Remove Connection Profile?
 
 vpn = VPN
     .connections = VPN Connections
+    .error = Failed to add VPN config
     .remove = Remove connection profile
     .select-file = Select a VPN configuration file
+
+vpn-error = VPN Error
+    .config = Failed to add VPN config
+    .connect = Failed to connect to VPN
+    .connection-editor = Connection editor failed
+    .connection-settings = Failed to get settings for active connections
+    .updating-state = Failed to update network manager state
+    .wireguard-config-path = Invalid file path for WireGuard config
+    .wireguard-config-path-desc = Chosen file must be on a local file system.
+    .wireguard-device = Failed to create WireGuard device
+    .with-password = Failed to set VPN { $field ->
+        *[username] username
+        [password] password
+        [password-flags] password-flags
+    } with nmcli
 
 wired = Wired
     .adapter = Wired adapter { $id }
@@ -74,6 +92,9 @@ wired = Wired
 wifi = Wi-Fi
     .adapter = Wi-Fi adapter { $id }
     .forget = Forget this network
+
+wireguard-dialog = Add WireGuard device
+    .description = Choose a device name for the WireGuard config.
 
 ## Networking: Online Accounts
 


### PR DESCRIPTION
- Adds error dialogs to the VPN page
- Requests an interface name upon adding a WireGuard config
- Renames the file to the requested valid interface name
- Adds the WireGuard connection via nmcli

## Todo

- Display WireGuard devices alongside OpenVPN profiles