### PR TITLE
[Startup apps] Improve styling

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -22,23 +22,21 @@ use crate::pages::sound;
 use crate::pages::{self, system, time};
 use crate::subscription::desktop_files;
 use crate::widget::{page_title, search_header};
-use cosmic::app::context_drawer::ContextDrawer;
 #[cfg(feature = "wayland")]
 use cosmic::cctk::{sctk::output::OutputInfo, wayland_client::protocol::wl_output::WlOutput};
-use cosmic::iced::Subscription;
-use cosmic::widget::{self, button, row, text_input};
 use cosmic::{
     Element,
-    app::{Core, Task},
+    app::{Core, Task, context_drawer::ContextDrawer},
     iced::{
-        self, Length,
+        self, Length, Subscription,
         event::{self, PlatformSpecific},
         window,
     },
     prelude::*,
     surface,
     widget::{
-        column, container, icon, id_container, nav_bar, scrollable, segmented_button, settings,
+        button, column, container, icon, id_container, nav_bar, row, scrollable, segmented_button,
+        settings, text_input,
     },
 };
 #[cfg(feature = "wayland")]
@@ -800,9 +798,7 @@ impl cosmic::Application for SettingsApp {
             return self.page_container(row::row());
         };
 
-        container(view)
-            .padding([cosmic::theme::active().cosmic().space_xxs(), 0])
-            .into()
+        container(view).into()
     }
 
     #[allow(clippy::too_many_lines)]
@@ -999,11 +995,8 @@ impl SettingsApp {
             .height(Length::Fill)
             .apply(|w| id_container(w, self.id()));
 
-        widget::column::with_capacity(3)
+        column::with_capacity(2)
             .push(self.page_container(header))
-            .push(widget::vertical_space().height(Length::Fixed(
-                cosmic::theme::active().cosmic().space_m().into(),
-            )))
             .push(view)
             .height(Length::Fill)
             .into()
@@ -1103,8 +1096,8 @@ impl SettingsApp {
             {
                 let section = (section.view_fn)(&self.pages, model.as_ref(), section)
                     .map(Message::PageMessage)
-                    .apply(iced::widget::container)
-                    .padding([0, 0, 0, cosmic::theme::active().cosmic().space_xl()]);
+                    .apply(container)
+                    .padding([0, 0, 0, cosmic::theme::active().cosmic().space_l()]);
 
                 sections.push(section.into());
             }
@@ -1137,14 +1130,12 @@ impl SettingsApp {
                 },
             )
             .spacing(theme.cosmic().space_s())
-            .padding(0)
             .apply(|widget| scrollable(self.page_container(widget)).height(Length::Fill))
             .apply(Element::from)
             .map(Message::Page);
 
-        widget::column::with_capacity(3)
+        column::with_capacity(2)
             .push(self.page_container(page_title(&self.pages.info[self.active_page])))
-            .push(widget::vertical_space().height(theme.cosmic().space_m()))
             .push(page_list)
             .height(Length::Fill)
             .into()
@@ -1161,13 +1152,15 @@ impl SettingsApp {
         } else {
             theme.cosmic().space_l()
         };
+        // prevents content from touching window edge on bottom of scroll
+        let bottom_spacer = theme.cosmic().space_m();
 
         container(content.into())
             .max_width(800)
             .width(Length::Fill)
             .apply(container)
             .center_x(Length::Fill)
-            .padding([0, padding])
+            .padding([0, padding, bottom_spacer, padding])
             .into()
     }
 }

--- a/cosmic-settings/src/pages/applications/startup_apps.rs
+++ b/cosmic-settings/src/pages/applications/startup_apps.rs
@@ -310,7 +310,7 @@ impl Page {
         directory_type: DirectoryType,
     ) -> Element<'_, crate::pages::Message> {
         let cosmic::cosmic_theme::Spacing {
-            space_s, space_l, ..
+            space_xs, space_l, ..
         } = cosmic::theme::spacing();
 
         let search = widget::search_input(fl!("type-to-search"), &self.application_search)
@@ -328,26 +328,25 @@ impl Page {
                             || exec.to_lowercase().contains(search_input)
                             || name.to_lowercase().contains(search_input)
                         {
-                            let mut row = widget::row::with_capacity(2).spacing(space_s);
+                            let mut row = widget::row::with_capacity(3)
+                                .spacing(space_xs)
+                                .align_y(Alignment::Center);
 
-                            row = row
-                                .push(icon::from_name(app.icon().unwrap_or("application-default")));
+                            row = row.push(
+                                icon::from_name(app.icon().unwrap_or("application-default"))
+                                    .size(32),
+                            );
 
                             if let Some(name) = app.name(&startup_apps.locales) {
-                                row = row.push(text(name));
+                                row = row.push(text(name).width(Length::Fill));
                             } else {
-                                row = row.push(text(&app.appid));
+                                row = row.push(text(&app.appid).width(Length::Fill));
                             }
+                            row = row.push(widget::button::text(fl!("add")).on_press(
+                                Message::AddStartupApplication(directory_type.clone(), app.clone()),
+                            ));
 
-                            list = list.add(settings::flex_item_row(vec![
-                                row.into(),
-                                widget::button::text(fl!("add"))
-                                    .on_press(Message::AddStartupApplication(
-                                        directory_type.clone(),
-                                        app.clone(),
-                                    ))
-                                    .into(),
-                            ]))
+                            list = list.add(row)
                         }
                     }
                 }
