### PR TITLE
Fix polish translation of automatically hide dock

### DIFF
--- a/i18n/pl/cosmic_settings.ftl
+++ b/i18n/pl/cosmic_settings.ftl
@@ -270,7 +270,7 @@ panel-appearance = Wygląd
 
 panel-behavior-and-position = Funkcjonowanie i Pozycja
     .autohide = Automatycznie chowaj panel
-    .dock-autohide = Automatycznie chowaj panel
+    .dock-autohide = Automatycznie chowaj dok
     .position = Pozycja na ekranie
     .display = Pokaż na wyświetlaczu
 


### PR DESCRIPTION
In "Automatically hide panel" and "automatically hide dock"  in Polish both "panel" and "dock" are translated as panel.
Described in issue 
[BUG] Wrong translation of "Automatically hide dock" in Polish #878 