### PR TITLE
fix: condensed padding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -760,7 +760,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "syn_derive",
 ]
 
@@ -957,7 +957,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1003,12 +1003,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "calloop"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ead1e1514bce44c0f40e027899fbc595907fc112635bed21b3b5d975c0a5e7"
+dependencies = [
+ "bitflags 2.6.0",
+ "polling 3.7.3",
+ "rustix 0.38.38",
+ "slab",
+ "tracing",
+]
+
+[[package]]
 name = "calloop-wayland-source"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop",
+ "calloop 0.13.0",
+ "rustix 0.38.38",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a7a1dbbe026a55ef47a500b123af5a9a0914520f061d467914cf21be95daf"
+dependencies = [
+ "calloop 0.14.1",
  "rustix 0.38.38",
  "wayland-backend",
  "wayland-client",
@@ -1136,7 +1161,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1455,14 +1480,14 @@ source = "git+https://github.com/pop-os/cosmic-protocols?rev=c8d3a1c#c8d3a1c3d40
 dependencies = [
  "cosmic-protocols",
  "libc",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client",
 ]
 
 [[package]]
 name = "cosmic-comp-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-comp#eb64fdaf8fe4f5e6957a35e74004b183acc905c8"
+source = "git+https://github.com/pop-os/cosmic-comp#90883c6ab12533da08a31da338881c38aa773634"
 dependencies = [
  "cosmic-config",
  "input",
@@ -1517,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "cosmic-idle-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-idle#f682e19f2105f7bb4b722b858bf747dcb60be2c0"
+source = "git+https://github.com/pop-os/cosmic-idle#08c1cf318e91831b6cbfd2c94d2fafbedb90919f"
 dependencies = [
  "cosmic-config",
  "serde",
@@ -1526,13 +1551,13 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#041a44eb6f825b7e0b3d45ccf745252b136d5da9"
+source = "git+https://github.com/pop-os/cosmic-panel#d114bd9c84ca6dec44fee6297d822ecde41ea403"
 dependencies = [
  "anyhow",
  "cosmic-config",
  "ron",
  "serde",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (git+https://github.com/Smithay/client-toolkit)",
  "tracing",
  "wayland-protocols-wlr",
  "xdg-shell-wrapper-config",
@@ -1928,7 +1953,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1950,7 +1975,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2034,7 +2059,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2092,7 +2117,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2121,7 +2146,7 @@ dependencies = [
  "bitflags 2.6.0",
  "mime",
  "raw-window-handle",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smithay-clipboard",
 ]
 
@@ -2214,7 +2239,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2298,15 +2323,14 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.72.0"
+version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4"
+checksum = "f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0"
 dependencies = [
  "bit_field",
- "flume",
  "half",
  "lebe",
- "miniz_oxide 0.7.4",
+ "miniz_oxide 0.8.0",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -2464,15 +2488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,7 +2557,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2699,7 +2714,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -3077,7 +3092,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.85",
+ "syn 2.0.86",
  "unic-langid",
 ]
 
@@ -3091,7 +3106,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -3162,7 +3177,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 2.0.0",
  "serde",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smol_str",
  "thiserror",
  "web-time",
@@ -3240,7 +3255,7 @@ dependencies = [
  "iced_core",
  "iced_futures",
  "raw-window-handle",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "window_clipboard",
 ]
@@ -3281,7 +3296,7 @@ dependencies = [
  "resvg",
  "rustc-hash 2.0.0",
  "rustix 0.38.38",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tiny-xlib",
  "wayland-backend",
@@ -3305,7 +3320,7 @@ dependencies = [
  "once_cell",
  "ouroboros",
  "rustc-hash 2.0.0",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "unicode-segmentation",
  "window_clipboard",
@@ -3324,7 +3339,7 @@ dependencies = [
  "log",
  "raw-window-handle",
  "rustc-hash 2.0.0",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tracing",
  "wasm-bindgen-futures",
@@ -3687,7 +3702,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -3914,7 +3929,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -4671,7 +4686,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -4951,7 +4966,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -5023,7 +5038,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -5330,7 +5345,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -5376,7 +5391,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -5475,7 +5490,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -5510,7 +5525,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -5702,7 +5717,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -5722,7 +5737,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "version_check",
  "yansi",
 ]
@@ -5766,7 +5781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -6176,7 +6191,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.85",
+ "syn 2.0.86",
  "walkdir",
 ]
 
@@ -6320,7 +6335,7 @@ dependencies = [
  "ab_glyph",
  "log",
  "memmap2 0.9.5",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-skia",
 ]
 
@@ -6384,7 +6399,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -6408,7 +6423,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -6447,7 +6462,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -6580,8 +6595,35 @@ checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
- "calloop",
- "calloop-wayland-source",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2 0.9.5",
+ "pkg-config",
+ "rustix 0.38.38",
+ "thiserror",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkbcommon",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "git+https://github.com/Smithay/client-toolkit#618a876400cb6c6b07a8ac5d3557f404602ec077"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytemuck",
+ "calloop 0.14.1",
+ "calloop-wayland-source 0.4.0",
  "cursor-icon",
  "libc",
  "log",
@@ -6607,7 +6649,7 @@ source = "git+https://github.com/pop-os/smithay-clipboard?tag=pop-dnd-5#5a3007de
 dependencies = [
  "libc",
  "raw-window-handle",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
 ]
 
@@ -6668,15 +6710,6 @@ dependencies = [
  "web-sys",
  "windows-sys 0.52.0",
  "x11rb",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]
@@ -6798,9 +6831,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6816,7 +6849,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -6827,7 +6860,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -6938,22 +6971,22 @@ checksum = "7f1835c76a9d443834c04539860f3ce46b9d93ef8c260057f939e967ca81180a"
 
 [[package]]
 name = "thiserror"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -7115,7 +7148,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -7189,6 +7222,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7202,7 +7236,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -7575,7 +7609,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "wasm-bindgen-shared",
 ]
 
@@ -7609,7 +7643,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8024,7 +8058,7 @@ checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -8035,7 +8069,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -8046,7 +8080,7 @@ checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -8057,7 +8091,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -8294,7 +8328,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block2",
  "bytemuck",
- "calloop",
+ "calloop 0.13.0",
  "cfg_aliases 0.2.1",
  "concurrent-queue",
  "core-foundation",
@@ -8316,7 +8350,7 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix 0.38.38",
  "sctk-adwaita",
- "smithay-client-toolkit",
+ "smithay-client-toolkit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smol_str",
  "tracing",
  "unicode-segmentation",
@@ -8433,7 +8467,7 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#041a44eb6f825b7e0b3d45ccf745252b136d5da9"
+source = "git+https://github.com/pop-os/cosmic-panel#d114bd9c84ca6dec44fee6297d822ecde41ea403"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",
@@ -8535,7 +8569,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "synstructure",
 ]
 
@@ -8637,7 +8671,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "zvariant_utils 2.1.0",
 ]
 
@@ -8687,7 +8721,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -8707,7 +8741,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "synstructure",
 ]
 
@@ -8747,7 +8781,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -8824,7 +8858,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "zvariant_utils 2.1.0",
 ]
 
@@ -8847,5 +8881,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -1082,7 +1082,7 @@ impl SettingsApp {
         let theme = cosmic::theme::active();
 
         let padding = if self.core.is_condensed() {
-            theme.cosmic().space_xxs()
+            theme.cosmic().space_s()
         } else {
             theme.cosmic().space_l()
         };

--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use cosmic::iced::{alignment, color, Length};
+use cosmic::iced::{color, Alignment, Length};
 use cosmic::iced_core::text::Wrapping;
 use cosmic::widget::{self, settings, text};
 use cosmic::Task;
@@ -121,7 +121,7 @@ impl page::Page<crate::pages::Message> for Page {
 
                 let pin = widget::text::title1(itoa::Buffer::new().format(*passkey).to_owned())
                     .width(Length::Fill)
-                    .align_x(alignment::Horizontal::Center)
+                    .align_x(Alignment::Center)
                     .wrapping(Wrapping::None);
 
                 let control = widget::column::with_capacity(2)
@@ -641,7 +641,7 @@ fn popup_button(message: Option<Message>, text: &str) -> Element<'_, Message> {
     let theme = cosmic::theme::active();
     let theme = theme.cosmic();
     widget::text::body(text)
-        .align_y(alignment::Vertical::Center)
+        .align_y(Alignment::Center)
         .apply(widget::button::custom)
         .padding([theme.space_xxxs(), theme.space_xs()])
         .width(Length::Fill)

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -17,7 +17,7 @@ use cosmic::cosmic_theme::{
     CornerRadii, Density, Spacing, Theme, ThemeBuilder, ThemeMode, DARK_THEME_BUILDER_ID,
     LIGHT_THEME_BUILDER_ID,
 };
-use cosmic::iced_core::{alignment, Color, Length};
+use cosmic::iced_core::{Alignment, Color, Length};
 use cosmic::iced_widget::scrollable::{Direction, Scrollbar};
 use cosmic::widget::icon::{from_name, icon};
 use cosmic::widget::{
@@ -1431,7 +1431,7 @@ impl page::Page<crate::pages::Message> for Page {
             .push(button::standard(fl!("export")).on_press(Message::StartExport))
             .apply(container)
             .width(Length::Fill)
-            .align_x(alignment::Horizontal::Right)
+            .align_x(Alignment::End)
             .apply(Element::from)
             .map(crate::pages::Message::Appearance);
 
@@ -1609,7 +1609,7 @@ pub fn mode_and_colors() -> Section<crate::pages::Message> {
                             ]
                             .spacing(space_xxs)
                             .width(Length::FillPortion(1))
-                            .align_x(cosmic::iced_core::Alignment::Center),
+                            .align_x(Alignment::Center),
                             cosmic::iced::widget::column![
                                 button::custom(
                                     icon(light_mode_illustration.clone(),)
@@ -1624,14 +1624,13 @@ pub fn mode_and_colors() -> Section<crate::pages::Message> {
                             ]
                             .spacing(space_xxs)
                             .width(Length::FillPortion(1))
-                            .align_x(cosmic::iced_core::Alignment::Center)
+                            .align_x(Alignment::Center)
                         ]
                         .spacing(48)
-                        .align_y(cosmic::iced_core::Alignment::Center)
+                        .align_y(Alignment::Center)
                         .width(Length::Fixed(424.0)),
                     )
-                    .width(Length::Fill)
-                    .align_x(cosmic::iced_core::alignment::Horizontal::Center),
+                    .center_x(Length::Fill),
                 )
                 .add(
                     settings::item::builder(&descriptions[auto_switch])
@@ -1864,7 +1863,7 @@ pub fn style() -> Section<crate::pages::Message> {
                             ]
                             .spacing(8)
                             .width(Length::FillPortion(1))
-                            .align_x(cosmic::iced_core::Alignment::Center),
+                            .align_x(Alignment::Center),
                             cosmic::iced::widget::column![
                                 button::custom(
                                     icon(
@@ -1886,7 +1885,7 @@ pub fn style() -> Section<crate::pages::Message> {
                             ]
                             .spacing(8)
                             .width(Length::FillPortion(1))
-                            .align_x(cosmic::iced_core::Alignment::Center),
+                            .align_x(Alignment::Center),
                             cosmic::iced::widget::column![
                                 button::custom(
                                     icon(
@@ -1908,15 +1907,14 @@ pub fn style() -> Section<crate::pages::Message> {
                                 text::body(&descriptions[square])
                             ]
                             .spacing(8)
-                            .align_x(cosmic::iced_core::Alignment::Center)
+                            .align_x(Alignment::Center)
                             .width(Length::FillPortion(1))
                         ]
                         .spacing(12)
                         .width(Length::Fixed(628.0))
-                        .align_y(cosmic::iced_core::Alignment::Center),
+                        .align_y(Alignment::Center),
                     )
-                    .width(Length::Fill)
-                    .align_x(cosmic::iced_core::alignment::Horizontal::Center),
+                    .center_x(Length::Fill),
                 )
                 .apply(Element::from)
                 .map(crate::pages::Message::Appearance)

--- a/cosmic-settings/src/pages/desktop/dock/applets.rs
+++ b/cosmic-settings/src/pages/desktop/dock/applets.rs
@@ -1,6 +1,6 @@
 use cosmic::{
     cosmic_config::CosmicConfigEntry,
-    iced::{alignment, Length},
+    iced::{Alignment, Length},
     widget::{button, container, row},
     Apply, Element, Task,
 };
@@ -82,17 +82,16 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn header_view(&self) -> Option<Element<'_, crate::pages::Message>> {
-        let theme = cosmic::theme::active();
-        let spacing = theme.cosmic().spacing;
+        let space_xxs = cosmic::theme::active().cosmic().spacing.space_xxs;
         let content = row::with_capacity(2)
-            .spacing(spacing.space_xxs)
+            .spacing(space_xxs)
             .push(
                 button::standard(fl!("add-applet"))
                     .on_press(Message(applets_inner::Message::AddAppletDrawer)),
             )
             .apply(container)
             .width(Length::Fill)
-            .align_x(alignment::Horizontal::Right)
+            .align_x(Alignment::End)
             .apply(Element::from)
             .map(crate::pages::Message::DockApplet);
 

--- a/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
@@ -4,7 +4,7 @@ use cosmic::iced::clipboard::dnd::{
 };
 use cosmic::iced::clipboard::mime::AsMimeTypes;
 use cosmic::iced::id::Internal;
-use cosmic::iced::{alignment, Vector};
+use cosmic::iced::Vector;
 
 use cosmic::iced_core;
 use cosmic::widget::{button, column, container, icon, list_column, row, text, text_input, Column};
@@ -12,9 +12,8 @@ use cosmic::widget::{button, column, container, icon, list_column, row, text, te
 use cosmic::{
     cosmic_config::{Config, CosmicConfigEntry},
     iced::{
-        alignment::{Horizontal, Vertical},
-        core::window,
-        event, mouse, overlay, touch, Alignment, Color, Length, Point, Rectangle, Size,
+        core::window, event, mouse, overlay, touch, Alignment, Color, Length, Point, Rectangle,
+        Size,
     },
     iced_runtime::{core::id::Id, Task},
     iced_widget::core::{
@@ -120,14 +119,13 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn header_view(&self) -> Option<Element<'_, crate::pages::Message>> {
-        let theme = cosmic::theme::active();
-        let spacing = theme.cosmic().spacing;
+        let space_xxs = theme::active().cosmic().spacing.space_xxs;
         let content = row::with_capacity(2)
-            .spacing(spacing.space_xxs)
+            .spacing(space_xxs)
             .push(button::standard(fl!("add-applet")).on_press(Message::AddAppletDrawer))
             .apply(container)
             .width(Length::Fill)
-            .align_x(alignment::Horizontal::Right)
+            .align_x(Alignment::End)
             .apply(Element::from)
             .map(crate::pages::Message::PanelApplet);
 
@@ -226,7 +224,13 @@ impl Page {
         &self,
         msg_map: T,
     ) -> Element<crate::pages::Message> {
-        let spacing = cosmic::theme::active().cosmic().spacing;
+        let cosmic::cosmic_theme::Spacing {
+            space_xxxs,
+            space_xxs,
+            space_xs,
+            space_l,
+            ..
+        } = theme::active().cosmic().spacing;
         let mut list_column = list_column();
         let mut has_some = false;
         for info in self
@@ -259,7 +263,7 @@ impl Page {
                     column::with_capacity(2)
                         .push(text::body(info.name.clone()))
                         .push(text::caption(info.description.clone()))
-                        .spacing(spacing.space_xxxs)
+                        .spacing(space_xxxs)
                         .width(Length::Fill)
                         .into(),
                     button::standard(fl!("add"))
@@ -291,8 +295,8 @@ impl Page {
                         .on_press(msg_map(Message::AddApplet(info.clone())))
                         .into(),
                 ])
-                .padding([0, spacing.space_l])
-                .spacing(spacing.space_xs)
+                .padding([0, space_l])
+                .spacing(space_xs)
                 .align_y(Alignment::Center),
             );
         }
@@ -300,7 +304,7 @@ impl Page {
             list_column = list_column.add(
                 text::body(fl!("no-applets-found"))
                     .width(Length::Fill)
-                    .align_x(Horizontal::Center),
+                    .align_x(Alignment::Center),
             );
         }
 
@@ -313,7 +317,7 @@ impl Page {
             list_column.into(),
         ])
         .align_x(Alignment::Center)
-        .spacing(spacing.space_xxs)
+        .spacing(space_xxs)
         .into()
     }
 
@@ -456,7 +460,12 @@ pub fn lists<
     msg_map: T,
 ) -> Section<crate::pages::Message> {
     Section::default().view::<P>(move |_binder, page, _section| {
-        let spacing = cosmic::theme::active().cosmic().spacing;
+        let cosmic::cosmic_theme::Spacing {
+            space_xxs,
+            space_xs,
+            space_s,
+            ..
+        } = theme::active().cosmic().spacing;
         let page = page.inner();
         let Some(config) = page.current_config.as_ref() else {
             return Element::from(text::body(fl!("unknown")));
@@ -492,7 +501,7 @@ pub fn lists<
                 )
                 .into(),
             ])
-            .spacing(spacing.space_xxs)
+            .spacing(space_xxs)
             .into(),
             column::with_children(vec![
                 text::body(fl!("center-segment")).into(),
@@ -522,7 +531,7 @@ pub fn lists<
                 )
                 .into(),
             ])
-            .spacing(spacing.space_xxs)
+            .spacing(space_xxs)
             .into(),
             column::with_children(vec![
                 text::body(fl!("end-segment")).into(),
@@ -553,11 +562,11 @@ pub fn lists<
                 )
                 .into(),
             ])
-            .spacing(spacing.space_xxs)
+            .spacing(space_xxs)
             .into(),
         ])
-        .padding([0, spacing.space_s])
-        .spacing(spacing.space_xs)
+        .padding([0, space_s])
+        .spacing(space_xs)
         .apply(Element::from)
         .map(msg_map)
     })
@@ -651,7 +660,12 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
         on_cancel: Message,
         active_dnd: Option<Applet<'a>>,
     ) -> Self {
-        let spacing = cosmic::theme::active().cosmic().spacing;
+        let cosmic::cosmic_theme::Spacing {
+            space_xxxs,
+            space_xxs,
+            space_xs,
+            ..
+        } = theme::active().cosmic().spacing;
         let applet_buttons = info
             .clone()
             .into_iter()
@@ -666,7 +680,7 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
                             .into(),
                         icon::from_name(info.icon).size(32).into(),
                         column::with_capacity(2)
-                            .spacing(spacing.space_xxxs)
+                            .spacing(space_xxxs)
                             .width(Length::Fill)
                             .push(text::body(info.name))
                             .push_maybe(if info.description.is_empty() {
@@ -680,7 +694,7 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
                             .on_press(on_remove(id_clone.clone()))
                             .into(),
                     ])
-                    .spacing(spacing.space_xs)
+                    .spacing(space_xs)
                     .align_y(Alignment::Center),
                 )
                 .width(Length::Fill)
@@ -711,8 +725,8 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
                     text::body(fl!("drop-here"))
                         .width(Length::Fill)
                         .height(Length::Fill)
-                        .align_y(Vertical::Center)
-                        .align_x(Horizontal::Center),
+                        .align_y(Alignment::Center)
+                        .align_x(Alignment::Center),
                 )
                 .width(Length::Fill)
                 .height(Length::Fixed(48.0))
