### PR TITLE
Updated appearance gap min

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -563,6 +563,20 @@ impl Page {
                     .set_active_hint(config, active_hint)
                     .unwrap_or_default()
                 {
+                    // Update the gap if it's less than the active hint
+                    if active_hint > self.theme_builder.gaps.1 {
+                        let mut gaps = self.theme_builder.gaps;
+                        gaps.1 = active_hint;
+                        if self
+                            .theme_builder
+                            .set_gaps(config, gaps)
+                            .unwrap_or_default()
+                        {
+                            self.theme_config_write("gaps", gaps);
+                        }
+                    }
+
+                    // Update the active_hint in the config
                     self.theme_config_write("active_hint", active_hint);
                 }
             }
@@ -576,7 +590,12 @@ impl Page {
 
                 let mut gaps = self.theme_builder.gaps;
 
-                gaps.1 = gap;
+                // Ensure that the gap is never less than what the active hint size is.
+                gaps.1 = if gap < self.theme_builder.active_hint {
+                    self.theme_builder.active_hint
+                } else {
+                    gap
+                };
 
                 if self
                     .theme_builder

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -1983,7 +1983,7 @@ pub fn window_management() -> Section<crate::pages::Message> {
                         page.theme_builder.gaps.1.to_string(),
                         page.theme_builder.gaps.1,
                         1,
-                        page.theme.active_hint,
+                        page.theme_builder.active_hint,
                         500,
                         Message::GapSize,
                     )),


### PR DESCRIPTION
Working on fixing [issue #805](https://github.com/pop-os/cosmic-settings/issues/805)

Updated the appearance page’s gap min to reflect the theme_builder.active_hint value instead of the default theme.active_hint value. I still need to test the change in this commit before merging.