### PR TITLE
feat: dynamically load pages when their sections are searched

### DIFF
--- a/cosmic-settings/src/pages/networking/vpn/mod.rs
+++ b/cosmic-settings/src/pages/networking/vpn/mod.rs
@@ -194,7 +194,6 @@ pub struct Page {
     dialog: Option<VpnDialog>,
     view_more_popup: Option<ConnectionId>,
     known_connections: IndexMap<UUID, ConnectionSettings>,
-    wireguard_connections: IndexMap<UUID, String>,
     /// Withhold device update if the view more popup is shown.
     withheld_devices: Option<Vec<network_manager::devices::DeviceInfo>>,
     /// Withhold active connections update if the view more popup is shown.


### PR DESCRIPTION
- Dynamically calls `on_enter` and `on_leave` as sections are displayed in search
- Updates a few pages to use the new abortable tasks feature in iced for their `on_enter` tasks