### PR TITLE
fix(power): Fix battery charged icon when a device is fully charged.

### DIFF
--- a/cosmic-settings/src/pages/power/backend/mod.rs
+++ b/cosmic-settings/src/pages/power/backend/mod.rs
@@ -308,6 +308,10 @@ impl Battery {
 
         let is_charging = matches!(battery_state, BatteryState::Charging);
 
+        let charged = matches!(battery_state, BatteryState::FullyCharged)
+            || matches!(battery_state, BatteryState::Charging)
+                && (percent - 100.0_f64).abs() < f64::EPSILON;
+
         if !is_charging {
             if let Ok(time) = proxy.time_to_empty().await {
                 if let Ok(dur) = Duration::from_std(std::time::Duration::from_secs(time as u64)) {
@@ -339,7 +343,12 @@ impl Battery {
         } else {
             0
         };
-        let charging = if is_charging { "charging-" } else { "" };
+        // Due to not having a specific icon for charged we use the charging one
+        let charging = if is_charging || charged {
+            "charging-"
+        } else {
+            ""
+        };
 
         let icon_name =
             format!("cosmic-applet-battery-level-{battery_percent}-{charging}symbolic",);


### PR DESCRIPTION
fixes #742 .

1. I have a detailed explanation on the issue
2. There is no specific icon for -charged so we use the -charging one which is the same
3. You can find the changed gnome like icons like this one here : https://github.com/ZorinOS/zorin-icon-themes/blob/38ffff902f67c8016b5fcb6654affb17f361ef28/ZorinBlue-Dark/scalable/status/battery-level-100-charged-symbolic.svg?plain=1
4. The code is conforming now to the gnome-shells from here:  https://github.com/GNOME/gnome-shell/blob/main/js/ui/status/system.js#L76-L85


Visual of the issue:

<img width="525" alt="Screenshot 2025-02-15 at 12 36 07 AM" src="https://github.com/user-attachments/assets/78821d80-86d9-4276-9449-668b68128903" />
