### PR TITLE
Prevent checkmark clipping

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/font_config.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/font_config.rs
@@ -71,9 +71,8 @@ pub fn selection_context<'a>(
 ) -> Element<'a, super::Message> {
     let space_l = theme::active().cosmic().spacing.space_l;
 
-    let svg_accent = Rc::new(|theme: &cosmic::Theme| {
-        let color = theme.cosmic().accent_color().into();
-        svg::Style { color: Some(color) }
+    let svg_accent = Rc::new(|theme: &cosmic::Theme| svg::Style {
+        color: Some(theme.cosmic().accent_color().into()),
     });
 
     let search_input = widget::search_input(fl!("type-to-search"), search)
@@ -86,8 +85,8 @@ pub fn selection_context<'a>(
             settings::item_row(vec![
                 widget::text::body(&**family)
                     .wrapping(Wrapping::Word)
+                    .width(cosmic::iced::Length::Fill)
                     .into(),
-                widget::horizontal_space().into(),
                 if selected {
                     widget::icon::from_name("object-select-symbolic")
                         .size(16)

--- a/cosmic-settings/src/pages/desktop/appearance/icon_themes.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/icon_themes.rs
@@ -63,7 +63,7 @@ pub fn button(
             )
             .on_press(Message::IconTheme(id))
             .selected(selected)
-            .padding([theme.space_xs(), theme.space_xs() + 1])
+            .padding(theme.space_xs())
             // Image button's style mostly works, but it needs a background to fit the design
             .class(button::ButtonClass::Custom {
                 active: Box::new(move |focused, theme| {

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -408,6 +408,8 @@ impl Page {
                 )
                 .row_spacing(theme.space_xs())
                 .column_spacing(theme.space_xs())
+                .apply(container)
+                .center_x(Length::Fill)
                 .into()
             ])
             .spacing(theme.space_xxs())

--- a/cosmic-settings/src/pages/time/region.rs
+++ b/cosmic-settings/src/pages/time/region.rs
@@ -343,8 +343,8 @@ impl Page {
                             cosmic::theme::Text::Default
                         })
                         .wrapping(Wrapping::Word)
+                        .width(Length::Fill)
                         .into(),
-                    widget::horizontal_space().into(),
                     if is_installed {
                         widget::icon::from_name("object-select-symbolic")
                             .size(16)
@@ -549,6 +549,7 @@ impl Page {
                             cosmic::theme::Text::Default
                         })
                         .wrapping(Wrapping::Word)
+                        .width(Length::Fill)
                         .into(),
                     if is_selected {
                         widget::icon::from_name("object-select-symbolic")

--- a/cosmic-settings/src/widget/mod.rs
+++ b/cosmic-settings/src/widget/mod.rs
@@ -23,7 +23,7 @@ pub fn color_picker_context_view<'a, Message: Clone + 'static>(
     let theme = theme::active();
     let spacing = &theme.cosmic().spacing;
 
-    let description = description.map(|description| text(description).width(Length::Fill));
+    let description = description.map(|description| text::caption(description));
 
     let color_picker = model
         .builder(on_update)
@@ -35,15 +35,13 @@ pub fn color_picker_context_view<'a, Message: Clone + 'static>(
             fl!("copied-to-clipboard"),
         )
         .apply(container)
-        .width(Length::Fixed(248.0))
-        .align_x(Alignment::Center)
+        .center_x(Length::Fixed(248.0))
         .apply(container)
         .center_x(Length::Fill);
 
     cosmic::widget::column()
         .push_maybe(description)
         .push(color_picker)
-        .padding(spacing.space_l)
         .align_x(Alignment::Center)
         .spacing(spacing.space_m)
         .width(Length::Fill)
@@ -103,17 +101,13 @@ pub fn unimplemented_page<Message: 'static>() -> Element<'static, Message> {
 
 #[must_use]
 pub fn display_container<'a, Message: 'a>(widget: Element<'a, Message>) -> Element<'a, Message> {
-    let display = container(widget)
+    container(widget)
         .class(crate::theme::display_container_screen())
         .apply(container)
         .padding(4)
-        .class(crate::theme::display_container_frame());
-
-    row::with_capacity(3)
-        .push(horizontal_space())
-        .push(display)
-        .push(horizontal_space())
-        .padding([0, 0, 8, 0])
+        .class(crate::theme::display_container_frame())
+        .apply(container)
+        .center_x(Length::Fill)
         .into()
 }
 


### PR DESCRIPTION
This prevents the checkmark from being clipped in the Font and Region selection drawers when resizing the window, and makes the icon theme selection buttons centered in the drawer.
Also includes some minor cleanup.
Fixes #895.