### PR TITLE
fix(sound): Apply sound volume debounce.

### DIFF
--- a/cosmic-settings/src/pages/sound.rs
+++ b/cosmic-settings/src/pages/sound.rs
@@ -316,7 +316,7 @@ impl Page {
             }
 
             Message::Pulse(pulse::Event::SourceVolume(volume)) => {
-                if self.sink_volume_debounce {
+                if self.source_volume_debounce {
                     return Command::none();
                 }
 
@@ -340,7 +340,7 @@ impl Page {
                 }
 
                 if let Some(command) = command {
-                    self.source_volume_debounce = true;
+                    self.sink_volume_debounce = true;
                     return command;
                 }
             }

--- a/cosmic-settings/src/pages/sound.rs
+++ b/cosmic-settings/src/pages/sound.rs
@@ -304,7 +304,7 @@ impl Page {
                 let mut command = None;
                 if let Some(&node_id) = self.source_ids.get(self.active_source.unwrap_or(0)) {
                     command = Some(cosmic::command::future(async move {
-                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        tokio::time::sleep(Duration::from_millis(64)).await;
                         crate::pages::Message::Sound(Message::SourceVolumeApply(node_id))
                     }));
                 }
@@ -334,7 +334,7 @@ impl Page {
                 let mut command = None;
                 if let Some(&node_id) = self.sink_ids.get(self.active_sink.unwrap_or(0)) {
                     command = Some(cosmic::command::future(async move {
-                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        tokio::time::sleep(Duration::from_millis(64)).await;
                         crate::pages::Message::Sound(Message::SinkVolumeApply(node_id))
                     }));
                 }


### PR DESCRIPTION
Fixes #712 . I was working on #711  and observed this, haven't figured out #711 yet though seems to be something different.

I double-checked with the almost same code of the cosmic-applet-audio here: https://github.com/pop-os/cosmic-applets/blob/master/cosmic-applet-audio/src/lib.rs#L381-L392

Edit: Just noticed in the applet we have a **64ms** delay whilst on settings **500ms**, which one of the two is correct?
There will be a significant noticeable difference with these changes applied between the two.
I think the 500ms feels kind of "laggy" when noticing cosmic-osd  whilst the 64ms seems like it is  applied almost "real-time" in my opinion. I could change the settings one in this PR if you have something in mind. 