### PR TITLE
Bump freedesktop-desktop-entry to 0.7.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,24 +1013,24 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cached"
-version = "0.54.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
+checksum = "b0839c297f8783316fcca9d90344424e968395413f0662a5481f79c6648bbc14"
 dependencies = [
  "ahash 0.8.11",
  "cached_proc_macro",
  "cached_proc_macro_types",
  "hashbrown 0.14.5",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "web-time",
 ]
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
+checksum = "673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -2647,17 +2647,15 @@ dependencies = [
 
 [[package]]
 name = "freedesktop-desktop-entry"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016f6ee9509f11c985aa402451f4ee900d1fafeb501a4c3d734ebecfc1130e05"
+checksum = "e6a4cdc5571033a6a329b9e8a8430594d1e3b60f42bb79e79686cadef34740ea"
 dependencies = [
  "cached",
- "dirs",
  "gettext-rs",
  "log",
  "memchr",
  "strsim 0.11.1",
- "textdistance",
  "thiserror 2.0.11",
  "xdg",
 ]
@@ -7046,12 +7044,6 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textdistance"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa672c55ab69f787dbc9126cc387dbe57fdd595f585e4524cf89018fa44ab819"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "cosmic-mime-apps"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-mime-apps#a5aefbd2e914682c151f3b8054dd711e7f57941d"
+source = "git+https://github.com/pop-os/cosmic-mime-apps#b0b85933dd7bc6e6f51d3d2a7312dbd6dc162cf3"
 dependencies = [
  "freedesktop-desktop-entry",
  "mime 0.3.17",

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -33,7 +33,7 @@ derive_setters = "0.1.6"
 dirs = "5.0.1"
 downcast-rs = "1.2.1"
 eyre = "0.6.12"
-freedesktop-desktop-entry = "0.7.7"
+freedesktop-desktop-entry = "0.7.8"
 futures = "0.3.31"
 hostname-validator = "1.1.1"
 hostname1-zbus = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }


### PR DESCRIPTION
part of https://github.com/pop-os/freedesktop-desktop-entry/issues/41

draft until https://github.com/pop-os/cosmic-mime-apps/pull/1 merged