### PR TITLE
[Default apps] Add desktop entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1777,7 +1777,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -3204,7 +3204,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "futures",
  "iced_core",
@@ -3230,7 +3230,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3264,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "bytes",
  "dnd",
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -3327,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -4329,7 +4329,7 @@ checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#a9c7c3cdbfd586b090437647e3d380977780d520"
+source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
 dependencies = [
  "apply",
  "ashpd 0.9.2",

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -203,13 +203,7 @@ impl cosmic::Application for SettingsApp {
         app.insert_page::<input::Page>();
         app.insert_page::<time::Page>();
         app.insert_page::<system::Page>();
-        #[cfg(feature = "wayland")]
-        {
-            app.insert_page::<desktop::panel::Page>();
-            app.insert_page::<desktop::dock::Page>();
-            app.insert_page::<desktop::panel::applets_inner::Page>();
-            app.insert_page::<desktop::dock::applets::Page>();
-        }
+
         let active_id = match flags.sub_command {
             Some(p) => app.subtask_to_page(&p),
             None => app

--- a/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
@@ -228,7 +228,7 @@ impl Page {
             space_xxxs,
             space_xxs,
             space_xs,
-            space_l,
+            space_s,
             ..
         } = theme::active().cosmic().spacing;
         let mut list_column = list_column();
@@ -295,7 +295,7 @@ impl Page {
                         .on_press(msg_map(Message::AddApplet(info.clone())))
                         .into(),
                 ])
-                .padding([0, space_l])
+                .padding([0, space_s])
                 .spacing(space_xs)
                 .align_y(Alignment::Center),
             );

--- a/cosmic-settings/src/pages/system/default_apps.rs
+++ b/cosmic-settings/src/pages/system/default_apps.rs
@@ -91,7 +91,7 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn info(&self) -> page::Info {
-        page::Info::new("default-apps", "application-default-symbolic")
+        page::Info::new("default-apps", "preferences-default-applications-symbolic")
             .title(fl!("default-apps"))
             .description(fl!("default-apps", "desc"))
     }

--- a/debian/install
+++ b/debian/install
@@ -1,9 +1,10 @@
 /usr/bin/cosmic-settings
+/usr/share/applications/com.system76.CosmicSettings.desktop
 /usr/share/applications/com.system76.CosmicSettings.About.desktop
 /usr/share/applications/com.system76.CosmicSettings.Appearance.desktop
 /usr/share/applications/com.system76.CosmicSettings.Bluetooth.desktop
 /usr/share/applications/com.system76.CosmicSettings.DateTime.desktop
-/usr/share/applications/com.system76.CosmicSettings.desktop
+/usr/share/applications/com.system76.CosmicSettings.DefaultApps.desktop
 /usr/share/applications/com.system76.CosmicSettings.Desktop.desktop
 /usr/share/applications/com.system76.CosmicSettings.Displays.desktop
 /usr/share/applications/com.system76.CosmicSettings.Dock.desktop

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -771,7 +771,7 @@ users = Users
 ## System: Default Applications
 
 default-apps = Default Applications
-    .desc = Default applications and file associations.
+    .desc = Default web browser, mail client, file browser, and other applications.
     .web-browser = Web browser
     .file-manager = File manager
     .mail-client = Mail client

--- a/justfile
+++ b/justfile
@@ -29,6 +29,7 @@ entry-about := appid + '.About.desktop'
 entry-appear := appid + '.Appearance.desktop'
 entry-bluetooth := appid + '.Bluetooth.desktop'
 entry-date-time := appid + '.DateTime.desktop'
+entry-default-apps := appid + '.DefaultApps.desktop'
 entry-desktop := appid + '.Desktop.desktop'
 entry-displays := appid + '.Displays.desktop'
 entry-dock := appid + '.Dock.desktop'
@@ -64,6 +65,7 @@ install-desktop-entries:
     install -Dm0644 'resources/{{entry-appear}}' '{{appdir}}/{{entry-appear}}'
     install -Dm0644 'resources/{{entry-bluetooth}}' '{{appdir}}/{{entry-bluetooth}}'
     install -Dm0644 'resources/{{entry-date-time}}' '{{appdir}}/{{entry-date-time}}'
+    install -Dm0644 'resources/{{entry-default-apps}}' '{{appdir}}/{{entry-default-apps}}'
     install -Dm0644 'resources/{{entry-desktop}}' '{{appdir}}/{{entry-desktop}}'
     install -Dm0644 'resources/{{entry-displays}}' '{{appdir}}/{{entry-displays}}'
     install -Dm0644 'resources/{{entry-dock}}' '{{appdir}}/{{entry-dock}}'
@@ -111,6 +113,7 @@ uninstall:
         '{{appdir}}/{{entry-appear}}' \
         '{{appdir}}/{{entry-bluetooth}}' \
         '{{appdir}}/{{entry-date-time}}' \
+        '{{appdir}}/{{entry-default-apps}}' \
         '{{appdir}}/{{entry-desktop}}' \
         '{{appdir}}/{{entry-displays}}' \
         '{{appdir}}/{{entry-dock}}' \

--- a/resources/com.system76.CosmicSettings.DefaultApps.desktop
+++ b/resources/com.system76.CosmicSettings.DefaultApps.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Default applications
+Comment=Default web browser, mail client, file browser, and other applications.
+Type=Settings
+Exec=cosmic-settings default-apps
+Terminal=false
+Categories=COSMIC
+Keywords=COSMIC
+NoDisplay=true
+OnlyShowIn=COSMIC
+Icon=preferences-default-applications
+StartupNotify=true


### PR DESCRIPTION
This adds a desktop entry for default apps, and matches the description and icon of its page list item to designs.
Also includes a minor padding fix for the Add applets context drawer, and removes the (likely accidental) additions to the NavBar in #789.