@@ -366,7 +365,9 @@ impl Page {
 
 fn apps() -> Section<crate::pages::Message> {
     let cosmic::cosmic_theme::Spacing {
-        space_xxs, space_s, ..
+        space_xxs,
+        space_xs,
+        ..
     } = cosmic::theme::spacing();
 
     Section::default()
@@ -387,28 +388,32 @@ fn apps() -> Section<crate::pages::Message> {
 
                     if let Some(apps) = startup_apps.apps.get(&directory_type) {
                         for app in apps {
-                            let mut row = widget::row::with_capacity(2).spacing(space_s);
+                            let mut row = widget::row::with_capacity(3)
+                                .spacing(space_xs)
+                                .align_y(Alignment::Center);
 
-                            row = row
-                                .push(icon::from_name(app.icon().unwrap_or("application-default")));
+                            row = row.push(
+                                icon::from_name(app.icon().unwrap_or("application-default"))
+                                    .size(32),
+                            );
 
                             if let Some(name) = app.name(&startup_apps.locales) {
-                                row = row.push(text(name));
+                                row = row.push(text(name).width(Length::Fill));
                             } else {
-                                row = row.push(text(&app.appid));
+                                row = row.push(text(&app.appid).width(Length::Fill));
                             }
 
-                            section = section.add(settings::flex_item_row(vec![
-                                row.into(),
+                            row = row.push(
                                 button::icon(icon::from_name("edit-delete-symbolic"))
                                     .extra_small()
                                     .on_press(Message::RemoveStartupApplication(
                                         directory_type.clone(),
                                         app.clone(),
                                         false,
-                                    ))
-                                    .into(),
-                            ]))
+                                    )),
+                            );
+
+                            section = section.add(row)
                         }
                     }
 

--- a/cosmic-settings/src/pages/applications/startup_apps.rs
+++ b/cosmic-settings/src/pages/applications/startup_apps.rs
@@ -417,11 +417,11 @@ fn apps() -> Section<crate::pages::Message> {
                         }
                     }
 
-                    let add_input_source = widget::button::standard(fl!("startup-apps", "add"))
+                    let add_startup_app = widget::button::standard(fl!("startup-apps", "add"))
                         .on_press(Message::ShowApplicationSidebar(directory_type.clone()));
 
                     view = view.push(section).push(widget::container(
-                        widget::container(add_input_source)
+                        widget::container(add_startup_app)
                             .width(Length::Fill)
                             .align_x(Alignment::End),
                     ));

--- a/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
@@ -1,4 +1,3 @@
-use button::Catalog as ButtonStyleSheet;
 use cosmic::iced::clipboard::dnd::{
     DndAction, DndDestinationRectangle, DndEvent, OfferEvent, SourceEvent,
 };
@@ -267,32 +266,7 @@ impl Page {
                         .spacing(space_xxxs)
                         .width(Length::Fill)
                         .into(),
-                    button::standard(fl!("add"))
-                        .class(button::ButtonClass::Custom {
-                            active: Box::new(|focused, theme| {
-                                let mut style =
-                                    theme.active(focused, false, &button::ButtonClass::Text);
-                                style.text_color = Some(theme.cosmic().accent_color().into());
-                                style
-                            }),
-                            disabled: Box::new(|theme| {
-                                let mut style = theme.disabled(&button::ButtonClass::Text);
-                                let mut text_color: Color = theme.cosmic().accent_color().into();
-                                text_color.a *= 0.5;
-                                style.text_color = Some(text_color);
-                                style
-                            }),
-                            hovered: Box::new(|focused, theme| {
-                                let mut style = theme.hovered(focused, false, &theme::Button::Text);
-                                style.text_color = Some(theme.cosmic().accent_color().into());
-                                style
-                            }),
-                            pressed: Box::new(|focused, theme| {
-                                let mut style = theme.pressed(focused, false, &theme::Button::Text);
-                                style.text_color = Some(theme.cosmic().accent_color().into());
-                                style
-                            }),
-                        })
+                    button::text(fl!("add"))
                         .on_press(msg_map(Message::AddApplet(info.clone())))
                         .into(),
                 ])


### PR DESCRIPTION
This prevents the Add button in the Startup apps context drawer from wrapping, and increases the icon size to match the applet context drawer.
![Screenshot_2025-03-27_15-13-53](https://github.com/user-attachments/assets/4b90a20d-df93-48fc-9a37-b6d637703353)

Also fixes the extra padding on the bottom of views, which pushed the scrollable up. Adds a bottom spacer to the scrollable content, to ensure that it doesn't touch the window edge at the bottom of a scroll.