### PR TITLE
improv: Make custom scale a slider & hide it unless asked for

### DIFF
--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -960,6 +960,8 @@ impl Page {
 
     /// Set the scale preset of the active display.
     pub fn set_scale_preset(&mut self, option: usize) -> Task<app::Message> {
+        self.cache.scale_selected = Some(option);
+
         if scale_is_custom(option) {
             self.custom_scale = Some(self.config.scale);
 
@@ -974,7 +976,6 @@ impl Page {
             ScaleValue::Preset(value) => value,
         };
 
-        self.cache.scale_selected = Some(option);
         self.set_scale(scale)
     }
 

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -382,7 +382,8 @@ display = Displays
     .refresh-rate = Refresh rate
     .resolution = Resolution
     .scale = Scale
-    .additional-scale-options = Additional scale options
+    .custom-scale-option = Custom
+    .custom-scale = Custom Scale
 
 mirroring = Mirroring
     .id = Mirroring { $id }


### PR DESCRIPTION
Fixes #999

https://github.com/user-attachments/assets/eb4cbc53-61d7-4037-88c8-888eedf8cd32

I have not tested this with multiple monitors yet, but it *should* work fine.

Due to how the page is loaded, if you set the custom slider to a value that matches a preset, it will reset to the preset value in the dropdown when the app is reloaded and hide the slider.