### PR TITLE
[Applets] Center applet text without a description in the applets context drawer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "accesskit_consumer",
  "atspi-common",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "zvariant 3.15.2",
 ]
 
@@ -166,9 +166,9 @@ checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almost"
@@ -194,7 +194,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "apply"
@@ -318,7 +318,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -760,7 +760,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -956,7 +956,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -973,9 +973,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "calendrical_calculations"
@@ -998,7 +998,7 @@ dependencies = [
  "polling 3.7.4",
  "rustix 0.38.41",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1135,7 +1135,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1178,7 +1178,7 @@ name = "clipboard_x11"
 version = "0.4.2"
 source = "git+https://github.com/pop-os/window_clipboard.git?tag=pop-0.13#a83bf83784276aaa882ef13555295a2ad9edd265"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
  "x11rb",
 ]
 
@@ -1450,18 +1450,19 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=c8d3a1c#c8d3a1c3d40d16235f4720969a54ed570ec7a976"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=d218c76#d218c76b58c7a3b20dd5e7943f93fc306a1b81b8"
 dependencies = [
  "cosmic-protocols",
  "libc",
  "smithay-client-toolkit",
  "wayland-client",
+ "wayland-protocols",
 ]
 
 [[package]]
 name = "cosmic-comp-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-comp#7e8cb91d2353538a561c58620204f5b4a9a5ccff"
