### PR TITLE
Add window edge snapping setting

### DIFF
--- a/cosmic-settings/src/pages/desktop/window_management.rs
+++ b/cosmic-settings/src/pages/desktop/window_management.rs
@@ -78,7 +78,7 @@ impl Default for Page {
             })
             .unwrap_or(true);
 
-        let window_snap_threshold = comp_config
+        let edge_snap_threshold = comp_config
             .get("window_snap_threshold")
             .inspect_err(|err| {
                 if !matches!(err, cosmic_config::Error::NoConfigDirectory) {
@@ -101,7 +101,7 @@ impl Default for Page {
             focus_delay_text: format!("{focus_follows_cursor_delay}"),
             cursor_follows_focus,
             show_active_hint,
-            edge_snap_threshold: window_snap_threshold,
+            edge_snap_threshold,
         }
     }
 }

--- a/cosmic-settings/src/pages/desktop/window_management.rs
+++ b/cosmic-settings/src/pages/desktop/window_management.rs
@@ -79,10 +79,10 @@ impl Default for Page {
             .unwrap_or(true);
 
         let edge_snap_threshold = comp_config
-            .get("window_snap_threshold")
+            .get("edge_snap_threshold")
             .inspect_err(|err| {
                 if !matches!(err, cosmic_config::Error::NoConfigDirectory) {
-                    error!(?err, "Failed to read config 'window_snap_threshold'")
+                    error!(?err, "Failed to read config 'edge_snap_threshold'")
                 }
             })
             .unwrap_or(0);

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -312,6 +312,9 @@ focus-navigation = Focus Navigation
     .focus-follows-cursor-delay = Focus follows cursor delay in ms
     .cursor-follows-focus = Cursor follows focus
 
+floating-layout = Floating Layout
+    .window-snap-threshold = Window snap-to-edge threshold
+
 ## Desktop: Workspaces
 
 workspaces = Workspaces

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -302,6 +302,8 @@ super-key = Super key action
     .applications = Open Applications
     .disable = Disable
 
+edge-gravity = Floating windows gravitate to nearby edges
+
 window-controls = Window Controls
     .maximize = Show maximize button
     .minimize = Show minimize button
@@ -311,9 +313,6 @@ focus-navigation = Focus Navigation
     .focus-follows-cursor = Focus follows cursor
     .focus-follows-cursor-delay = Focus follows cursor delay in ms
     .cursor-follows-focus = Cursor follows focus
-
-floating-layout = Floating Layout
-    .window-snap-threshold = Window snap-to-edge threshold
 
 ## Desktop: Workspaces
 


### PR DESCRIPTION
Relies on https://github.com/pop-os/cosmic-comp/pull/1189

~~Creates a new section in the "Window Managment" page called "Floating Layout", which has the "Window snap-to-edge threshold setting" that defaults to `0` (no edge snapping).~~

Adds a "Floating windows gravitate to nearby edges" toggle in the "Window Managment" page that sets the `edge_snap_threshold` cosmic-comp configuration to 10 pixels if enabled, or 0 pixels (off) if disabled.