### PR TITLE
fix(shortcuts): Prevent panic when deleting the last keybind of a custom shortcut.

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
@@ -321,6 +321,10 @@ impl Model {
                         if shortcut.is_default {
                             self.config_add(Action::Disable, shortcut.binding.clone());
                         } else {
+                            // if last keybind deleted, clear shortcut context
+                            if model.bindings.is_empty() {
+                                self.shortcut_context = None;
+                            }
                             self.config_remove(&shortcut.binding);
                         }
 


### PR DESCRIPTION
Fix #575 


* Clear shortcut context and close the context_drawer where the panics happen in an empty slab/array when deleting the last keybind of a shortcut.
* This is a solution where it may be acceptable if we consider that there is no point for a user to delete the last keybind of a shortcut instead of editing it, without wanting  to delete the shortcut as a whole.
* A totally different "user journey" would be to although you have deleted everything in memory and config/fs, to open the Add shortcut context-drawer by having the previous deleted command and description ,if any, populated, but this fix would be a lot more difficult.

[screen-capture.webm](https://github.com/user-attachments/assets/6340c5fc-fbbc-40a8-a888-80bbfabfa848)
