### PR TITLE
Displayed non-matching day and month

### DIFF
--- a/cosmic-settings/src/pages/time/region.rs
+++ b/cosmic-settings/src/pages/time/region.rs
@@ -396,7 +396,7 @@ impl Page {
 
         let dtf = DateTimeFormatter::try_new_experimental(&locale.into(), options).unwrap();
 
-        let datetime = DateTime::try_new_gregorian_datetime(1776, 7, 4, 12, 0, 0)
+        let datetime = DateTime::try_new_gregorian_datetime(1776, 7, 14, 12, 0, 0)
             .unwrap()
             .to_iso()
             .to_any();
@@ -436,7 +436,7 @@ impl Page {
 
         let dtf = DateTimeFormatter::try_new_experimental(&locale.into(), options).unwrap();
 
-        let datetime = DateTime::try_new_gregorian_datetime(1776, 7, 4, 12, 0, 0)
+        let datetime = DateTime::try_new_gregorian_datetime(1776, 7, 14, 12, 0, 0)
             .unwrap()
             .to_iso()
             .to_any();
@@ -472,7 +472,7 @@ impl Page {
 
         let dtf = DateTimeFormatter::try_new_experimental(&locale.into(), options).unwrap();
 
-        let datetime = DateTime::try_new_gregorian_datetime(1776, 7, 4, 12, 0, 0)
+        let datetime = DateTime::try_new_gregorian_datetime(1776, 7, 14, 12, 0, 0)
             .unwrap()
             .to_iso()
             .to_any();


### PR DESCRIPTION
# Issue
When displaying date format, we used to write 07/04/1776. But with that, it is not obvious, is it DD/MM/YYYY or MM/DD/YYYY

# Fix
Change day number, so it is greater than 12

![image](https://github.com/user-attachments/assets/8600b582-5e59-476c-85e6-ad6b47951fd4)


P.S. Yeah, 2 lines lower there is **Date & Time** section, but nevertheless, this approach looks better