### PR TITLE
Make pages requiring OS features configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,8 +2321,7 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 [[package]]
 name = "fast_image_resize"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66a61fbfc84ef99a839499cf9e5a7c2951d2da874ea00f29ee938bc50d1b396"
+source = "git+https://github.com/jackpot51/fast_image_resize.git#c48fdca44951e1cfb212eec47fc6d444647a00d3"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -6841,7 +6840,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows 0.57.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -7961,18 +7960,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
- "windows-implement 0.53.0",
- "windows-interface 0.53.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
+ "windows-implement",
+ "windows-interface",
  "windows-targets 0.52.6",
 ]
 
@@ -7996,18 +7985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-implement"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8019,32 +7996,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.82",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.82",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,11 @@ cosmic-randr = { git = "https://github.com/pop-os/cosmic-randr" }
 tokio = { version = "1.40.0", features = ["macros"] }
 
 [workspace.dependencies.libcosmic]
-features = ["multi-window", "winit", "tokio", "xdg-portal"]
+features = ["multi-window", "winit", "tokio"]
 git = "https://github.com/pop-os/libcosmic"
 
 [workspace.dependencies.cosmic-config]
 git = "https://github.com/pop-os/libcosmic"
-features = ["dbus"]
 
 [workspace.dependencies.cosmic-bg-config]
 git = "https://github.com/pop-os/cosmic-bg"

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -7,21 +7,21 @@ license = "GPL-3.0-only"
 [dependencies]
 anyhow = "1.0"
 as-result = "0.2.1"
-ashpd = { version = "0.9", default-features = false, features = ["tokio"] }
+ashpd = { version = "0.9", default-features = false, features = ["tokio"], optional = true }
 async-channel = "2.3.1"
 chrono = "0.4.38"
 clap = { version = "4.5.17", features = ["derive"] }
 color-eyre = "0.6.3"
 cosmic-bg-config.workspace = true
-cosmic-comp-config.workspace = true
+cosmic-comp-config = { workspace = true, optional = true }
 cosmic-config.workspace = true
-cosmic-dbus-networkmanager = { git = "https://github.com/pop-os/dbus-settings-bindings" }
-cosmic-panel-config.workspace = true
+cosmic-dbus-networkmanager = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
+cosmic-panel-config = { workspace = true, optional = true }
 cosmic-randr-shell.workspace = true
-cosmic-randr.workspace = true
-cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon" }
+cosmic-randr = { workspace = true, optional = true }
+cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", optional = true }
 cosmic-settings-page = { path = "../page" }
-cosmic-settings-system = { path = "../pages/system" }
+cosmic-settings-system = { path = "../pages/system", optional = true }
 cosmic-settings-wallpaper = { path = "../pages/wallpapers" }
 derivative = "2.2.0"
 derive_setters = "0.1.6"
@@ -31,7 +31,7 @@ eyre = "0.6.12"
 freedesktop-desktop-entry = "0.7.5"
 futures = "0.3.30"
 hostname-validator = "1.1.1"
-hostname1-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }
+hostname1-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
 i18n-embed-fl = "0.9.1"
 image = "0.25"
 indexmap = "2.5.0"
@@ -50,22 +50,24 @@ slotmap = "1.0.7"
 static_init = "1.0.3"
 sunrise = "1.0.1"
 tachyonix = "0.3.1"
-timedate-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }
-tokio.workspace = true
+timedate-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
+tokio = { workspace = true, features = ["fs", "io-util", "sync"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-udev = "0.9.0"
-upower_dbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }
-bluez-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }
+udev = { version = "0.9.0", optional = true }
+upower_dbus = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
+bluez-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
 url = "2.5.2"
 xkb-data = "0.2.1"
-zbus = { version = "4.4.0", features = ["tokio"] }
+zbus = { version = "4.4.0", features = ["tokio"], optional = true }
 ustr = "1.0.0"
 fontdb = "0.16.2"
 
 [dependencies.cosmic-settings-subscriptions]
 git = "https://github.com/pop-os/cosmic-settings-subscriptions"
+#TODO: only select features as needed
 features = ["network_manager", "pipewire", "pulse"]
+optional = true
 
 [dependencies.icu]
 version = "1.5.0"
