### PR TITLE
Add the ability to remap caps lock to control

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/mod.rs
@@ -45,6 +45,7 @@ static CAPS_LOCK_OPTIONS: &[(&str, &str)] = &[
     ("Swap with Escape", "caps:swapescape"),
     ("Backspace", "caps:backspace"),
     ("Super", "caps:super"),
+    ("Control", "caps:ctrl_modifier"),
 ];
 
 const STR_ORDER: &str = "`str` is always comparable";


### PR DESCRIPTION
The ability to remap the caps lock key was recently added but it wasn't possible to remap it to act as an extra control key. This commit makes that possible.

This is especially useful to reduce stress on the pinky finger when using control heavy applications like Emacs.