### PR TITLE
Fixed spin button behavior in desktop->appearance->mod.rs

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -1973,8 +1973,8 @@ pub fn window_management() -> Section<crate::pages::Message> {
                 .add(settings::item::builder(&descriptions[active_hint]).control(
                     cosmic::widget::spin_button(
                         page.theme_builder.active_hint.to_string(),
+                        page.theme_builder.active_hint,
                         1,
-                        page.theme.active_hint,
                         0,
                         500,
                         Message::WindowHintSize,


### PR DESCRIPTION
# Changes
Fixed the behavior of the spin button for the appearance settings.

Changed the order of the active hint spin button to the following:  
  
```rs
cosmic::widget::spin_button(
    page.theme_builder.active_hint.to_string(),
    page.theme_builder.active_hint,
    1,
    0,
    500,
    Message::WindowHintSize,
),
```  
  
It was changed from:  
  
```rs
cosmic::widget::spin_button(
    page.theme_builder.active_hint.to_string(),
    1,
    page.theme.active_hint,
    0,
    500,
    Message::WindowHintSize,
),
```  
  
# Reason for the Change
The reason for the change is because the the step and value were swapped making both the active_hint spin button and the gaps spin button have unintended behaviors.