@@ -76,10 +78,46 @@ version = "0.15.0"
 features = ["fluent-system", "desktop-requester"]
 
 [features]
-default = ["wayland", "dbus-config", "single-instance", "a11y", "wgpu"]
-wayland = ["libcosmic/wayland"]
-dbus-config = ["libcosmic/dbus-config"]
-single-instance = ["libcosmic/single-instance"]
+default = [
+    "a11y",
+    "dbus-config",
+    "linux",
+    "single-instance",
+    "wgpu",
+]
+
+# Default features for Linux
+linux = [
+    "page-about",
+    "page-bluetooth",
+    "page-date",
+    "page-input",
+    "page-networking",
+    "page-power",
+    "page-sound",
+    "page-window-management",
+    "page-workspaces",
+    "xdg-portal",
+    "wayland",
+]
+
+# Pages
+page-about = ["dep:cosmic-settings-system", "dep:hostname1-zbus", "dep:zbus"]
+page-bluetooth = ["dep:bluez-zbus", "dep:zbus"]
+page-date = ["dep:timedate-zbus", "dep:zbus"]
+page-input = ["dep:cosmic-comp-config", "dep:cosmic-settings-config", "dep:udev"]
+page-networking = ["ashpd", "dep:cosmic-dbus-networkmanager", "dep:cosmic-settings-subscriptions", "dep:zbus"]
+page-power = ["dep:upower_dbus", "dep:zbus"]
+page-sound = ["dep:cosmic-settings-subscriptions"]
+page-window-management = ["dep:cosmic-settings-config"]
+page-workspaces = ["dep:cosmic-comp-config"]
+
+# Other features
 a11y = ["libcosmic/a11y"]
-wgpu = ["libcosmic/wgpu"]
+ashpd = ["dep:ashpd"]
+dbus-config = ["libcosmic/dbus-config", "cosmic-config/dbus"]
+single-instance = ["libcosmic/single-instance"]
 test = []
+wayland = ["libcosmic/wayland", "dep:cosmic-panel-config", "dep:cosmic-randr"]
+wgpu = ["libcosmic/wgpu"]
+xdg-portal = ["libcosmic/xdg-portal"]

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -2,9 +2,18 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use crate::config::Config;
+#[cfg(feature = "page-bluetooth")]
+use crate::pages::bluetooth;
 use crate::pages::desktop::{self, appearance};
-use crate::pages::input::{self};
-use crate::pages::{self, bluetooth, display, networking, power, sound, system, time};
+#[cfg(feature = "page-input")]
+use crate::pages::input;
+#[cfg(feature = "page-networking")]
+use crate::pages::networking;
+#[cfg(feature = "page-power")]
+use crate::pages::power;
+#[cfg(feature = "page-sound")]
+use crate::pages::sound;
+use crate::pages::{self, display, system, time};
 use crate::subscription::desktop_files;
 use crate::widget::{page_title, search_header};
 use crate::PageCommands;
@@ -29,6 +38,7 @@ use cosmic::{
     },
     Element,
 };
+#[cfg(feature = "wayland")]
 use cosmic_panel_config::CosmicPanelConfig;
 use cosmic_settings_page::{self as page, section};
 #[cfg(feature = "wayland")]
