### PR TITLE
Removing duplicate fluent username/password nodes

### DIFF
--- a/i18n/de/cosmic_settings.ftl
+++ b/i18n/de/cosmic_settings.ftl
@@ -783,8 +783,6 @@ administrator = Administrator
 add-user = Benutzer hinzufügen
 remove-user = Benutzer entfernen
 full-name = Vollständiger Name
-username = Benutzername
-password = Passwort
 
 ## System: Standardanwendungen
 

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -784,8 +784,6 @@ administrator = Administrator
 add-user = Add user
 remove-user = Remove user
 full-name = Full name
-#username = Username
-#password = Password
 
 ## System: Default Applications
 

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -784,8 +784,8 @@ administrator = Administrator
 add-user = Add user
 remove-user = Remove user
 full-name = Full name
-username = Username
-password = Password
+#username = Username
+#password = Password
 
 ## System: Default Applications
 

--- a/i18n/fr/cosmic_settings.ftl
+++ b/i18n/fr/cosmic_settings.ftl
@@ -32,7 +32,7 @@ no-vpn = Pas de connexion VPN disponible.
 password = Mot de passe
 remove = Supprimer
 settings = Paramètres
-username = Identifiant
+username = Nom d'utilisateur
 visible-networks = Réseaux visibles
 
 auth-dialog = Authentification requise
@@ -778,8 +778,6 @@ administrator = Administrateur
 add-user = Ajouter l'utilisateur
 remove-user = Supprimer l'utilisateur
 full-name = Nom complet
-username = Nom d'utilisateur
-password = Mot de passe
 
 ## System: Default Applications
 

--- a/i18n/ga/cosmic_settings.ftl
+++ b/i18n/ga/cosmic_settings.ftl
@@ -782,8 +782,6 @@ administrator = Riarthóir
 add-user = Cuir úsáideoir leis
 remove-user = Bain úsáideoir
 full-name = Ainm iomlán
-username = Ainm úsáideora
-password = Pasfhocal
 
 ## System: Default Applications
 

--- a/i18n/it/cosmic_settings.ftl
+++ b/i18n/it/cosmic_settings.ftl
@@ -787,8 +787,6 @@ administrator = Amministratore
 add-user = Aggiungi utente
 remove-user = Rimuovi utente
 full-name = Nome completo
-username = Nome utente
-password = Password
 
 ## System: Default Applications
 

--- a/i18n/nl/cosmic_settings.ftl
+++ b/i18n/nl/cosmic_settings.ftl
@@ -786,8 +786,6 @@ administrator = Systeembeheerder (root)
 add-user = Gebruiker toevoegen
 remove-user = Gebruiker verwijderen
 full-name = Volledige naam
-username = Gebruikersnaam
-password = Wachtwoord
 
 ## System: Default Applications
 

--- a/i18n/pl/cosmic_settings.ftl
+++ b/i18n/pl/cosmic_settings.ftl
@@ -801,8 +801,6 @@ administrator = Administrator
 add-user = Dodaj użytkownika
 remove-user = Usuń użytkownika
 full-name = Pełna nazwa
-username = Nazwa użytkownika
-password = Hasło
 
 ## System: Domyślne aplikacje
 

--- a/i18n/pt-BR/cosmic_settings.ftl
+++ b/i18n/pt-BR/cosmic_settings.ftl
@@ -782,8 +782,6 @@ administrator = Administrador
 add-user = Adicionar usuário
 remove-user = Remover usuário
 full-name = Nome completo
-username = Usuário
-password = Senha
 
 ## System: Default Applications
 

--- a/i18n/sv/cosmic_settings.ftl
+++ b/i18n/sv/cosmic_settings.ftl
@@ -524,8 +524,6 @@ administrator = Administratör
 add-user = Lägg till användare
 remove-user = Ta bort användare
 full-name = Fullständigt namn
-username = Användarnamn
-password = Lösenord
 
 users = Användare
     .desc = Autentisering och login, låsskärm.

--- a/i18n/th/cosmic_settings.ftl
+++ b/i18n/th/cosmic_settings.ftl
@@ -769,8 +769,6 @@ administrator = ผู้ดูแลระบบ
 add-user = เพิ่มผู้ใช้
 remove-user = ลบผู้ใช้
 full-name = ชื่อเต็ม
-username = ชื่อผู้ใช้
-password = รหัสผ่าน
 
 ## System: Default Applications
 

--- a/i18n/tr/cosmic_settings.ftl
+++ b/i18n/tr/cosmic_settings.ftl
@@ -783,8 +783,6 @@ administrator = Yönetici
 add-user = Kullanıcı ekle
 remove-user = Kullanıcı kaldır
 full-name = Tam ad
-username = Kullanıcı adı
-password = Parola
 
 ## System: Default Applications
 


### PR DESCRIPTION
**changes tl;dr**
- for some reason, debugging cosmic-settings would occasionally cause it to crash due to a duplicate `username` and `password` keys in fluent
- duplicates have been removed
- in the case of french, the 2 usernames had different translations, so i went with the one that seemed to make most contextual sense (apologies in advance if wrong)

error i got:
```
/home/user/RustroverProjects/s76/cosmic-settings/target/debug/cosmic-settings
  ERROR  Error while adding resource to bundle: Overriding { kind: Message, id: "username" }.
    at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/i18n-embed-0.15.3/src/fluent.rs:35 on main

  ERROR  Error while adding resource to bundle: Overriding { kind: Message, id: "password" }.
    at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/i18n-embed-0.15.3/src/fluent.rs:35 on main

  ERROR  Error while adding resource to bundle: Overriding { kind: Message, id: "username" }.
    at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/i18n-embed-0.15.3/src/fluent.rs:35 on main

  ERROR  Error while adding resource to bundle: Overriding { kind: Message, id: "password" }.
    at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/i18n-embed-0.15.3/src/fluent.rs:35 on main
```