### PR TITLE
Adaptive VRR support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols//?rev=bd65e0f2d55429954839c9e6c7bc5b0d198b85f0#bd65e0f2d55429954839c9e6c7bc5b0d198b85f0"
+source = "git+https://github.com/pop-os/cosmic-protocols//?rev=27d70b6#27d70b6eb9c785a2a48341016f32a7b1ac4980ac"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -1565,7 +1565,7 @@ dependencies = [
 [[package]]
 name = "cosmic-randr"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-randr#8d0938029f223016fde11aef4c5233ddbfdb2796"
+source = "git+https://github.com/pop-os/cosmic-randr#311b944d3f549af21a57fd348d0ede8219dd7f9c"
 dependencies = [
  "cosmic-protocols",
  "futures-lite 2.5.0",
@@ -1581,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "cosmic-randr-shell"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-randr#8d0938029f223016fde11aef4c5233ddbfdb2796"
+source = "git+https://github.com/pop-os/cosmic-randr#311b944d3f549af21a57fd348d0ede8219dd7f9c"
 dependencies = [
  "kdl",
  "slotmap",
@@ -7821,7 +7821,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -7849,7 +7849,7 @@ dependencies = [
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
@@ -7890,7 +7890,7 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ lto = "thin"
 # smithay-client-toolkit = { git = "https://github.com/smithay/client-toolkit//", rev = "c583de8" }
 
 [patch.'https://github.com/pop-os/cosmic-protocols']
-cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols//", rev = "bd65e0f2d55429954839c9e6c7bc5b0d198b85f0" }
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols//", rev = "27d70b6" }
 
 # For development and testing purposes
 # [patch.'https://github.com/pop-os/libcosmic']

--- a/i18n/de/cosmic_settings.ftl
+++ b/i18n/de/cosmic_settings.ftl
@@ -351,6 +351,12 @@ orientation = Ausrichtung
     .rotate-180 = Um 180 Grad drehen
     .rotate-270 = Um 270 Grad drehen
 
+vrr = Variable refresh rate
+    .enabled = Aktiv
+    .force = Immer aktiv
+    .auto = Automatisch
+    .disabled = Deaktiviert
+
 scheduling = Zeitplanung
     .manual = Manueller Zeitplan
 

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -384,6 +384,12 @@ orientation = Orientation
     .rotate-180 = Rotate 180
     .rotate-270 = Rotate 270
 
+vrr = Variable refresh rate
+    .enabled = Enabled
+    .force = Always
+    .auto = Automatic
+    .disabled = Disabled
+
 scheduling = Scheduling
     .manual = Manual schedule
 


### PR DESCRIPTION
Draft until `cosmic-randr` changes are merged, so we don't have the patched dependency.

But this shouldn't regress as old `cosmic-randr` versions should never report `adaptive_sync_support`. So already ready for review.