### PR TITLE
improve(bluetooth): ignore devices with unknown type and without alias

### DIFF
--- a/cosmic-settings/src/pages/bluetooth/backend.rs
+++ b/cosmic-settings/src/pages/bluetooth/backend.rs
@@ -158,6 +158,8 @@ impl PartialEq for Adapter {
 
 impl Eq for Adapter {}
 
+const default_device_icon: &str = "bluetooth-symbolic";
+
 fn device_type_to_icon(device_type: &str) -> &'static str {
     match device_type {
         "computer" => "laptop-symbolic",
@@ -173,7 +175,7 @@ fn device_type_to_icon(device_type: &str) -> &'static str {
         "input-mouse" => "input-mouse-symbolic",
         "printer" => "printer-network-symbolic",
         "camera-photo" => "camera-photo-symbolic",
-        _ => "bluetooth-symbolic",
+        _ => default_device_icon,
     }
 }
 
@@ -264,6 +266,10 @@ impl Device {
     #[must_use]
     pub fn has_alias(&self) -> bool {
         self.alias.is_some()
+    }
+    #[must_use]
+    pub fn is_known_device_type(&self) -> bool {
+        self.icon != default_device_icon
     }
     #[must_use]
     pub fn alias_or_addr(&self) -> &str {

--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -746,6 +746,10 @@ fn available_devices() -> Section<crate::pages::Message> {
                         return None::<Element<'_, Message>>;
                     }
 
+                    if !device.is_known_device_type() && !device.has_alias() {
+                        return None::<Element<'_, Message>>;
+                    }
+
                     let mut items = vec![
                         widget::icon::from_name(device.icon).size(16).into(),
                         text(device.alias_or_addr()).wrapping(Wrapping::Word).into(),


### PR DESCRIPTION
The list of nearby bluetooth devices without an alias (only MAC address is displayed) is very long in my case (20+), making it difficult to select a device for pairing, especially since new devices are constantly being added and removed.

I installed blueman to see how it handles these devices, and it also does not display them.

Instead of ignoring all devices without an alias, I applied the filter only to unknown device types.

I also considered adding an option to enable/disable the filtering, but I'm not sure if it's really necessary or if anyone would actually use it.