+source = "git+https://github.com/pop-os/cosmic-comp#e3b41c5c554cc5aadf44183866ff4df7c2957d09"
 dependencies = [
  "cosmic-config",
  "input",
@@ -1471,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1493,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1507,7 +1508,7 @@ dependencies = [
  "bitflags 2.6.0",
  "derive_builder",
  "procfs",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "zbus 4.4.0",
  "zvariant 4.2.0",
@@ -1536,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#fd840c31c302c616146c28f7b008a91c5694baf6"
+source = "git+https://github.com/pop-os/cosmic-panel#734e3fafe2eafea1cb3cece7d0b4ddf72a2c4323"
 dependencies = [
  "anyhow",
  "cosmic-config",
@@ -1551,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols//?rev=27d70b6#27d70b6eb9c785a2a48341016f32a7b1ac4980ac"
+source = "git+https://github.com/pop-os/cosmic-protocols//?rev=d218c76#d218c76b58c7a3b20dd5e7943f93fc306a1b81b8"
 dependencies = [
  "bitflags 2.6.0",
  "wayland-backend",
@@ -1569,9 +1570,9 @@ source = "git+https://github.com/pop-os/cosmic-randr#311b944d3f549af21a57fd348d0
 dependencies = [
  "cosmic-protocols",
  "futures-lite 2.5.0",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "tachyonix",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "wayland-client",
@@ -1585,7 +1586,7 @@ source = "git+https://github.com/pop-os/cosmic-randr#311b944d3f549af21a57fd348d0
 dependencies = [
  "kdl",
  "slotmap",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -1630,7 +1631,7 @@ dependencies = [
  "i18n-embed-fl",
  "icu",
  "image 0.25.5",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itertools 0.13.0",
  "itoa",
  "libcosmic",
@@ -1669,7 +1670,7 @@ dependencies = [
  "cosmic-config",
  "serde",
  "serde_with",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "xkbcommon",
 ]
@@ -1711,7 +1712,7 @@ dependencies = [
  "pipewire",
  "rustix 0.38.41",
  "secure-string",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1777,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1788,7 +1789,7 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1958,7 +1959,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1980,7 +1981,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2064,7 +2065,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2122,7 +2123,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2244,7 +2245,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2255,12 +2256,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2318,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener 5.3.1",
  "pin-project-lite",
@@ -2367,7 +2368,7 @@ dependencies = [
  "document-features",
  "image 0.25.5",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2489,7 +2490,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2562,7 +2563,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2592,7 +2593,7 @@ dependencies = [
  "memchr",
  "strsim 0.11.1",
  "textdistance",
- "thiserror",
+ "thiserror 1.0.69",
  "xdg",
 ]
 
@@ -2605,15 +2606,15 @@ dependencies = [
  "dirs",
  "once_cell",
  "rust-ini",
- "thiserror",
+ "thiserror 1.0.69",
  "xdg",
 ]
 
 [[package]]
 name = "fs-err"
-version = "2.11.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+checksum = "8bb60e7409f34ef959985bc9d9c5ee8f5db24ee46ed9775850548021710f807f"
 dependencies = [
  "autocfg",
  "tokio",
@@ -2719,7 +2720,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2878,13 +2879,13 @@ dependencies = [
 
 [[package]]
 name = "gpt"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8283e7331b8c93b9756e0cfdbcfb90312852f953c6faf9bf741e684cc3b6ad69"
+checksum = "ffa5448a0d9d541f1840c0e1b5fe513360861ca83c4b920619f54efe277f9254"
 dependencies = [
  "bitflags 2.6.0",
  "crc",
- "log",
+ "simple-bytes",
  "uuid",
 ]
 
@@ -2915,7 +2916,7 @@ checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
 dependencies = [
  "log",
  "presser",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
  "windows 0.52.0",
 ]
@@ -3001,7 +3002,7 @@ dependencies = [
  "com",
  "libc",
  "libloading",
- "thiserror",
+ "thiserror 1.0.69",
  "widestring",
  "winapi",
 ]
@@ -3066,7 +3067,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "thiserror",
+ "thiserror 1.0.69",
  "unic-langid",
 ]
 
@@ -3087,7 +3088,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "rust-embed",
- "thiserror",
+ "thiserror 1.0.69",
  "unic-langid",
  "walkdir",
 ]
@@ -3109,7 +3110,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.89",
+ "syn 2.0.90",
  "unic-langid",
 ]
 
@@ -3123,7 +3124,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3152,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3163,14 +3164,14 @@ dependencies = [
  "iced_winit",
  "image 0.24.9",
  "mime 0.1.0",
- "thiserror",
+ "thiserror 1.0.69",
  "window_clipboard",
 ]
 
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3179,10 +3180,11 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
+ "cosmic-client-toolkit",
  "dnd",
  "glam",
  "iced_accessibility",
@@ -3192,11 +3194,10 @@ dependencies = [
  "once_cell",
  "palette",
  "raw-window-handle",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "serde",
- "smithay-client-toolkit",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.69",
  "web-time",
  "window_clipboard",
 ]
@@ -3204,12 +3205,12 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "futures",
  "iced_core",
  "log",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "tokio",
  "wasm-bindgen-futures",
  "wasm-timer",
@@ -3223,14 +3224,14 @@ dependencies = [
  "cosmic-text",
  "etagere",
  "lru",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "wgpu",
 ]
 
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -3244,43 +3245,43 @@ dependencies = [
  "lyon_path",
  "once_cell",
  "raw-window-handle",
- "rustc-hash 2.0.0",
- "thiserror",
+ "rustc-hash 2.1.0",
+ "thiserror 1.0.69",
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
  "iced_wgpu",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "bytes",
+ "cosmic-client-toolkit",
  "dnd",
  "iced_accessibility",
  "iced_core",
  "iced_futures",
  "raw-window-handle",
- "smithay-client-toolkit",
- "thiserror",
+ "thiserror 1.0.69",
  "window_clipboard",
 ]
 
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3288,7 +3289,7 @@ dependencies = [
  "kurbo 0.10.4",
  "log",
  "resvg",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "softbuffer",
  "tiny-skia",
 ]
@@ -3296,11 +3297,12 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
  "bytemuck",
+ "cosmic-client-toolkit",
  "futures",
  "glam",
  "guillotiere",
@@ -3311,10 +3313,9 @@ dependencies = [
  "once_cell",
  "raw-window-handle",
  "resvg",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.0",
  "rustix 0.38.41",
- "smithay-client-toolkit",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny-xlib",
  "wayland-backend",
  "wayland-client",
@@ -3327,8 +3328,9 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
+ "cosmic-client-toolkit",
  "dnd",
  "iced_accessibility",
  "iced_renderer",
@@ -3336,9 +3338,8 @@ dependencies = [
  "num-traits",
  "once_cell",
  "ouroboros",
- "rustc-hash 2.0.0",
- "smithay-client-toolkit",
- "thiserror",
+ "rustc-hash 2.1.0",
+ "thiserror 1.0.69",
  "unicode-segmentation",
  "window_clipboard",
 ]
@@ -3346,8 +3347,9 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
+ "cosmic-client-toolkit",
  "dnd",
  "iced_accessibility",
  "iced_futures",
@@ -3355,9 +3357,8 @@ dependencies = [
  "iced_runtime",
  "log",
  "raw-window-handle",
- "rustc-hash 2.0.0",
- "smithay-client-toolkit",
- "thiserror",
+ "rustc-hash 2.1.0",
+ "thiserror 1.0.69",
  "tracing",
  "wasm-bindgen-futures",
  "wayland-backend",
@@ -3719,7 +3720,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3883,9 +3884,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -3957,7 +3958,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4022,9 +4023,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jni"
@@ -4037,7 +4038,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -4068,10 +4069,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -4227,13 +4229,13 @@ dependencies = [
 
 [[package]]
 name = "kdl"
-version = "4.6.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062c875482ccb676fd40c804a40e3824d4464c18c364547456d1c8e8e951ae47"
+checksum = "3a18038fbecda667e7ea2101bdd02af754da5e17ca2887a7649b8f3fa809d8b8"
 dependencies = [
  "miette",
  "nom",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4322,14 +4324,14 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#96c67e29a496a930ec40502a9fa3ea81af15da40"
+source = "git+https://github.com/pop-os/libcosmic#b524ccb0a46b1ca585db09638c33e39e79829716"
 dependencies = [
  "apply",
  "ashpd 0.9.2",
@@ -4358,7 +4360,7 @@ dependencies = [
  "serde",
  "slotmap",
  "taffy",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "unicode-segmentation",
@@ -4379,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -4395,9 +4397,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libpulse-binding"
-version = "2.28.1"
+version = "2.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3557a2dfc380c8f061189a01c6ae7348354e0c9886038dc6c171219c08eaff"
+checksum = "b6b1040a6c4c4d1e9e852000f6202df1a02a4f074320de336ab21e4fd317b538"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -4703,25 +4705,25 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "5.10.0"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
 dependencies = [
+ "cfg-if",
  "miette-derive",
- "once_cell",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-width",
 ]
 
 [[package]]
 name = "miette-derive"
-version = "5.10.0"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4777,11 +4779,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -4805,12 +4806,12 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "log",
  "rustc-hash 1.1.0",
  "spirv",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
@@ -4826,7 +4827,7 @@ dependencies = [
  "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4984,7 +4985,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5045,7 +5046,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5352,7 +5353,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5367,7 +5368,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
 dependencies = [
- "ttf-parser 0.25.0",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -5398,7 +5399,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5497,7 +5498,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5532,7 +5533,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5572,7 +5573,7 @@ dependencies = [
  "nix 0.27.1",
  "once_cell",
  "pipewire-sys",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5701,7 +5702,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5721,7 +5722,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "version_check",
  "yansi",
 ]
@@ -5765,7 +5766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5908,7 +5909,7 @@ dependencies = [
  "rand_chacha",
  "simd_helpers",
  "system-deps",
- "thiserror",
+ "thiserror 1.0.69",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -5999,7 +6000,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6185,7 +6186,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.89",
+ "syn 2.0.90",
  "walkdir",
 ]
 
@@ -6239,9 +6240,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"
@@ -6381,7 +6382,7 @@ checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
 dependencies = [
  "log",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "xml-rs",
 ]
 
@@ -6393,7 +6394,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6402,7 +6403,7 @@ version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6417,7 +6418,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6439,7 +6440,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6456,7 +6457,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6525,6 +6526,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple-bytes"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11532d9d241904f095185f35dcdaf930b1427a94d5b01d7002d74ba19b44cc4"
 
 [[package]]
 name = "simplecss"
@@ -6597,7 +6604,7 @@ dependencies = [
  "memmap2 0.9.5",
  "pkg-config",
  "rustix 0.38.41",
- "thiserror",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -6641,9 +6648,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6764,7 +6771,7 @@ version = "0.1.0"
 source = "git+https://github.com/serpent-os/blsforme.git#3c1ca74c220b2297338a2c4be8da55dcf3f438e8"
 dependencies = [
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -6808,9 +6815,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6825,7 +6832,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6854,17 +6861,14 @@ dependencies = [
 [[package]]
 name = "system"
 version = "0.1.0"
-source = "git+https://github.com/serpent-os/lichen#ea0ed88d444068aeffbf505f1379dbc3d9757975"
+source = "git+https://github.com/serpent-os/lichen#0d1c4301a45e79be6be79f4bbc092d67c997dfc3"
 dependencies = [
  "fs-err",
- "futures",
  "gpt",
  "serde",
  "serde_json",
  "superblock",
- "thiserror",
- "tokio",
- "tokio-stream",
+ "thiserror 2.0.4",
 ]
 
 [[package]]
@@ -6956,7 +6960,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
+dependencies = [
+ "thiserror-impl 2.0.4",
 ]
 
 [[package]]
@@ -6967,7 +6980,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6993,9 +7017,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -7014,9 +7038,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7067,9 +7091,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-xlib"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d52f22673960ad13af14ff4025997312def1223bfa7c8e4949d099e6b3d5d1c"
+checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
 dependencies = [
  "as-raw-xcb-connection",
  "ctor-lite",
@@ -7105,18 +7129,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.2",
- "parking_lot 0.12.3",
+ "mio 1.0.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio-macros",
  "tracing",
  "windows-sys 0.52.0",
@@ -7130,7 +7153,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -7140,20 +7163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -7194,7 +7203,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -7205,7 +7214,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7214,9 +7223,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -7225,20 +7234,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -7246,9 +7255,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-error"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -7267,9 +7276,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -7297,9 +7306,9 @@ checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "ttf-parser"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "type-map"
@@ -7578,9 +7587,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7589,36 +7598,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7626,22 +7636,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-timer"
@@ -7785,9 +7795,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7821,7 +7831,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -7845,16 +7855,16 @@ dependencies = [
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wgpu-hal",
  "wgpu-types",
 ]
@@ -7890,14 +7900,14 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "profiling",
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -7964,7 +7974,7 @@ dependencies = [
  "dnd",
  "mime 0.1.0",
  "raw-window-handle",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8047,7 +8057,7 @@ checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -8058,7 +8068,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -8069,7 +8079,7 @@ checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -8080,7 +8090,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -8456,7 +8466,7 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-panel#fd840c31c302c616146c28f7b008a91c5694baf6"
+source = "git+https://github.com/pop-os/cosmic-panel#734e3fafe2eafea1cb3cece7d0b4ddf72a2c4323"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",
@@ -8507,9 +8517,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
+checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
 
 [[package]]
 name = "xmlwriter"
@@ -8558,7 +8568,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -8660,7 +8670,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "zvariant_utils 2.1.0",
 ]
 
@@ -8710,7 +8720,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -8730,7 +8740,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "synstructure",
 ]
 
@@ -8770,7 +8780,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -8847,7 +8857,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
  "zvariant_utils 2.1.0",
 ]
 
@@ -8870,5 +8880,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.90",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ lto = "thin"
 # smithay-client-toolkit = { git = "https://github.com/smithay/client-toolkit//", rev = "c583de8" }
 
 [patch.'https://github.com/pop-os/cosmic-protocols']
-cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols//", rev = "27d70b6" }
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols//", rev = "d218c76" }
 
 # For development and testing purposes
 # [patch.'https://github.com/pop-os/libcosmic']

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -932,7 +932,7 @@ impl SettingsApp {
         }
 
         let view = self
-            .page_container(settings::view_column(sections_column).padding(0))
+            .page_container(settings::view_column(sections_column))
             .apply(scrollable)
             .height(Length::Fill)
             .apply(|w| id_container(w, self.id()));
@@ -1050,7 +1050,7 @@ impl SettingsApp {
             }
         }
 
-        self.page_container(settings::view_column(sections).padding(0))
+        self.page_container(settings::view_column(sections))
             .apply(scrollable)
             .into()
     }

--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -597,7 +597,7 @@ fn status() -> Section<crate::pages::Message> {
                     } else {
                         text::body(&descriptions[bluetooth_heading]).into()
                     },
-                    widget::horizontal_space().width(Length::Fill).into(),
+                    widget::horizontal_space().into(),
                     if page.popup_setting {
                         widget::popover(
                             widget::button::icon(widget::icon::from_name(
@@ -735,7 +735,7 @@ fn connected_devices() -> Section<crate::pages::Message> {
                                 .wrapping(Wrapping::Word)
                                 .into()
                         },
-                        widget::horizontal_space().width(Length::Fill).into(),
+                        widget::horizontal_space().into(),
                         match device.enabled {
                             Active::Enabled => widget::text(&descriptions[device_connected]).into(),
                             Active::Enabling => widget::text(&descriptions[device_connecting])
@@ -790,7 +790,7 @@ fn available_devices() -> Section<crate::pages::Message> {
                     let mut items = vec![
                         widget::icon::from_name(device.icon).size(16).into(),
                         text(device.alias_or_addr()).wrapping(Wrapping::Word).into(),
-                        widget::horizontal_space().width(Length::Fill).into(),
+                        widget::horizontal_space().into(),
                     ];
 
                     if device.enabled == Active::Enabling {
@@ -840,7 +840,7 @@ fn multiple_adapter() -> Section<crate::pages::Message> {
                             .into(),
                         widget::horizontal_space().width(theme.space_xxs()).into(),
                         text(&adapter.alias).wrapping(Wrapping::Word).into(),
-                        widget::horizontal_space().width(Length::Fill).into(),
+                        widget::horizontal_space().into(),
                         widget::icon::from_name("go-next-symbolic").into(),
                     ];
                     if page.adapter_connected(path) {

--- a/cosmic-settings/src/pages/desktop/appearance/font_config.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/font_config.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use cosmic::{
     config::{CosmicTk, FontConfig},
-    iced::Length,
     iced_core::text::Wrapping,
     theme,
     widget::{self, settings, svg},
@@ -89,7 +88,7 @@ pub fn selection_context<'a>(
                 widget::text::body(&**family)
                     .wrapping(Wrapping::Word)
                     .into(),
-                widget::horizontal_space().width(Length::Fill).into(),
+                widget::horizontal_space().into(),
                 if selected {
                     widget::icon::from_name("object-select-symbolic")
                         .size(16)

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -1568,9 +1568,7 @@ pub fn mode_and_colors() -> Section<crate::pages::Message> {
         .title(fl!("mode-and-colors"))
         .descriptions(descriptions)
         .view::<Page>(move |_binder, page, section| {
-            let Spacing {
-                space_xxs, space_s, ..
-            } = cosmic::theme::active().cosmic().spacing;
+            let Spacing { space_xxs, .. } = cosmic::theme::active().cosmic().spacing;
 
             let descriptions = &section.descriptions;
             let palette = &page.theme_builder.palette.as_ref();
@@ -1728,7 +1726,7 @@ pub fn mode_and_colors() -> Section<crate::pages::Message> {
                         )
                         .direction(Direction::Horizontal(Scrollbar::new()))
                     ]
-                    .padding([16, space_s, 0, space_s])
+                    .padding([16, 0, 0, 0])
                     .spacing(space_xxs),
                 )
                 .add(

--- a/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
@@ -226,9 +226,8 @@ impl Page {
     ) -> Element<crate::pages::Message> {
         let cosmic::cosmic_theme::Spacing {
             space_xxxs,
-            space_xxs,
             space_xs,
-            space_s,
+            space_l,
             ..
         } = theme::active().cosmic().spacing;
         let mut list_column = list_column();
@@ -262,7 +261,11 @@ impl Page {
                     icon::from_name(&*info.icon).size(32).icon().into(),
                     column::with_capacity(2)
                         .push(text::body(info.name.clone()))
-                        .push(text::caption(info.description.clone()))
+                        .push_maybe(if info.description.is_empty() {
+                            None
+                        } else {
+                            Some(text::caption(info.description.clone()))
+                        })
                         .spacing(space_xxxs)
                         .width(Length::Fill)
                         .into(),
@@ -295,7 +298,7 @@ impl Page {
                         .on_press(msg_map(Message::AddApplet(info.clone())))
                         .into(),
                 ])
-                .padding([0, space_s])
+                .padding([space_xxxs, 0])
                 .spacing(space_xs)
                 .align_y(Alignment::Center),
             );
@@ -317,7 +320,7 @@ impl Page {
             .push(search)
             .push(list_column)
             .align_x(Alignment::Center)
-            .spacing(space_xxs)
+            .spacing(space_l)
             .into()
     }
 

--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -273,7 +273,7 @@ pub(crate) fn configuration<P: page::Page<crate::pages::Message> + PanelPage>(
                 .find(|(_, v)| v.id == page.applets_page_id())
             {
                 let control = row::with_children(vec![
-                    horizontal_space().width(Length::Fill).into(),
+                    horizontal_space().into(),
                     icon::from_name("go-next-symbolic").size(16).into(),
                 ]);
 

--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -1297,7 +1297,7 @@ pub fn settings() -> Section<crate::pages::Message> {
                         },
                     )
                     .push(category_selection)
-                    .push(cosmic::widget::horizontal_space().width(Length::Fill))
+                    .push(cosmic::widget::horizontal_space())
                     .push_maybe(add_button)
                     .into(),
             );

--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -1073,15 +1073,16 @@ pub fn display_arrangement() -> Section<crate::pages::Message> {
         .show_while::<Page>(|page| page.list.outputs.len() > 1)
         .view::<Page>(move |_binder, page, section| {
             let descriptions = &section.descriptions;
-            let theme = cosmic::theme::active();
+            let cosmic::cosmic_theme::Spacing {
+                space_xxs, space_m, ..
+            } = cosmic::theme::active().cosmic().spacing;
 
             column()
-                .padding(cosmic::iced::Padding::from([
-                    theme.cosmic().space_s(),
-                    theme.cosmic().space_m(),
-                ]))
-                .spacing(theme.cosmic().space_xs())
-                .push(widget::text::body(&descriptions[display_arrangement_desc]))
+                .push(
+                    text::body(&descriptions[display_arrangement_desc])
+                        .apply(container)
+                        .padding([space_xxs, space_m]),
+                )
                 .push({
                     Arrangement::new(&page.list, &page.display_tabs)
                         .on_select(|id| pages::Message::Displays(Message::Display(id)))
@@ -1094,9 +1095,12 @@ pub fn display_arrangement() -> Section<crate::pages::Message> {
                         .width(Length::Shrink)
                         .direction(Direction::Horizontal(Scrollbar::new()))
                         .apply(container)
+                        .padding([48, 32, 32, 32])
                         .center_x(Length::Fill)
                 })
-                .apply(widget::list::container)
+                .apply(container)
+                .class(cosmic::theme::Container::List)
+                .width(Length::Fill)
                 .into()
         })
 }
@@ -1224,7 +1228,7 @@ pub fn display_configuration() -> Section<crate::pages::Message> {
                 content = content.push(display_switcher).push(display_enable);
             } else {
                 content = content
-                    .push(widget::text::heading(&descriptions[options_label]))
+                    .push(text::heading(&descriptions[options_label]))
                     .push_maybe(display_options.map(|items| {
                         let mut column = list_column();
                         for item in items {

--- a/cosmic-settings/src/pages/display/night_light.rs
+++ b/cosmic-settings/src/pages/display/night_light.rs
@@ -3,9 +3,10 @@
 
 use super::{Message, NightLight};
 use crate::pages;
-use cosmic::iced_core::{Alignment, Length, Padding};
-use cosmic::prelude::CollectionWidget;
-use cosmic::widget::{button, column, icon, list_column, row, toggler};
+use cosmic::iced_core::{Alignment, Length};
+use cosmic::widget::{
+    button, column, container, icon, list_column, row, settings, text, toggler, vertical_space,
+};
 use cosmic::{Apply, Element, Task};
 use std::sync::Arc;
 
@@ -14,33 +15,40 @@ pub fn view(
     description: &'static str,
     button: Option<(&'static str, Message)>,
 ) -> Element<'static, Message> {
-    let theme = cosmic::theme::active();
-    let theme = theme.cosmic();
+    let cosmic::cosmic_theme::Spacing {
+        space_xxs, space_l, ..
+    } = cosmic::theme::active().cosmic().spacing;
     let has_checkmark = button.is_none();
 
-    let content = column::with_capacity(3)
-        .padding(Padding::from([theme.space_xxs(), theme.space_l()]))
-        .push(cosmic::widget::text::body(mode))
-        .push(cosmic::widget::text::caption(description))
-        .push(cosmic::widget::Space::new(Length::Fill, 12))
+    let content = column::with_capacity(4)
+        .padding([space_xxs, space_l])
+        .push(text::body(mode))
+        .push(text::caption(description))
+        .push(vertical_space().height(12))
         .push_maybe(button.map(|(text, message)| {
             button::text(text)
                 .class(cosmic::theme::Button::Link)
                 .trailing_icon(icon::from_name("go-next-symbolic").size(16))
-                .padding(0)
                 .on_press(message)
         }));
 
     if has_checkmark {
         row::with_capacity(2)
-            .align_items(Alignment::Center)
+            .align_y(Alignment::Center)
             .push(content)
             .push(icon::from_name("object-select-symbolic").size(24))
             .apply(Element::from)
-            .apply(cosmic::widget::list::container)
+            .apply(container)
+            .class(cosmic::theme::Container::List)
+            .padding(8)
+            .width(Length::Fill)
             .into()
     } else {
-        cosmic::widget::list::container(content).into()
+        container(content)
+            .class(cosmic::theme::Container::List)
+            .padding(8)
+            .width(Length::Fill)
+            .into()
     }
 }
 
@@ -50,14 +58,15 @@ impl super::Page {
 
         // Displays the night light status, and a button for configuring it.
         container = container.add(
-            cosmic::widget::settings::item::builder(&*super::text::NIGHT_LIGHT)
+            settings::item::builder(&*super::text::NIGHT_LIGHT)
                 .description(&*super::text::NIGHT_LIGHT_DESCRIPTION)
                 .control(
                     row()
-                        .align_items(Alignment::Center)
-                        .push(toggler(self.config.night_light_enabled, |enable| {
-                            Message::NightLight(NightLight::Toggle(enable))
-                        }))
+                        .align_y(Alignment::Center)
+                        .push(
+                            toggler(self.config.night_light_enabled)
+                                .on_toggle(Message::NightLight(NightLight::Toggle)),
+                        )
                         .push(
                             button::icon(icon::from_name("go-next-symbolic"))
                                 .extra_small()

--- a/cosmic-settings/src/pages/networking/vpn/mod.rs
+++ b/cosmic-settings/src/pages/networking/vpn/mod.rs
@@ -835,7 +835,7 @@ fn devices_view() -> Section<crate::pages::Message> {
 
                         let widget = widget::settings::item_row(vec![
                             identifier.into(),
-                            widget::horizontal_space().width(Length::Fill).into(),
+                            widget::horizontal_space().into(),
                             controls.into(),
                         ]);
 

--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -676,7 +676,7 @@ fn devices_view() -> Section<crate::pages::Message> {
 
                         let widget = widget::settings::item_row(vec![
                             identifier.into(),
-                            widget::horizontal_space().width(Length::Fill).into(),
+                            widget::horizontal_space().into(),
                             controls.into(),
                         ]);
 

--- a/cosmic-settings/src/pages/networking/wired.rs
+++ b/cosmic-settings/src/pages/networking/wired.rs
@@ -541,7 +541,7 @@ impl Page {
 
                     let widget = widget::settings::item_row(vec![
                         identifier.into(),
-                        widget::horizontal_space().width(Length::Fill).into(),
+                        widget::horizontal_space().into(),
                         controls.into(),
                     ]);
 

--- a/cosmic-settings/src/pages/time/date.rs
+++ b/cosmic-settings/src/pages/time/date.rs
@@ -6,7 +6,6 @@ use std::str::FromStr;
 use chrono::{Datelike, Timelike};
 use cosmic::{
     cosmic_config::{self, ConfigGet, ConfigSet},
-    iced::Length,
     iced_core::text::Wrapping,
     widget::{self, dropdown, settings},
     Apply, Element, Task,
@@ -339,7 +338,7 @@ impl Page {
     fn timezone_context_item<'a>(&self, id: usize, timezone: &'a str) -> Element<'a, Message> {
         widget::button::custom(widget::settings::item_row(vec![
             widget::text::body(timezone).wrapping(Wrapping::Word).into(),
-            widget::horizontal_space().width(Length::Fill).into(),
+            widget::horizontal_space().into(),
         ]))
         .on_press(Message::Timezone(id))
         .class(cosmic::theme::Button::Icon)

--- a/cosmic-settings/src/pages/time/region.rs
+++ b/cosmic-settings/src/pages/time/region.rs
@@ -331,7 +331,7 @@ impl Page {
                         })
                         .wrapping(Wrapping::Word)
                         .into(),
-                    widget::horizontal_space().width(Length::Fill).into(),
+                    widget::horizontal_space().into(),
                     if is_installed {
                         widget::icon::from_name("object-select-symbolic")
                             .size(16)

--- a/cosmic-settings/src/widget/mod.rs
+++ b/cosmic-settings/src/widget/mod.rs
@@ -90,7 +90,7 @@ pub fn search_page_link<Message: 'static>(title: &str) -> button::TextButton<Mes
 pub fn page_title<Message: 'static>(page: &page::Info) -> Element<Message> {
     row::with_capacity(2)
         .push(text::title3(page.title.as_str()))
-        .push(horizontal_space().width(Length::Fill))
+        .push(horizontal_space())
         .into()
 }
 
@@ -110,9 +110,9 @@ pub fn display_container<'a, Message: 'a>(widget: Element<'a, Message>) -> Eleme
         .class(crate::theme::display_container_frame());
 
     row::with_capacity(3)
-        .push(horizontal_space().width(Length::Fill))
+        .push(horizontal_space())
         .push(display)
-        .push(horizontal_space().width(Length::Fill))
+        .push(horizontal_space())
         .padding([0, 0, 8, 0])
         .into()
 }
@@ -190,7 +190,7 @@ pub fn sub_page_header<'a, Message: 'static + Clone>(
 pub fn go_next_item<Msg: Clone + 'static>(description: &str, msg: Msg) -> cosmic::Element<'_, Msg> {
     settings::item_row(vec![
         text::body(description).wrapping(Wrapping::Word).into(),
-        horizontal_space().width(Length::Fill).into(),
+        horizontal_space().into(),
         icon::from_name("go-next-symbolic").size(16).icon().into(),
     ])
     .apply(widget::container)
@@ -208,7 +208,7 @@ pub fn go_next_with_item<'a, Msg: Clone + 'static>(
 ) -> cosmic::Element<'_, Msg> {
     settings::item_row(vec![
         text::body(description).wrapping(Wrapping::Word).into(),
-        horizontal_space().width(Length::Fill).into(),
+        horizontal_space().into(),
         widget::row::with_capacity(2)
             .push(item)
             .push(icon::from_name("go-next-symbolic").size(16).icon())


### PR DESCRIPTION
This makes the applet name centered if it doesn't have a description, same as on the main applet page.

I don't have multiple displays, so I didn't test the Display page changes, but they should match designs (provided the designs I'm looking at are up-to-date).
Edit: Or should the padding for display arrangement be removed (I can't test so I'm not sure what that looks like), since it doesn't seem to be the same in all places in the designs?