### PR TITLE
[Bluetooth] Remove settings cog next to Bluetooth toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3993,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a611371471e98973dbcab4e0ec66c31a10bc356eeb4d54a0e05eac8158fe38c"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -7775,7 +7775,7 @@ checksum = "c89532cc712a2adb119eb4d09694b402576052254d0bb284f82ac1c47fb786ad"
 dependencies = [
  "bitflags 2.6.0",
  "downcast-rs",
- "io-lifetimes 2.0.3",
+ "io-lifetimes 2.0.4",
  "rustix 0.38.41",
  "wayland-backend",
  "wayland-scanner",

--- a/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
@@ -466,7 +466,6 @@ pub fn lists<
         let cosmic::cosmic_theme::Spacing {
             space_xxs,
             space_xs,
-            space_s,
             ..
         } = theme::active().cosmic().spacing;
         let page = page.inner();
@@ -568,7 +567,6 @@ pub fn lists<
             .spacing(space_xxs)
             .into(),
         ])
-        .padding([0, space_s])
         .spacing(space_xs)
         .apply(Element::from)
         .map(msg_map)

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -115,7 +115,6 @@ bluetooth = Bluetooth
     .disconnect = Disconnect
     .forget = Forget
     .dbus-error = An error has occurred while interacting with DBus: { $why }
-    .show-device-without-name = Show devices without name
 
 bluetooth-paired = Previously Connected Devices
     .connect = Connect


### PR DESCRIPTION
This removes extra horizontal padding from the applet list, which caused misalignment.
Didn't notice it with the previous PR.

Edit: The second commit should fix #797. I think the logic is correct (or more the removal of it), but have no idea how to test.
Should also fix #708 on the Bluetooth page, since it seems `settings::item_row` causes the issue, while `settings::item::builder` works properly.