@@ -59,35 +69,50 @@ pub struct SettingsApp {
 impl SettingsApp {
     fn subtask_to_page(&self, cmd: &PageCommands) -> Option<Entity> {
         match cmd {
+            #[cfg(feature = "page-about")]
             PageCommands::About => self.pages.page_id::<system::about::Page>(),
             PageCommands::Appearance => self.pages.page_id::<desktop::appearance::Page>(),
+            #[cfg(feature = "page-bluetooth")]
             PageCommands::Bluetooth => self.pages.page_id::<bluetooth::Page>(),
+            #[cfg(feature = "page-date")]
             PageCommands::DateTime => self.pages.page_id::<time::date::Page>(),
             PageCommands::Desktop => self.pages.page_id::<desktop::Page>(),
             PageCommands::Displays => self.pages.page_id::<display::Page>(),
             #[cfg(feature = "wayland")]
             PageCommands::Dock => self.pages.page_id::<desktop::dock::Page>(),
             PageCommands::Firmware => self.pages.page_id::<system::firmware::Page>(),
+            #[cfg(feature = "page-input")]
             PageCommands::Input => self.pages.page_id::<input::Page>(),
+            #[cfg(feature = "page-input")]
             PageCommands::Keyboard => self.pages.page_id::<input::keyboard::Page>(),
+            #[cfg(feature = "page-input")]
             PageCommands::Mouse => self.pages.page_id::<input::mouse::Page>(),
+            #[cfg(feature = "page-networking")]
             PageCommands::Network => self.pages.page_id::<networking::Page>(),
             #[cfg(feature = "wayland")]
             PageCommands::Panel => self.pages.page_id::<desktop::panel::Page>(),
+            #[cfg(feature = "page-power")]
             PageCommands::Power => self.pages.page_id::<power::Page>(),
             PageCommands::RegionLanguage => self.pages.page_id::<time::region::Page>(),
+            #[cfg(feature = "page-sound")]
             PageCommands::Sound => self.pages.page_id::<sound::Page>(),
             PageCommands::System => self.pages.page_id::<system::Page>(),
             PageCommands::Time => self.pages.page_id::<time::Page>(),
+            #[cfg(feature = "page-input")]
             PageCommands::Touchpad => self.pages.page_id::<input::touchpad::Page>(),
             PageCommands::Users => self.pages.page_id::<system::users::Page>(),
+            #[cfg(feature = "page-networking")]
             PageCommands::Vpn => self.pages.page_id::<networking::vpn::Page>(),
             PageCommands::Wallpaper => self.pages.page_id::<desktop::wallpaper::Page>(),
+            #[cfg(feature = "page-window-management")]
             PageCommands::WindowManagement => {
                 self.pages.page_id::<desktop::window_management::Page>()
             }
+            #[cfg(feature = "page-networking")]
             PageCommands::Wired => self.pages.page_id::<networking::wired::Page>(),
+            #[cfg(feature = "page-networking")]
             PageCommands::Wireless => self.pages.page_id::<networking::wifi::Page>(),
+            #[cfg(feature = "page-workspaces")]
             PageCommands::Workspaces => self.pages.page_id::<desktop::workspaces::Page>(),
         }
     }
@@ -153,12 +178,17 @@ impl cosmic::Application for SettingsApp {
             search_selections: Vec::default(),
         };
 
+        #[cfg(feature = "page-networking")]
         app.insert_page::<networking::Page>();
+        #[cfg(feature = "page-bluetooth")]
         app.insert_page::<bluetooth::Page>();
         let desktop_id = app.insert_page::<desktop::Page>().id();
         app.insert_page::<display::Page>();
+        #[cfg(feature = "page-sound")]
         app.insert_page::<sound::Page>();
+        #[cfg(feature = "page-power")]
         app.insert_page::<power::Page>();
+        #[cfg(feature = "page-input")]
         app.insert_page::<input::Page>();
         app.insert_page::<time::Page>();
         app.insert_page::<system::Page>();
@@ -244,6 +274,7 @@ impl cosmic::Application for SettingsApp {
                     futures::future::pending::<()>().await;
                 }),
             ),
