### PR TITLE
refactor: Improve terminal binary path detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,7 @@ dependencies = [
  "udev",
  "upower_dbus",
  "url",
+ "which",
  "xkb-data",
  "zbus 4.4.0",
  "zbus_polkit",
@@ -2266,6 +2267,12 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -7898,6 +7905,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "widestring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8356,6 +8375,12 @@ checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ git = "https://github.com/pop-os/cosmic-randr"
 [workspace.dependencies.sctk]
 git = "https://github.com/smithay/client-toolkit/"
 package = "smithay-client-toolkit"
+which = "4.4"
+
 # rev = "c583de8"
 
 [profile.release-with-debug]

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -74,6 +74,7 @@ rustix = "0.38.41"
 gettext-rs = { version = "0.7.2", features = [
     "gettext-system",
 ], optional = true }
+which = "7.0.1"
 
 [dependencies.cosmic-settings-subscriptions]
 git = "https://github.com/pop-os/cosmic-settings-subscriptions"


### PR DESCRIPTION
Replace alternative path detection with more robust binary path finding
Use which crate to locate terminal binaries
Extract binary path from desktop entry
Simplify symlink creation for x-terminal-emulator

It is important to mention that:

    I will still send the PR regarding this in the cosmic-files repository
    the functionality is not 100% complete, in developer mode, when we open cosmic-settings and cosmic-files and I change the terminal and try to click on open terminal in cosmic-files, cosmic files will open the terminal that was already selected, so if I am in cosmic-terminal when I open it and switch to warp and click on open in terminal it will open the old terminal and not warp (which was selected) so we still need to implement some function for cosmic-files to get the changes in real time from the cosmic-settings terminal change
    but if you close cosmic files and hit cargo run again, it opens the correct terminal (which would be warp).

continuation and correction of the PR #935 
