### PR TITLE
Respect default terminal in cosmic_settings_config (keybind SUPER+T) when changed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "jobserver",
  "libc",
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "cosmic-comp-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-comp#2678cf41b2550d4959ac74b3da14761d93a74f3d"
+source = "git+https://github.com/pop-os/cosmic-comp#2bf74951ea2d8f41dbc468506bca367663a88fab"
 dependencies = [
  "cosmic-config",
  "input",
@@ -1519,7 +1519,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1541,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "bitflags 2.8.0",
  "bytes",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "futures",
  "iced_core",
@@ -3293,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "bitflags 2.8.0",
  "bytemuck",
@@ -3315,7 +3315,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3327,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3359,7 +3359,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.8.0",
@@ -3390,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3409,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -4414,7 +4414,7 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic#0b7e23444afb3f351cd947c52babb6b87f30381d"
+source = "git+https://github.com/pop-os/libcosmic#ccc1068d9fd894334feef7d50a7a2b6930c7a34f"
 dependencies = [
  "apply",
  "ashpd 0.9.2",


### PR DESCRIPTION
**changes tl;dr**
- you can change your default terminal via COSMIC settings, but cosmic_settings_config is by default bound to `cosmic-term`
- when we change the default terminal, persist this setting if possible by grabbing the relevant `exec` from its FreeDesktop path

demonstration vid:

https://github.com/user-attachments/assets/2d7b0592-a440-422c-837f-7b4e75e5ed30

resolves https://github.com/pop-os/cosmic-epoch/issues/1557