### PR TITLE
[Power] Only show suspend on battery power if the system has a battery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3138,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -3172,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "futures",
  "iced_core",
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -3220,7 +3220,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "bytes",
  "dnd",
@@ -3248,7 +3248,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3264,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -3295,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -4286,7 +4286,7 @@ checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#842cd2ec9418e64911c60588fe70a1ce9c45a1b7"
+source = "git+https://github.com/pop-os/libcosmic#4b562867eccb65895953023a19393fa293aafb4b"
 dependencies = [
  "apply",
  "ashpd 0.9.2",

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -462,10 +462,11 @@ power-mode = Power Mode
     .performance-desc = Peak performance and power usage.
     .no-backend = Backend not found. Install system76-power or power-profiles-daemon.
 
-power-saving = Power Savings Options
+power-saving = Power Saving Options
     .turn-off-screen-after = Turn off the screen after
+    .auto-suspend = Automatic suspend
     .auto-suspend-ac = Automatic suspend when plugged in
-    .auto-suspend-battery = Automatic on battery power
+    .auto-suspend-battery = Automatic suspend on battery power
 
 ## Input
 


### PR DESCRIPTION
This is a minor improvement to not show a non-applicable option on e.g. desktops.
I assumed that suspend on AC works the same on laptops and desktops, so I just added a separate fluent key to not mention "plugged in" on systems without a battery (since that's the only state they can be in).

Also fixed a minor text mismatch between the designs and implementation.