@@ -728,7 +742,7 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
                 .into()
             } else {
                 Column::with_children(applet_buttons)
-                    .spacing(spacing.space_xxs)
+                    .spacing(space_xxs)
                     .into()
             },
             active_applet_offer: active_dnd,
@@ -746,7 +760,7 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
         pos: Point,
         offered_applet: Applet<'a>,
     ) -> Vec<Applet<'a>> {
-        let spacing = cosmic::theme::active().cosmic().spacing;
+        let space_xxs = theme::active().cosmic().spacing.space_xxs;
         let mut reordered: Vec<_> = self.info.clone();
 
         if !layout.bounds().contains(pos) {
@@ -767,8 +781,7 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
             return reordered;
         }
 
-        let height = (layout.bounds().height
-            - spacing.space_xxs as f32 * (self.info.len() - 1) as f32)
+        let height = (layout.bounds().height - space_xxs as f32 * (self.info.len() - 1) as f32)
             / self.info.len() as f32;
 
         let mut found = false;
@@ -778,7 +791,7 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
             if i == 0 || i == reordered.len() {
                 y += height / 2.0;
             } else {
-                y += height + spacing.space_xxs as f32;
+                y += height + space_xxs as f32;
             }
             if pos.y <= y {
                 reordered.insert(i, offered_applet.clone());
@@ -926,7 +939,7 @@ where
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
     ) -> event::Status {
-        let spacing = cosmic::theme::active().cosmic().spacing;
+        let space_xxs = theme::active().cosmic().spacing.space_xxs;
         let mut ret = match self.inner.as_widget_mut().on_event(
             &mut tree.children[0],
             event.clone(),
@@ -942,7 +955,7 @@ where
         };
 
         let height = (layout.bounds().height
-            - spacing.space_xxs as f32 * (self.info.len().saturating_sub(1)) as f32)
+            - space_xxs as f32 * (self.info.len().saturating_sub(1)) as f32)
             / self.info.len() as f32;
         let state = tree.state.downcast_mut::<ReorderWidgetState>();
 
