### PR TITLE
fix: 'open' arrow icon on user details

### DIFF
--- a/cosmic-settings/src/pages/system/users/mod.rs
+++ b/cosmic-settings/src/pages/system/users/mod.rs
@@ -681,7 +681,7 @@ fn user_list() -> Section<crate::pages::Message> {
                         icon::from_name(if expanded {
                             "go-up-symbolic"
                         } else {
-                            "go-next-symbolic"
+                            "go-down-symbolic"
                         })
                         .icon()
                         .size(16)


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-settings/issues/1045