### PR TITLE
[Panel] Fix opacity slider styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -245,36 +245,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -318,7 +318,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -494,7 +494,7 @@ dependencies = [
  "futures-lite 2.3.0",
  "parking",
  "polling 3.7.3",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -544,7 +544,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "windows-sys 0.48.0",
 ]
 
@@ -563,7 +563,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.3.1",
  "futures-lite 2.3.0",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "tracing",
 ]
 
@@ -575,7 +575,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -590,7 +590,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -610,7 +610,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -624,7 +624,7 @@ name = "atomicwrites"
 version = "0.4.2"
 source = "git+https://github.com/jackpot51/rust-atomicwrites#043ab4859d53ffd3d55334685303d8df39c9f768"
 dependencies = [
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "tempfile",
  "windows-sys 0.48.0",
 ]
@@ -760,7 +760,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "syn_derive",
 ]
 
@@ -957,7 +957,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -997,7 +997,7 @@ dependencies = [
  "bitflags 2.6.0",
  "log",
  "polling 3.7.3",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "slab",
  "thiserror",
 ]
@@ -1009,7 +1009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "wayland-backend",
  "wayland-client",
 ]
@@ -1136,7 +1136,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1258,9 +1258,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colorgrad"
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "cosmic-comp-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-comp#0092dac08cff7af16c0fd90b9f11d0559163a135"
+source = "git+https://github.com/pop-os/cosmic-comp#eb64fdaf8fe4f5e6957a35e74004b183acc905c8"
 dependencies = [
  "cosmic-config",
  "input",
@@ -1472,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "cosmic-randr"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-randr#907471b6bc42151ef0ed80a6f595e82b85367dc4"
+source = "git+https://github.com/pop-os/cosmic-randr#8d0938029f223016fde11aef4c5233ddbfdb2796"
 dependencies = [
  "cosmic-protocols",
  "futures-lite 2.3.0",
@@ -1562,7 +1562,7 @@ dependencies = [
 [[package]]
 name = "cosmic-randr-shell"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-randr#907471b6bc42151ef0ed80a6f595e82b85367dc4"
+source = "git+https://github.com/pop-os/cosmic-randr#8d0938029f223016fde11aef4c5233ddbfdb2796"
 dependencies = [
  "kdl",
  "slotmap",
@@ -1684,7 +1684,7 @@ dependencies = [
  "libpulse-binding",
  "log",
  "pipewire",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "secure-string",
  "thiserror",
  "tokio",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1918,7 +1918,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1940,7 +1940,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2024,7 +2024,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2082,7 +2082,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2145,7 +2145,7 @@ dependencies = [
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
- "rustix 0.38.37",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -2155,7 +2155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41334f8405792483e32ad05fbb9c5680ff4e84491883d2947a4757dc54cb2ac6"
 dependencies = [
  "drm-sys",
- "rustix 0.38.37",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2532,7 +2532,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2689,7 +2689,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3067,7 +3067,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.82",
+ "syn 2.0.85",
  "unic-langid",
 ]
 
@@ -3081,7 +3081,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3128,7 +3128,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3137,7 +3137,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "futures",
  "iced_core",
@@ -3188,7 +3188,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3222,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "bytes",
  "dnd",
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -3270,7 +3270,7 @@ dependencies = [
  "raw-window-handle",
  "resvg",
  "rustc-hash 2.0.0",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "smithay-client-toolkit",
  "thiserror",
  "tiny-xlib",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3304,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3677,7 +3677,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3904,7 +3904,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4276,7 +4276,7 @@ checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#795654610a2875fe4316add18df6f33a4bc86af1"
+source = "git+https://github.com/pop-os/libcosmic#fde0516484750e0a7d2499e54964c5ed6ba8e16b"
 dependencies = [
  "apply",
  "ashpd 0.9.2",
@@ -4338,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "3bda4c6077b0b08da2c48b172195795498381a7c8988c9e6212a6c55c5b9bd70"
 
 [[package]]
 name = "libpulse-binding"
@@ -4661,7 +4661,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4941,7 +4941,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5013,7 +5013,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5320,7 +5320,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5366,7 +5366,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5465,7 +5465,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5485,29 +5485,29 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -5599,7 +5599,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5692,7 +5692,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5712,7 +5712,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "version_check",
  "yansi",
 ]
@@ -5727,7 +5727,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "procfs-core",
- "rustix 0.38.37",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -5756,7 +5756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5985,9 +5985,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6166,7 +6166,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.82",
+ "syn 2.0.85",
  "walkdir",
 ]
 
@@ -6240,9 +6240,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -6374,7 +6374,7 @@ checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6398,7 +6398,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6437,7 +6437,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6577,7 +6577,7 @@ dependencies = [
  "log",
  "memmap2 0.9.5",
  "pkg-config",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "thiserror",
  "wayland-backend",
  "wayland-client",
@@ -6649,7 +6649,7 @@ dependencies = [
  "objc",
  "raw-window-handle",
  "redox_syscall 0.4.1",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "tiny-xlib",
  "wasm-bindgen",
  "wayland-backend",
@@ -6788,9 +6788,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6806,7 +6806,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6817,7 +6817,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6840,7 +6840,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows 0.54.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -6907,7 +6907,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "windows-sys 0.59.0",
 ]
 
@@ -6943,7 +6943,7 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7105,7 +7105,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7192,7 +7192,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -7424,9 +7424,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "ustr"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e904a2279a4a36d2356425bb20be271029cc650c335bc82af8bfae30085a3d0"
+checksum = "18b19e258aa08450f93369cf56dd78063586adf19e92a75b338a800f799a0208"
 dependencies = [
  "ahash 0.8.11",
  "byteorder",
@@ -7565,7 +7565,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -7599,7 +7599,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7633,7 +7633,7 @@ checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -7641,12 +7641,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f45d1222915ef1fd2057220c1d9d9624b7654443ea35c3877f7a52bd0a5a2d"
+checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
 dependencies = [
  "bitflags 2.6.0",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -7664,20 +7664,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a94697e66e76c85923b0d28a0c251e8f0666f58fc47d316c0f4da6da75d37cb"
+checksum = "32b08bc3aafdb0035e7fe0fdf17ba0c09c268732707dca4ae098f60cb28c9e4c"
 dependencies = [
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5755d77ae9040bb872a25026555ce4cb0ae75fd923e90d25fba07d81057de0"
+checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -7688,9 +7688,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0a41a6875e585172495f7a96dfa42ca7e0213868f4f15c313f7c33221a7eff"
+checksum = "9b31cab548ee68c7eb155517f2212049dc151f7cd7910c2b66abfd31c3ee12bd"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -7701,9 +7701,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad87b5fd1b1d3ca2f792df8f686a2a11e3fe1077b71096f7a175ab699f89109"
+checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -7726,14 +7726,14 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f18d47038c0b10479e695d99ed073e400ccd9bdbb60e6e503c96f62adcb12b6"
+checksum = "c89532cc712a2adb119eb4d09694b402576052254d0bb284f82ac1c47fb786ad"
 dependencies = [
  "bitflags 2.6.0",
  "downcast-rs",
  "io-lifetimes 2.0.3",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -7960,8 +7960,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core 0.54.0",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.53.0",
+ "windows-interface 0.53.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -7985,6 +7995,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-implement"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7992,7 +8014,18 @@ checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8003,7 +8036,18 @@ checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8260,7 +8304,7 @@ dependencies = [
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
@@ -8344,7 +8388,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "x11rb-protocol",
 ]
 
@@ -8481,7 +8525,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "synstructure",
 ]
 
@@ -8583,7 +8627,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "zvariant_utils 2.1.0",
 ]
 
@@ -8633,7 +8677,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8653,7 +8697,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "synstructure",
 ]
 
@@ -8693,7 +8737,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -8770,7 +8814,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "zvariant_utils 2.1.0",
 ]
 
@@ -8793,5 +8837,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]

--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -1,7 +1,7 @@
 use cosmic::{
     cctk::sctk::reexports::client::{backend::ObjectId, protocol::wl_output::WlOutput, Proxy},
     cosmic_config::{self, CosmicConfigEntry},
-    iced::Length,
+    iced::{Alignment, Length},
     theme,
     widget::{
         button, container, dropdown, horizontal_space, icon, row, settings, slider, text, toggler,
@@ -223,26 +223,31 @@ pub(crate) fn style<
                         .into(),
                         text::body(fl!("large")).into(),
                     ])
-                    .spacing(12),
+                    .align_y(Alignment::Center)
+                    .spacing(8),
                 ))
                 .add(settings::flex_item(
                     &descriptions[background_opacity],
-                    row::with_capacity(3)
-                        .push(text::body(fl!(
-                            "number",
-                            HashMap::from_iter(vec![("number", 0)])
-                        )))
+                    row::with_capacity(2)
+                        .align_y(Alignment::Center)
+                        .spacing(8)
+                        .push(
+                            text::body(fl!(
+                                "number",
+                                HashMap::from_iter(vec![(
+                                    "number",
+                                    (panel_config.opacity * 100.0) as i32
+                                )])
+                            ))
+                            .width(Length::Fixed(22.0))
+                            .align_x(Alignment::Center),
+                        )
                         .push(
                             slider(0..=100, (panel_config.opacity * 100.0) as i32, |v| {
                                 Message::OpacityRequest(v as f32 / 100.0)
                             })
                             .breakpoints(&[50]),
-                        )
-                        .push(text::body(fl!(
-                            "number",
-                            HashMap::from_iter(vec![("number", 100)])
-                        )))
-                        .spacing(12),
+                        ),
                 ))
                 .apply(Element::from)
                 .map(msg_map)

--- a/cosmic-settings/src/pages/input/mouse.rs
+++ b/cosmic-settings/src/pages/input/mouse.rs
@@ -51,7 +51,6 @@ fn mouse() -> Section<crate::pages::Message> {
         .view::<Page>(move |binder, _page, section| {
             let descriptions = &section.descriptions;
             let input = binder.page::<super::Page>().expect("input page not found");
-            let theme = cosmic::theme::active();
 
             settings::section()
                 .title(&section.title)
@@ -81,8 +80,12 @@ fn mouse() -> Section<crate::pages::Message> {
 
                         row::with_capacity(2)
                             .align_y(Alignment::Center)
-                            .spacing(theme.cosmic().space_s())
-                            .push(text::body(format!("{:.0}", value.round())))
+                            .spacing(8)
+                            .push(
+                                text::body(format!("{:.0}", value.round()))
+                                    .width(Length::Fixed(22.0))
+                                    .align_x(Alignment::Center),
+                            )
                             .push(slider)
                     }),
                 )
@@ -116,7 +119,6 @@ fn scrolling() -> Section<crate::pages::Message> {
         .view::<Page>(move |binder, _page, section| {
             let descriptions = &section.descriptions;
             let input = binder.page::<super::Page>().expect("input page not found");
-            let theme = cosmic::theme::active();
 
             settings::section()
                 .title(&section.title)
@@ -141,8 +143,12 @@ fn scrolling() -> Section<crate::pages::Message> {
 
                     row::with_capacity(2)
                         .align_y(Alignment::Center)
-                        .spacing(theme.cosmic().space_s())
-                        .push(text::body(format!("{:.0}", value.round())))
+                        .spacing(8)
+                        .push(
+                            text::body(format!("{:.0}", value.round()))
+                                .width(Length::Fixed(22.0))
+                                .align_x(Alignment::Center),
+                        )
                         .push(slider)
                 }))
                 .add(

--- a/cosmic-settings/src/pages/input/touchpad.rs
+++ b/cosmic-settings/src/pages/input/touchpad.rs
@@ -69,7 +69,6 @@ fn touchpad() -> Section<crate::pages::Message> {
         .view::<Page>(move |binder, _page, section| {
             let descriptions = &section.descriptions;
             let input = binder.page::<super::Page>().expect("input page not found");
-            let theme = cosmic::theme::active();
 
             settings::section()
                 .title(&section.title)
@@ -104,8 +103,12 @@ fn touchpad() -> Section<crate::pages::Message> {
 
                         row::with_capacity(2)
                             .align_y(Alignment::Center)
-                            .spacing(theme.cosmic().space_s())
-                            .push(text::body(format!("{:.0}", value.round())))
+                            .spacing(8)
+                            .push(
+                                text::body(format!("{:.0}", value.round()))
+                                    .width(Length::Fixed(22.0))
+                                    .align_x(Alignment::Center),
+                            )
                             .push(slider)
                     }),
                 )
@@ -200,7 +203,6 @@ fn scrolling() -> Section<crate::pages::Message> {
             let page = binder
                 .page::<super::Page>()
                 .expect("input devices page not found");
-            let theme = cosmic::theme::active();
 
             settings::section()
                 .title(&section.title)
@@ -250,8 +252,12 @@ fn scrolling() -> Section<crate::pages::Message> {
 
                     row::with_capacity(2)
                         .align_y(Alignment::Center)
-                        .spacing(theme.cosmic().space_s())
-                        .push(text::body(format!("{:.0}", value.round())))
+                        .spacing(8)
+                        .push(
+                            text::body(format!("{:.0}", value.round()))
+                                .width(Length::Fixed(22.0))
+                                .align_x(Alignment::Center),
+                        )
                         .push(slider)
                 }))
                 // Natural scrolling toggle

--- a/cosmic-settings/src/pages/sound.rs
+++ b/cosmic-settings/src/pages/sound.rs
@@ -4,6 +4,7 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use cosmic::{
+    iced::{Alignment, Length},
     widget::{self, settings},
     Element, Task,
 };
@@ -608,9 +609,8 @@ fn input() -> Section<crate::pages::Message> {
         .title(fl!("sound-input"))
         .descriptions(descriptions)
         .view::<Page>(move |_binder, page, section| {
-            let volume_control = widget::row::with_capacity(3)
-                .align_y(cosmic::iced::Alignment::Center)
-                .spacing(4)
+            let volume_control = widget::row::with_capacity(4)
+                .align_y(Alignment::Center)
                 .push(
                     widget::button::icon(widget::icon::from_name(if page.source_mute {
                         "microphone-sensitivity-muted-symbolic"
@@ -619,7 +619,12 @@ fn input() -> Section<crate::pages::Message> {
                     }))
                     .on_press(Message::SourceMuteToggle),
                 )
-                .push(widget::text::body(&page.source_volume_text))
+                .push(
+                    widget::text::body(&page.source_volume_text)
+                        .width(Length::Fixed(22.0))
+                        .align_x(Alignment::Center),
+                )
+                .push(widget::horizontal_space().width(8))
                 .push(
                     widget::slider(0..=150, page.source_volume, Message::SourceVolumeChanged)
                         .breakpoints(&[100]),
@@ -666,9 +671,8 @@ fn output() -> Section<crate::pages::Message> {
         .title(fl!("sound-output"))
         .descriptions(descriptions)
         .view::<Page>(move |_binder, page, section| {
-            let volume_control = widget::row::with_capacity(3)
-                .align_y(cosmic::iced::Alignment::Center)
-                .spacing(4)
+            let volume_control = widget::row::with_capacity(4)
+                .align_y(Alignment::Center)
                 .push(
                     widget::button::icon(if page.sink_mute {
                         widget::icon::from_name("audio-volume-muted-symbolic")
@@ -677,7 +681,12 @@ fn output() -> Section<crate::pages::Message> {
                     })
                     .on_press(Message::SinkMuteToggle),
                 )
-                .push(widget::text::body(&page.sink_volume_text))
+                .push(
+                    widget::text::body(&page.sink_volume_text)
+                        .width(Length::Fixed(22.0))
+                        .align_x(Alignment::Center),
+                )
+                .push(widget::horizontal_space().width(8))
                 .push(
                     widget::slider(0..=150, page.sink_volume, Message::SinkVolumeChanged)
                         .breakpoints(&[100]),


### PR DESCRIPTION
Makes the panel opacity slider show the current opacity, to match designs.
![screenshot-2024-10-27-19-26-31](https://github.com/user-attachments/assets/c2516d3f-7fdc-4786-8be7-3d31eb12cd00)

I fixed the spacing of rows with sliders, since spacing variables don't seem to be used there in the designs.
The sound page is a bit different, since there shouldn't be any spacing between the icon and number, but 8 spacing between the number and slider, so I put a `horizontal_space()` there.