@@ -995,8 +1008,7 @@ where
                                     self.info.iter().enumerate().find(|(i, _)| {
                                         start.y
                                             < layout.bounds().y
-                                                + (*i + 1) as f32
-                                                    * (height + spacing.space_xxs as f32)
+                                                + (*i + 1) as f32 * (height + space_xxs as f32)
                                     })
                                 {
                                     let applet = applet.clone().into_owned();

--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -16,19 +16,17 @@ use std::{
 
 #[cfg(feature = "xdg-portal")]
 use cosmic::dialog::file_chooser;
-use cosmic::iced::{Color, Length};
+use cosmic::iced::{Alignment, Color, Length};
+use cosmic::iced_runtime::core::image::Handle as ImageHandle;
 use cosmic::widget::{
     button, dropdown, list_column, row,
     segmented_button::{self, SingleSelectModel},
     settings, tab_bar, text, toggler,
 };
-use cosmic::{iced_core::alignment, iced_runtime::core::image::Handle as ImageHandle};
-use cosmic::{iced_core::Alignment, widget::icon};
 use cosmic::{
-    widget::{color_picker::ColorPickerUpdate, ColorPickerModel},
-    Element,
+    widget::{color_picker::ColorPickerUpdate, icon, ColorPickerModel},
+    Apply, Element, Task,
 };
-use cosmic::{Apply, Task};
 use cosmic_bg_config::Source;
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
@@ -1214,10 +1212,9 @@ pub fn settings() -> Section<crate::pages::Message> {
             ));
 
             if page.wallpaper_service_config.same_on_all {
-                let element = text(fl!("all-displays"))
-                    .font(cosmic::font::semibold())
-                    .align_x(alignment::Horizontal::Center)
-                    .align_y(alignment::Vertical::Center)
+                let element = text::heading(fl!("all-displays"))
+                    .align_x(Alignment::Center)
+                    .align_y(Alignment::Center)
                     .width(Length::Fill)
                     .height(Length::Fill)
                     .apply(cosmic::widget::container)
@@ -1374,7 +1371,7 @@ pub fn settings() -> Section<crate::pages::Message> {
 //         .push(content)
 //         .width(Length::Fill)
 //         .height(Length::Fill)
-//         .align_items(cosmic::iced_core::Alignment::Center)
+//         .align_y(Alignment::Center)
 //         .apply(Element::from)
 // }
 

--- a/cosmic-settings/src/pages/input/keyboard/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/mod.rs
@@ -4,7 +4,7 @@ use std::cmp;
 
 use cosmic::{
     cosmic_config::{self, ConfigSet},
-    iced::{self, Length},
+    iced::{Alignment, Color, Length},
     iced_core::Border,
     theme,
     widget::{self, button, container, icon, radio, row, settings, ListColumn},
@@ -203,7 +203,7 @@ fn popover_menu(id: DefaultKey) -> cosmic::Element<'static, Message> {
         container::Style {
             icon_color: Some(theme.cosmic().background.on.into()),
             text_color: Some(theme.cosmic().background.on.into()),
-            background: Some(iced::Color::from(theme.cosmic().background.base).into()),
+            background: Some(Color::from(theme.cosmic().background.base).into()),
             border: Border {
                 radius: cosmic.corner_radii.radius_m.into(),
                 ..Default::default()
@@ -654,7 +654,7 @@ fn input_sources() -> Section<crate::pages::Message> {
                 .push(
                     widget::container(add_input_source)
                         .width(Length::Fill)
-                        .align_x(iced::alignment::Horizontal::Right),
+                        .align_x(Alignment::End),
                 )
                 .apply(Element::from)
                 .map(crate::pages::Message::Keyboard)
@@ -752,7 +752,7 @@ fn keyboard_typing_assist() -> Section<crate::pages::Message> {
                     .max_width(250);
 
                     row::with_capacity(3)
-                        .align_y(iced::Alignment::Center)
+                        .align_y(Alignment::Center)
                         .spacing(theme.cosmic().space_s())
                         .push(widget::text::body(&descriptions[short]))
                         .push(delay_slider)
@@ -772,7 +772,7 @@ fn keyboard_typing_assist() -> Section<crate::pages::Message> {
                     .max_width(250);
 
                     row::with_capacity(3)
-                        .align_y(iced::Alignment::Center)
+                        .align_y(Alignment::Center)
                         .spacing(theme.cosmic().space_s())
                         .push(widget::text::body(&descriptions[slow]))
                         .push(rate_slider)

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
@@ -1,4 +1,3 @@
-use cosmic::iced::alignment::Horizontal;
 use cosmic::iced::{Alignment, Length};
 use cosmic::widget::{self, button, icon, settings, text};
 use cosmic::{theme, Apply, Element, Task};
@@ -546,7 +545,7 @@ fn context_drawer(
         .spacing(space_xs)
         .apply(widget::container)
         .width(Length::Fill)
-        .align_x(Horizontal::Right);
+        .align_x(Alignment::End);
 
     widget::column::with_capacity(if show_action { 3 } else { 2 })
         .spacing(space_l)

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/custom.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/custom.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
 use super::{ShortcutBinding, ShortcutMessage, ShortcutModel};
-use cosmic::iced::alignment::Horizontal;
-use cosmic::iced::Length;
+
+use cosmic::iced::{Alignment, Length};
 use cosmic::widget::{self, button, icon};
 use cosmic::{Apply, Element, Task};
 use cosmic_settings_config::shortcuts::{Action, Shortcuts};
@@ -279,7 +279,7 @@ impl Page {
             .on_press(Message::AddShortcut)
             .apply(widget::container)
             .width(Length::Fill)
-            .align_x(Horizontal::Right);
+            .align_x(Alignment::End);
 
         widget::column()
             .spacing(32)
@@ -435,7 +435,7 @@ fn shortcuts() -> Section<crate::pages::Message> {
                 .on_press(Message::ShortcutContext)
                 .apply(widget::container)
                 .width(Length::Fill)
-                .align_x(Horizontal::Right);
+                .align_x(Alignment::End);
 
             widget::column()
                 .push(content)

--- a/cosmic-settings/src/pages/networking/vpn/mod.rs
+++ b/cosmic-settings/src/pages/networking/vpn/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use ashpd::desktop::file_chooser::FileFilter;
 use cosmic::{
-    iced::{alignment, Length},
+    iced::{Alignment, Length},
     iced_core::text::Wrapping,
     widget::{self, icon},
     Apply, Element, Task,
@@ -324,7 +324,7 @@ impl page::Page<crate::pages::Message> for Page {
                 .on_press(Message::AddNetwork)
                 .apply(widget::container)
                 .width(Length::Fill)
-                .align_x(alignment::Horizontal::Right)
+                .align_x(Alignment::End)
                 .apply(Element::from)
                 .map(crate::pages::Message::Vpn),
         )
@@ -781,7 +781,7 @@ fn devices_view() -> Section<crate::pages::Message> {
                             widget::button::text(connect_txt).on_press(msg).into()
                         } else {
                             widget::text::body(connect_txt)
-                                .align_y(alignment::Vertical::Center)
+                                .align_y(Alignment::Center)
                                 .into()
                         };
 
@@ -826,7 +826,7 @@ fn devices_view() -> Section<crate::pages::Message> {
                         let controls = widget::row::with_capacity(2)
                             .push(connect)
                             .push_maybe(view_more)
-                            .align_y(alignment::Alignment::Center)
+                            .align_y(Alignment::Center)
                             .spacing(spacing.space_xxs);
 
                         let widget = widget::settings::item_row(vec![
@@ -852,7 +852,7 @@ fn popup_button(message: Message, text: &str) -> Element<'_, Message> {
     let theme = cosmic::theme::active();
     let theme = theme.cosmic();
     widget::text::body(text)
-        .align_y(alignment::Vertical::Center)
+        .align_y(Alignment::Center)
         .apply(widget::button::custom)
         .padding([theme.space_xxxs(), theme.space_xs()])
         .width(Length::Fill)

--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::Context;
 use cosmic::{
-    iced::{alignment, Length},
+    iced::{Alignment, Length},
     iced_core::text::Wrapping,
     widget::{self, icon},
     Apply, Element, Task,
@@ -193,7 +193,7 @@ impl page::Page<crate::pages::Message> for Page {
                 .on_press(Message::AddNetwork)
                 .apply(widget::container)
                 .width(Length::Fill)
-                .align_x(alignment::Horizontal::Right)
+                .align_x(Alignment::End)
                 .apply(Element::from)
                 .map(crate::pages::Message::WiFi),
         )
@@ -545,10 +545,9 @@ fn devices_view() -> Section<crate::pages::Message> {
                         .push(icon::from_name("airplane-mode-symbolic"))
                         .push(widget::text::body(&section.descriptions[airplane_mode_txt]))
                         .spacing(8)
-                        .align_y(alignment::Alignment::Center)
+                        .align_y(Alignment::Center)
                         .apply(widget::container)
-                        .width(Length::Fill)
-                        .align_x(alignment::Horizontal::Center)
+                        .center_x(Length::Fill)
                 }));
 
             if !state.airplane_mode
@@ -557,8 +556,7 @@ fn devices_view() -> Section<crate::pages::Message> {
             {
                 let no_networks_found =
                     widget::container(widget::text::body(&section.descriptions[no_networks_txt]))
-                        .align_x(alignment::Horizontal::Center)
-                        .width(Length::Fill);
+                        .center_x(Length::Fill);
 
                 view = view.push(no_networks_found);
             } else {
@@ -622,7 +620,7 @@ fn devices_view() -> Section<crate::pages::Message> {
                             widget::button::text(connect_txt).on_press(msg).into()
                         } else {
                             widget::text::body(connect_txt)
-                                .align_y(alignment::Vertical::Center)
+                                .align_y(Alignment::Center)
                                 .into()
                         };
 
@@ -671,7 +669,7 @@ fn devices_view() -> Section<crate::pages::Message> {
                         let controls = widget::row::with_capacity(2)
                             .push(connect)
                             .push_maybe(view_more)
-                            .align_y(alignment::Alignment::Center)
+                            .align_y(Alignment::Center)
                             .spacing(spacing.space_xxs);
 
                         let widget = widget::settings::item_row(vec![
@@ -721,7 +719,7 @@ fn popup_button(message: Message, text: &str) -> Element<'_, Message> {
     let theme = cosmic::theme::active();
     let theme = theme.cosmic();
     widget::text::body(text)
-        .align_y(alignment::Vertical::Center)
+        .align_y(Alignment::Center)
         .apply(widget::button::custom)
         .padding([theme.space_xxxs(), theme.space_xs()])
         .width(Length::Fill)

--- a/cosmic-settings/src/pages/networking/wired.rs
+++ b/cosmic-settings/src/pages/networking/wired.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use anyhow::Context;
 use cosmic::{
-    iced::{alignment, Length},
+    iced::{Alignment, Length},
     iced_core::text::Wrapping,
     widget::{self, icon},
     Apply, Element, Task,
@@ -149,7 +149,7 @@ impl page::Page<crate::pages::Message> for Page {
                 .on_press(Message::AddNetwork)
                 .apply(widget::container)
                 .width(Length::Fill)
-                .align_x(alignment::Horizontal::Right)
+                .align_x(Alignment::End)
                 .apply(Element::from)
                 .map(crate::pages::Message::Wired),
         )
@@ -487,7 +487,7 @@ impl Page {
                         widget::button::text(connect_txt).on_press(msg).into()
                     } else {
                         widget::text::body(connect_txt)
-                            .align_y(alignment::Vertical::Center)
+                            .align_y(Alignment::Center)
                             .into()
                     };
 
@@ -535,7 +535,7 @@ impl Page {
                     let controls = widget::row::with_capacity(2)
                         .push(connect)
                         .push_maybe(view_more)
-                        .align_y(alignment::Alignment::Center)
+                        .align_y(Alignment::Center)
                         .spacing(spacing.space_xxs);
 
                     let widget = widget::settings::item_row(vec![
@@ -607,7 +607,7 @@ fn popup_button(message: Message, text: &str) -> Element<'_, Message> {
     let theme = cosmic::theme::active();
     let theme = theme.cosmic();
     widget::text::body(text)
-        .align_y(alignment::Vertical::Center)
+        .align_y(Alignment::Center)
         .apply(widget::button::custom)
         .padding([theme.space_xxxs(), theme.space_xs()])
         .width(Length::Fill)

--- a/cosmic-settings/src/pages/power/mod.rs
+++ b/cosmic-settings/src/pages/power/mod.rs
@@ -386,6 +386,7 @@ fn power_saving() -> Section<crate::pages::Message> {
         .title(fl!("power-saving"))
         .descriptions(descriptions)
         .view::<Page>(move |_binder, page, section| {
+            let descriptions = &section.descriptions;
             let screen_off_time = page
                 .idle_conf
                 .screen_off_time
@@ -398,17 +399,17 @@ fn power_saving() -> Section<crate::pages::Message> {
                 .idle_conf
                 .suspend_on_battery_time
                 .map(|t| Duration::from_millis(t.into()));
-            let mut section_view = settings::section()
+            let mut section = settings::section()
                 .title(&section.title)
                 .add(power_saving_row(
-                    &section.descriptions[turn_off_screen_desc],
+                    &descriptions[turn_off_screen_desc],
                     &page.screen_off_labels,
                     screen_off_time,
                     SCREEN_OFF_TIMES,
                     Message::ScreenOffTimeChange,
                 ))
                 .add(power_saving_row(
-                    &section.descriptions[if page.battery.is_present {
+                    &descriptions[if page.battery.is_present {
                         auto_suspend_ac_desc
                     } else {
                         auto_suspend_desc
@@ -419,15 +420,15 @@ fn power_saving() -> Section<crate::pages::Message> {
                     Message::SuspendOnAcTimeChange,
                 ));
             if page.battery.is_present {
-                section_view = section_view.add(power_saving_row(
-                    &section.descriptions[auto_suspend_battery_desc],
+                section = section.add(power_saving_row(
+                    &descriptions[auto_suspend_battery_desc],
                     &page.suspend_labels,
                     suspend_on_battery_time,
                     SUSPEND_TIMES,
                     Message::SuspendOnBatteryTimeChange,
                 ));
             }
-            section_view
+            section
                 .apply(cosmic::Element::from)
                 .map(crate::pages::Message::Power)
         })

--- a/cosmic-settings/src/widget/mod.rs
+++ b/cosmic-settings/src/widget/mod.rs
@@ -4,7 +4,7 @@
 use std::borrow::Cow;
 
 use cosmic::cosmic_theme::Spacing;
-use cosmic::iced::{alignment, Length};
+use cosmic::iced::{Alignment, Length};
 use cosmic::iced_core::text::Wrapping;
 use cosmic::widget::color_picker::ColorPickerUpdate;
 use cosmic::widget::{
@@ -37,13 +37,12 @@ pub fn color_picker_context_view<'a, Message: Clone + 'static>(
                 )
                 .apply(container)
                 .width(Length::Fixed(248.0))
-                .align_x(alignment::Horizontal::Center)
+                .align_x(Alignment::Center)
                 .apply(container)
-                .width(Length::Fill)
-                .align_x(alignment::Horizontal::Center),
+                .center_x(Length::Fill),
         )
         .padding(spacing.space_l)
-        .align_x(cosmic::iced_core::Alignment::Center)
+        .align_x(Alignment::Center)
         .spacing(spacing.space_m)
         .width(Length::Fill)
         .apply(Element::from)
@@ -147,13 +146,13 @@ pub fn page_list_item<'a, Message: 'static + Clone>(
             row::with_capacity(2)
                 .push(text::body(info))
                 .push(container(icon::from_name("go-next-symbolic").size(20)).padding(8))
-                .align_y(alignment::Alignment::Center),
+                .align_y(Alignment::Center),
         )
         .padding(0)
         .spacing(space_xxs)
         .apply(container)
         .padding([space_s, space_m])
-        .align_x(alignment::Horizontal::Center)
+        .align_x(Alignment::Center)
         .class(theme::Container::List)
         .apply(button::custom)
         .padding(0)
@@ -211,7 +210,7 @@ pub fn go_next_with_item<'a, Msg: Clone + 'static>(
         widget::row::with_capacity(2)
             .push(item)
             .push(icon::from_name("go-next-symbolic").size(16).icon())
-            .align_y(alignment::Alignment::Center)
+            .align_y(Alignment::Center)
             .spacing(cosmic::theme::active().cosmic().spacing.space_s)
             .into(),
     ])


### PR DESCRIPTION
This makes the min width horizontal padding "match" the designs with `@space_s`. It doesn't really match them, since all apps have 8 padding around them, so the previous value was technically more correct.
But since the padding around apps will likely be removed (so that the scrollbar is closer to the edge), it might be better to use the value from the designs (though the dynamic padding is more complex in the designs, depending on window width, etc...).
So this technically fixes #511, at least when not using Compact density (slight clipping with the scrollbar).

Initially wanted to try to fix [this issue](https://github.com/pop-os/cosmic-epoch/issues/1202), but wasn't able to, so I got carried away with the minor code cleanup. :)