+            #[cfg(feature = "ashpd")]
             crate::subscription::daytime().map(|daytime| {
                 Message::PageMessage(pages::Message::Appearance(appearance::Message::Daytime(
                     daytime,
@@ -323,6 +354,7 @@ impl cosmic::Application for SettingsApp {
             }
 
             Message::PageMessage(message) => match message {
+                #[cfg(feature = "page-about")]
                 crate::pages::Message::About(message) => {
                     page::update!(self.pages, message, system::about::Page);
                 }
@@ -333,12 +365,14 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                #[cfg(feature = "page-bluetooth")]
                 crate::pages::Message::Bluetooth(message) => {
                     if let Some(page) = self.pages.page_mut::<bluetooth::Page>() {
                         return page.update(message).map(Into::into);
                     }
                 }
 
+                #[cfg(feature = "page-date")]
                 crate::pages::Message::DateAndTime(message) => {
                     if let Some(page) = self.pages.page_mut::<time::date::Page>() {
                         return page.update(message).map(Into::into);
@@ -355,6 +389,7 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                #[cfg(feature = "page-workspaces")]
                 crate::pages::Message::DesktopWorkspaces(message) => {
                     page::update!(self.pages, message, desktop::workspaces::Page);
                 }
@@ -379,24 +414,28 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                #[cfg(feature = "page-input")]
                 crate::pages::Message::Input(message) => {
                     if let Some(page) = self.pages.page_mut::<input::Page>() {
                         return page.update(message).map(Into::into);
                     }
                 }
 
+                #[cfg(feature = "page-input")]
                 crate::pages::Message::Keyboard(message) => {
                     if let Some(page) = self.pages.page_mut::<input::keyboard::Page>() {
                         return page.update(message).map(Into::into);
                     }
                 }
 
+                #[cfg(feature = "page-input")]
                 crate::pages::Message::KeyboardShortcuts(message) => {
                     if let Some(page) = self.pages.page_mut::<input::keyboard::shortcuts::Page>() {
                         return page.update(message).map(Into::into);
                     }
                 }
 
+                #[cfg(feature = "page-input")]
                 crate::pages::Message::CustomShortcuts(message) => {
                     if let Some(page) = self
                         .pages
@@ -406,6 +445,7 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                #[cfg(feature = "page-input")]
                 crate::pages::Message::ManageWindowShortcuts(message) => {
                     if let Some(page) = self
                         .pages
@@ -415,6 +455,7 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                #[cfg(feature = "page-input")]
                 crate::pages::Message::MoveWindowShortcuts(message) => {
                     if let Some(page) = self
                         .pages
@@ -424,6 +465,7 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                #[cfg(feature = "page-input")]
                 crate::pages::Message::NavShortcuts(message) => {
                     if let Some(page) = self
                         .pages
@@ -433,12 +475,14 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                #[cfg(feature = "page-sound")]
                 crate::pages::Message::Sound(message) => {
                     if let Some(page) = self.pages.page_mut::<sound::Page>() {
                         return page.update(message).map(Into::into);
                     }
                 }
 
+                #[cfg(feature = "page-input")]
                 crate::pages::Message::SystemShortcuts(message) => {
                     if let Some(page) = self
                         .pages
@@ -448,6 +492,7 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                #[cfg(feature = "page-input")]
                 crate::pages::Message::TilingShortcuts(message) => {
                     if let Some(page) = self
                         .pages
@@ -465,6 +510,7 @@ impl cosmic::Application for SettingsApp {
                     return self.activate_page(page);
                 }
 
+                #[cfg(feature = "page-networking")]
                 crate::pages::Message::Networking(message) => {
                     if let Some(page) = self.pages.page_mut::<networking::Page>() {
                         return page.update(message).map(Into::into);
@@ -485,26 +531,31 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                #[cfg(feature = "page-power")]
                 crate::pages::Message::Power(message) => {
                     page::update!(self.pages, message, power::Page);
                 }
 
+                #[cfg(feature = "page-networking")]
                 crate::pages::Message::Vpn(message) => {
                     if let Some(page) = self.pages.page_mut::<networking::vpn::Page>() {
                         return page.update(message).map(Into::into);
                     }
                 }
 
+                #[cfg(feature = "page-networking")]
                 crate::pages::Message::WiFi(message) => {
                     if let Some(page) = self.pages.page_mut::<networking::wifi::Page>() {
                         return page.update(message).map(Into::into);
                     }
                 }
 
+                #[cfg(feature = "page-window-management")]
                 crate::pages::Message::WindowManagement(message) => {
                     page::update!(self.pages, message, desktop::window_management::Page);
                 }
 
+                #[cfg(feature = "page-networking")]
                 crate::pages::Message::Wired(message) => {
                     if let Some(page) = self.pages.page_mut::<networking::wired::Page>() {
                         return page.update(message).map(Into::into);

--- a/cosmic-settings/src/main.rs
+++ b/cosmic-settings/src/main.rs
@@ -39,58 +39,73 @@ pub struct Args {
 #[derive(Subcommand, Debug, Serialize, Deserialize, Clone)]
 pub enum PageCommands {
     /// About settings page
+    #[cfg(feature = "page-about")]
     About,
     /// Appearance settings page
     Appearance,
     /// Bluetooth settings page
+    #[cfg(feature = "page-bluetooth")]
     Bluetooth,
     /// Date & Time settings page
+    #[cfg(feature = "page-date")]
     DateTime,
     /// Desktop settings page
     Desktop,
     /// Displays settings page
     Displays,
-    #[cfg(feature = "wayland")]
     /// Dock settings page
+    #[cfg(feature = "wayland")]
     Dock,
     /// Firmware settings page
     Firmware,
     /// Input Devices settings page
+    #[cfg(feature = "page-input")]
     Input,
     /// Keyboard settings page
+    #[cfg(feature = "page-input")]
     Keyboard,
     /// Mouse settings page
+    #[cfg(feature = "page-input")]
     Mouse,
     /// Network settings page
+    #[cfg(feature = "page-networking")]
     Network,
-    #[cfg(feature = "wayland")]
     /// Panel settings page
+    #[cfg(feature = "wayland")]
     Panel,
     /// Power settings page
+    #[cfg(feature = "page-power")]
     Power,
     /// Region & Language settings page
     RegionLanguage,
     /// Sound settings page
+    #[cfg(feature = "page-sound")]
     Sound,
     /// System & Accounts settings page
     System,
     /// Time & Language settings page
     Time,
     /// Touchpad settings page
+    #[cfg(feature = "page-input")]
     Touchpad,
     /// Users settings page
     Users,
     /// VPN settings page
+    #[cfg(feature = "page-networking")]
     Vpn,
     /// Wallpaper settings page
     Wallpaper,
     /// Window management settings page
+    #[cfg(feature = "page-window-management")]
     WindowManagement,
     /// Wired settings page
+    #[cfg(feature = "page-networking")]
     Wired,
     /// WiFi settings page
+    #[cfg(feature = "page-networking")]
     Wireless,
     /// Workspaces settings page
+    #[cfg(feature = "page-workspaces")]
     Workspaces,
 }
 

--- a/cosmic-settings/src/pages/desktop/mod.rs
+++ b/cosmic-settings/src/pages/desktop/mod.rs
@@ -7,7 +7,9 @@ pub mod dock;
 #[cfg(feature = "wayland")]
 pub mod panel;
 pub mod wallpaper;
+#[cfg(feature = "page-window-management")]
 pub mod window_management;
+#[cfg(feature = "page-workspaces")]
 pub mod workspaces;
 
 use cosmic_settings_page as page;
@@ -24,10 +26,11 @@ impl page::Page<crate::pages::Message> for Page {
 }
 
 impl page::AutoBind<crate::pages::Message> for Page {
-    fn sub_pages(page: page::Insert<crate::pages::Message>) -> page::Insert<crate::pages::Message> {
-        let mut page = page
-            .sub_page::<wallpaper::Page>()
-            .sub_page::<appearance::Page>();
+    fn sub_pages(
+        mut page: page::Insert<crate::pages::Message>,
+    ) -> page::Insert<crate::pages::Message> {
+        page = page.sub_page::<wallpaper::Page>();
+        page = page.sub_page::<appearance::Page>();
 
         #[cfg(feature = "wayland")]
         {
@@ -35,8 +38,17 @@ impl page::AutoBind<crate::pages::Message> for Page {
             page = page.sub_page::<dock::Page>();
         }
 
-        page.sub_page::<window_management::Page>()
-            .sub_page::<workspaces::Page>()
+        #[cfg(feature = "page-window-management")]
+        {
+            page = page.sub_page::<window_management::Page>();
+        }
+
+        #[cfg(feature = "page-workspaces")]
+        {
+            page = page.sub_page::<workspaces::Page>();
+        }
+
+        page
     }
 }
 

--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -14,14 +14,13 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(feature = "xdg-portal")]
+use cosmic::dialog::file_chooser;
 use cosmic::iced::{Color, Length};
-use cosmic::{
-    dialog::file_chooser,
-    widget::{
-        button, dropdown, list_column, row,
-        segmented_button::{self, SingleSelectModel},
-        settings, tab_bar, text, toggler,
-    },
+use cosmic::widget::{
+    button, dropdown, list_column, row,
+    segmented_button::{self, SingleSelectModel},
+    settings, tab_bar, text, toggler,
 };
 use cosmic::{iced_core::alignment, iced_runtime::core::image::Handle as ImageHandle};
 use cosmic::{iced_core::Alignment, widget::icon};
@@ -68,8 +67,10 @@ pub struct InitUpdate {
 #[derive(Clone, Debug)]
 pub enum Message {
     /// Adds a new wallpaper folder.
+    #[cfg(feature = "xdg-portal")]
     AddFolder(Arc<Result<Url, file_chooser::Error>>),
     /// Adds a new image file the system wallpaper folder.
+    #[cfg(feature = "xdg-portal")]
     AddFile(Arc<Result<Url, file_chooser::Error>>),
     /// Cache currently displayed image.
     CacheDisplayImage,
@@ -576,6 +577,7 @@ impl Page {
             }
 
             Category::AddFolder => {
+                #[cfg(feature = "xdg-portal")]
                 return cosmic::command::future(async {
                     let dialog_result = file_chooser::open::Dialog::new()
                         .title(fl!("wallpaper", "folder-dialog"))
@@ -770,6 +772,7 @@ impl Page {
             }
 
             Message::ImageAddDialog => {
+                #[cfg(feature = "xdg-portal")]
                 return cosmic::Task::future(async {
                     let dialog_result = file_chooser::open::Dialog::new()
                         .title(fl!("wallpaper", "image-dialog"))
@@ -847,6 +850,7 @@ impl Page {
                 }
             }
 
+            #[cfg(feature = "xdg-portal")]
             Message::AddFolder(result) => {
                 let path = match dialog_response(result) {
                     DialogResponse::Path(path) => path,
@@ -883,6 +887,7 @@ impl Page {
                 }
             }
 
+            #[cfg(feature = "xdg-portal")]
             Message::AddFile(result) => {
                 let path = match dialog_response(result) {
                     DialogResponse::Path(path) => path,
@@ -1348,6 +1353,7 @@ enum DialogResponse {
     Path(PathBuf),
 }
 
+#[cfg(feature = "xdg-portal")]
 fn dialog_response(result: Arc<Result<Url, file_chooser::Error>>) -> DialogResponse {
     let Some(result) = Arc::into_inner(result) else {
         return DialogResponse::Error(String::from("Arc::into_inner returned None"));

--- a/cosmic-settings/src/pages/mod.rs
+++ b/cosmic-settings/src/pages/mod.rs
@@ -3,25 +3,35 @@
 
 use cosmic_settings_page::Entity;
 
+#[cfg(feature = "page-bluetooth")]
 pub mod bluetooth;
 pub mod desktop;
 pub mod display;
+#[cfg(feature = "page-input")]
 pub mod input;
+#[cfg(feature = "page-networking")]
 pub mod networking;
+#[cfg(feature = "page-power")]
 pub mod power;
+#[cfg(feature = "page-sound")]
 pub mod sound;
 pub mod system;
 pub mod time;
 
 #[derive(Clone, Debug)]
 pub enum Message {
+    #[cfg(feature = "page-about")]
     About(system::about::Message),
     Appearance(desktop::appearance::Message),
+    #[cfg(feature = "page-bluetooth")]
     Bluetooth(bluetooth::Message),
+    #[cfg(feature = "page-input")]
     CustomShortcuts(input::keyboard::shortcuts::custom::Message),
+    #[cfg(feature = "page-date")]
     DateAndTime(time::date::Message),
     Desktop(desktop::Message),
     DesktopWallpaper(desktop::wallpaper::Message),
+    #[cfg(feature = "page-workspaces")]
     DesktopWorkspaces(desktop::workspaces::Message),
     Displays(display::Message),
     #[cfg(feature = "wayland")]
@@ -32,25 +42,40 @@ pub enum Message {
         id: String,
         message: Vec<u8>,
     },
+    #[cfg(feature = "page-input")]
     Input(input::Message),
+    #[cfg(feature = "page-input")]
     Keyboard(input::keyboard::Message),
+    #[cfg(feature = "page-input")]
     KeyboardShortcuts(input::keyboard::shortcuts::Message),
+    #[cfg(feature = "page-input")]
     ManageWindowShortcuts(input::keyboard::shortcuts::ShortcutMessage),
+    #[cfg(feature = "page-input")]
     MoveWindowShortcuts(input::keyboard::shortcuts::ShortcutMessage),
+    #[cfg(feature = "page-input")]
     NavShortcuts(input::keyboard::shortcuts::ShortcutMessage),
+    #[cfg(feature = "page-networking")]
     Networking(networking::Message),
     Page(Entity),
     #[cfg(feature = "wayland")]
     Panel(desktop::panel::Message),
     #[cfg(feature = "wayland")]
     PanelApplet(desktop::panel::applets_inner::Message),
+    #[cfg(feature = "page-power")]
     Power(power::Message),
+    #[cfg(feature = "page-sound")]
     Sound(sound::Message),
+    #[cfg(feature = "page-input")]
     SystemShortcuts(input::keyboard::shortcuts::ShortcutMessage),
+    #[cfg(feature = "page-input")]
     TilingShortcuts(input::keyboard::shortcuts::ShortcutMessage),
+    #[cfg(feature = "page-networking")]
     Vpn(networking::vpn::Message),
+    #[cfg(feature = "page-networking")]
     WiFi(networking::wifi::Message),
+    #[cfg(feature = "page-window-management")]
     WindowManagement(desktop::window_management::Message),
+    #[cfg(feature = "page-networking")]
     Wired(networking::wired::Message),
 }
 

--- a/cosmic-settings/src/pages/system/mod.rs
+++ b/cosmic-settings/src/pages/system/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
+#[cfg(feature = "page-about")]
 pub mod about;
 pub mod firmware;
 pub mod users;
@@ -17,9 +18,15 @@ impl page::Page<crate::pages::Message> for Page {
 }
 
 impl page::AutoBind<crate::pages::Message> for Page {
-    fn sub_pages(page: page::Insert<crate::pages::Message>) -> page::Insert<crate::pages::Message> {
-        page.sub_page::<users::Page>()
-            .sub_page::<about::Page>()
-            .sub_page::<firmware::Page>()
+    fn sub_pages(
+        mut page: page::Insert<crate::pages::Message>,
+    ) -> page::Insert<crate::pages::Message> {
+        page = page.sub_page::<users::Page>();
+        #[cfg(feature = "page-about")]
+        {
+            page = page.sub_page::<about::Page>();
+        }
+        page = page.sub_page::<firmware::Page>();
+        page
     }
 }

--- a/cosmic-settings/src/pages/time/mod.rs
+++ b/cosmic-settings/src/pages/time/mod.rs
@@ -3,6 +3,7 @@
 
 use cosmic_settings_page as page;
 
+#[cfg(feature = "page-date")]
 pub mod date;
 pub mod region;
 
@@ -18,7 +19,14 @@ impl page::Page<crate::pages::Message> for Page {
 }
 
 impl page::AutoBind<crate::pages::Message> for Page {
-    fn sub_pages(page: page::Insert<crate::pages::Message>) -> page::Insert<crate::pages::Message> {
-        page.sub_page::<date::Page>().sub_page::<region::Page>()
+    fn sub_pages(
+        mut page: page::Insert<crate::pages::Message>,
+    ) -> page::Insert<crate::pages::Message> {
+        #[cfg(feature = "page-date")]
+        {
+            page = page.sub_page::<date::Page>();
+        }
+        page = page.sub_page::<region::Page>();
+        page
     }
 }

--- a/cosmic-settings/src/subscription/mod.rs
+++ b/cosmic-settings/src/subscription/mod.rs
@@ -1,5 +1,7 @@
 // TODO: Do not use subscriptions for pages.
 mod desktop_files;
 pub use desktop_files::*;
+#[cfg(feature = "ashpd")]
 mod daytime;
+#[cfg(feature = "ashpd")]
 pub use daytime::*;

--- a/pages/wallpapers/Cargo.toml
+++ b/pages/wallpapers/Cargo.toml
@@ -11,7 +11,8 @@ cosmic-config = { workspace = true }
 cosmic-randr-shell = { workspace = true }
 dirs = "5.0.1"
 eyre = "0.6.12"
-fast_image_resize = { version = "5.0.0", features = ["image"] }
+# Upstream version 5.0.0 has compilation error on Redox's toolchain
+fast_image_resize = { git = "https://github.com/jackpot51/fast_image_resize.git", features = ["image"] }
 freedesktop-icons = "0.2.6"
 futures-lite = "2.3.0"
 futures-util = "0.3.30"


### PR DESCRIPTION
This enables cosmic-settings to be built with minimal capabilities for other OS's (namely the appearance page).