### PR TITLE
new Xwayland compatibility options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols//?rev=ee0d46f#ee0d46f4b7e1508011a98225f14c4a0528ab2914"
+source = "git+https://github.com/pop-os/cosmic-protocols//?rev=0c3bef9#0c3bef999996f0b8c81aad02a3fcff0528793194"
 dependencies = [
  "bitflags 2.9.0",
  "cosmic-protocols",
@@ -1510,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "cosmic-comp-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-comp#cbc4ad6fc2010f7de04d680e8d4b90eaac0c6d4e"
+source = "git+https://github.com/pop-os/cosmic-comp?rev=c28427c#c28427cdc1f39d03ab3716817101eebc3e8ac42e"
 dependencies = [
  "cosmic-config",
  "input",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols//?rev=ee0d46f#ee0d46f4b7e1508011a98225f14c4a0528ab2914"
+source = "git+https://github.com/pop-os/cosmic-protocols//?rev=0c3bef9#0c3bef999996f0b8c81aad02a3fcff0528793194"
 dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
@@ -1627,7 +1627,7 @@ dependencies = [
 [[package]]
 name = "cosmic-randr"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-randr#c247019230c5d820dd1c3d47bc4e3c52fb03b42f"
+source = "git+https://github.com/pop-os/cosmic-randr?rev=b09f157#b09f157cd5d351741be12c4d22544647a5ecbaf1"
 dependencies = [
  "cosmic-protocols",
  "futures-lite 2.6.0",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "cosmic-randr-shell"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-randr#c247019230c5d820dd1c3d47bc4e3c52fb03b42f"
+source = "git+https://github.com/pop-os/cosmic-randr?rev=b09f157#b09f157cd5d351741be12c4d22544647a5ecbaf1"
 dependencies = [
  "kdl",
  "slotmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 rust-version = "1.80.0"
 
 [workspace.dependencies]
-cosmic-randr = { git = "https://github.com/pop-os/cosmic-randr" }
+cosmic-randr = { git = "https://github.com/pop-os/cosmic-randr", rev = "b09f157" }
 tokio = { version = "1.43.0", features = ["macros"] }
 
 [workspace.dependencies.libcosmic]
@@ -22,6 +22,7 @@ git = "https://github.com/pop-os/cosmic-bg"
 
 [workspace.dependencies.cosmic-comp-config]
 git = "https://github.com/pop-os/cosmic-comp"
+rev = "c28427c"
 
 [workspace.dependencies.cosmic-idle-config]
 git = "https://github.com/pop-os/cosmic-idle"
@@ -31,6 +32,7 @@ git = "https://github.com/pop-os/cosmic-panel"
 
 [workspace.dependencies.cosmic-randr-shell]
 git = "https://github.com/pop-os/cosmic-randr"
+rev = "b09f157"
 
 [workspace.dependencies.sctk]
 git = "https://github.com/smithay/client-toolkit/"
@@ -49,8 +51,8 @@ lto = "thin"
 # smithay-client-toolkit = { git = "https://github.com/smithay/client-toolkit//", rev = "c583de8" }
 
 [patch.'https://github.com/pop-os/cosmic-protocols']
-cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols//", rev = "ee0d46f" }
-cosmic-client-toolkit = { git = "https://github.com/pop-os/cosmic-protocols//", rev = "ee0d46f" }
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols//", rev = "0c3bef9" }
+cosmic-client-toolkit = { git = "https://github.com/pop-os/cosmic-protocols//", rev = "0c3bef9" }
 
 # [patch.'https://github.com/pop-os/cosmic-settings-daemon']
 # cosmic-settings-config = { git = "https://github.com/pop-os/cosmic-settings-daemon//", branch = "input_nobuild" }

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -489,7 +489,12 @@ impl cosmic::Application for SettingsApp {
 
                 #[cfg(feature = "page-legacy-applications")]
                 crate::pages::Message::LegacyApplications(message) => {
-                    page::update!(self.pages, message, applications::legacy_applications::Page);
+                    if let Some(page) = self
+                        .pages
+                        .page_mut::<applications::legacy_applications::Page>()
+                    {
+                        return page.update(message).map(Into::into);
+                    }
                 }
 
                 #[cfg(feature = "page-input")]

--- a/cosmic-settings/src/pages/applications/legacy_applications.rs
+++ b/cosmic-settings/src/pages/applications/legacy_applications.rs
@@ -1,27 +1,46 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::{
+    process::ExitStatus,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
 use cosmic::{
-    Apply, Element,
+    Apply, Element, Task,
     cosmic_config::{self, ConfigGet, ConfigSet},
     iced::Length,
-    widget::{self, text},
+    surface,
+    widget::{self, dropdown, text},
 };
 use cosmic_comp_config::{EavesdroppingKeyboardMode, XwaylandDescaling, XwaylandEavesdropping};
+use cosmic_randr_shell::List;
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
 use slab::Slab;
 use slotmap::SlotMap;
+use tokio::sync::oneshot;
 use tracing::error;
 
 #[derive(Clone, Debug)]
 pub enum Message {
+    RandrUpdate(Arc<Result<List, cosmic_randr_shell::Error>>),
+    RandrResult(Arc<std::io::Result<ExitStatus>>),
     SetXwaylandDescaling(XwaylandDescaling),
     SetXwaylandKeyboardMode(EavesdroppingKeyboardMode),
     SetXwaylandMouseButtonMode(bool),
+    SetXwaylandPrimaryOutput(usize),
+    Surface(surface::Action),
 }
 
 pub struct Page {
+    refresh_pending: Arc<AtomicBool>,
+    randr_handle: Option<(oneshot::Sender<()>, cosmic::iced::task::Handle)>,
+    output_options: Vec<String>,
+    output_options_selected: usize,
     comp_config: cosmic_config::Config,
     comp_config_descale_xwayland: XwaylandDescaling,
     comp_config_xwayland_eavesdropping: XwaylandEavesdropping,
@@ -48,7 +67,12 @@ impl Default for Page {
                 Default::default()
             });
 
+        let no_display = fl!("legacy-app-scaling", "no-display");
         Self {
+            refresh_pending: Arc::new(AtomicBool::new(false)),
+            randr_handle: None,
+            output_options: vec![no_display],
+            output_options_selected: 0,
             comp_config,
             comp_config_descale_xwayland,
             comp_config_xwayland_eavesdropping,
@@ -75,13 +99,110 @@ impl page::Page<crate::pages::Message> for Page {
         .title(fl!("legacy-applications"))
         .description(fl!("legacy-applications", "desc"))
     }
+
+    fn on_enter(&mut self) -> Task<crate::pages::Message> {
+        let mut tasks = Vec::new();
+
+        tasks.push(cosmic::task::future(on_enter()));
+
+        let refresh_pending = self.refresh_pending.clone();
+        let (tx, mut rx) = tachyonix::channel(4);
+        let (canceller, cancelled) = oneshot::channel::<()>();
+        let runtime = tokio::runtime::Handle::current();
+
+        // Spawns a background service to monitor for display state changes.
+        // This must be spawned onto its own thread because `*mut wayland_sys::client::wl_display` is not Send-able.
+        tokio::task::spawn_blocking(move || {
+            let dispatcher = std::pin::pin!(async move {
+                let Ok((mut context, mut event_queue)) = cosmic_randr::connect(tx) else {
+                    return;
+                };
+
+                loop {
+                    if context.dispatch(&mut event_queue).await.is_err() {
+                        return;
+                    }
+                }
+            });
+
+            runtime.block_on(futures::future::select(cancelled, dispatcher));
+        });
+
+        // Forward messages from another thread to prevent the monitoring thread from blocking.
+        let (randr_task, randr_handle) =
+            Task::stream(async_fn_stream::fn_stream(|emitter| async move {
+                while let Ok(message) = rx.recv().await {
+                    if let cosmic_randr::Message::ManagerDone = message {
+                        if !refresh_pending.swap(true, Ordering::SeqCst) {
+                            _ = emitter.emit(on_enter().await).await;
+                        }
+                    }
+                }
+            }))
+            .abortable();
+
+        tasks.push(randr_task);
+        self.randr_handle = Some((canceller, randr_handle));
+
+        cosmic::task::batch(tasks)
+    }
+
+    fn on_leave(&mut self) -> Task<crate::pages::Message> {
+        if let Some((canceller, handle)) = self.randr_handle.take() {
+            _ = canceller.send(());
+            handle.abort();
+        }
+
+        Task::none()
+    }
+}
+
+pub async fn on_enter() -> crate::pages::Message {
+    let randr_fut = cosmic_randr_shell::list();
+
+    crate::pages::Message::LegacyApplications(Message::RandrUpdate(Arc::new(randr_fut.await)))
 }
 
 impl page::AutoBind<crate::pages::Message> for Page {}
 
 impl Page {
-    pub fn update(&mut self, message: Message) {
+    pub fn update(&mut self, message: Message) -> Task<crate::app::Message> {
         match message {
+            Message::RandrUpdate(randr) => {
+                match Arc::into_inner(randr) {
+                    Some(Ok(outputs)) => {
+                        let output_options_selected = outputs
+                            .outputs
+                            .values()
+                            .position(|o| o.xwayland_primary.is_some_and(std::convert::identity))
+                            .map(|x| x + 1)
+                            .unwrap_or(0);
+                        let mut output_options = vec![fl!("legacy-app-scaling", "no-display")];
+                        output_options.extend(
+                            outputs
+                                .outputs
+                                .values()
+                                .flat_map(|o| o.xwayland_primary.is_some().then(|| o.name.clone())),
+                        );
+
+                        self.output_options_selected = output_options_selected;
+                        self.output_options = output_options;
+                    }
+
+                    Some(Err(why)) => {
+                        tracing::error!(why = why.to_string(), "error fetching displays");
+                    }
+
+                    None => (),
+                }
+
+                self.refresh_pending.store(false, Ordering::SeqCst);
+            }
+            Message::RandrResult(result) => {
+                if let Some(Err(why)) = Arc::into_inner(result) {
+                    tracing::error!(why = why.to_string(), "cosmic-randr error");
+                }
+            }
             Message::SetXwaylandDescaling(descale) => {
                 self.comp_config_descale_xwayland = descale;
                 if let Err(err) = self
@@ -109,7 +230,28 @@ impl Page {
                     error!(?err, "Failed to set config 'xwayland_eavesdropping'");
                 }
             }
+            Message::SetXwaylandPrimaryOutput(idx) => {
+                let mut task = tokio::process::Command::new("cosmic-randr");
+                task.arg("xwayland");
+                if idx == 0 {
+                    task.arg("--no-primary");
+                } else {
+                    task.arg("--primary").arg(&self.output_options[idx]);
+                }
+
+                return cosmic::task::future(async move {
+                    tracing::debug!(?task, "executing");
+                    crate::app::Message::PageMessage(crate::pages::Message::LegacyApplications(
+                        Message::RandrResult(Arc::new(task.status().await)),
+                    ))
+                });
+            }
+            Message::Surface(a) => {
+                return cosmic::task::message(crate::app::Message::Surface(a));
+            }
         }
+
+        Task::none()
     }
 }
 
@@ -243,6 +385,21 @@ pub fn legacy_application_scaling() -> Section<crate::pages::Message> {
                     .width(Length::Fill)
                     .into(),
                 ]))
+                .add(widget::settings::item(
+                    &descriptions[preferred_display],
+                    dropdown::popup_dropdown(
+                        &page.output_options,
+                        Some(page.output_options_selected),
+                        Message::SetXwaylandPrimaryOutput,
+                        cosmic::iced::window::Id::RESERVED,
+                        Message::Surface,
+                        |a| {
+                            crate::app::Message::PageMessage(
+                                crate::pages::Message::LegacyApplications(a),
+                            )
+                        },
+                    ),
+                ))
                 .apply(Element::from)
                 .map(crate::pages::Message::LegacyApplications)
         })

--- a/cosmic-settings/src/pages/applications/legacy_applications.rs
+++ b/cosmic-settings/src/pages/applications/legacy_applications.rs
@@ -7,7 +7,7 @@ use cosmic::{
     iced::Length,
     widget::{self, text},
 };
-use cosmic_comp_config::{EavesdroppingKeyboardMode, XwaylandEavesdropping};
+use cosmic_comp_config::{EavesdroppingKeyboardMode, XwaylandDescaling, XwaylandEavesdropping};
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
 use slab::Slab;
@@ -16,14 +16,14 @@ use tracing::error;
 
 #[derive(Clone, Debug)]
 pub enum Message {
-    SetXwaylandDescaling(bool),
+    SetXwaylandDescaling(XwaylandDescaling),
     SetXwaylandKeyboardMode(EavesdroppingKeyboardMode),
     SetXwaylandMouseButtonMode(bool),
 }
 
 pub struct Page {
     comp_config: cosmic_config::Config,
-    comp_config_descale_xwayland: bool,
+    comp_config_descale_xwayland: XwaylandDescaling,
     comp_config_xwayland_eavesdropping: XwaylandEavesdropping,
 }
 
@@ -36,7 +36,7 @@ impl Default for Page {
                     error!(?err, "Failed to read config 'descale_xwayland'");
                 }
 
-                false
+                XwaylandDescaling::Disabled
             });
         let comp_config_xwayland_eavesdropping = comp_config
             .get("xwayland_eavesdropping")
@@ -192,10 +192,13 @@ pub fn legacy_application_global_shortcuts() -> Section<crate::pages::Message> {
 pub fn legacy_application_scaling() -> Section<crate::pages::Message> {
     let mut descriptions = Slab::new();
 
-    let system = descriptions.insert(fl!("legacy-app-scaling", "scaled-by-system"));
-    let system_desc = descriptions.insert(fl!("legacy-app-scaling", "system-description"));
-    let native = descriptions.insert(fl!("legacy-app-scaling", "scaled-natively"));
-    let native_desc = descriptions.insert(fl!("legacy-app-scaling", "native-description"));
+    let gaming = descriptions.insert(fl!("legacy-app-scaling", "scaled-gaming"));
+    let gaming_desc = descriptions.insert(fl!("legacy-app-scaling", "gaming-description"));
+    let apps = descriptions.insert(fl!("legacy-app-scaling", "scaled-applications"));
+    let apps_desc = descriptions.insert(fl!("legacy-app-scaling", "applications-description"));
+    let compat = descriptions.insert(fl!("legacy-app-scaling", "scaled-compatibility"));
+    let compat_desc = descriptions.insert(fl!("legacy-app-scaling", "compatibility-description"));
+    let preferred_display = descriptions.insert(fl!("legacy-app-scaling", "preferred-display"));
 
     Section::default()
         .title(fl!("legacy-app-scaling"))
@@ -207,9 +210,9 @@ pub fn legacy_application_scaling() -> Section<crate::pages::Message> {
                 .add(widget::settings::item_row(vec![
                     widget::radio(
                         widget::column()
-                            .push(text::body(&descriptions[system]))
-                            .push(text::caption(&descriptions[system_desc])),
-                        false,
+                            .push(text::body(&descriptions[gaming]))
+                            .push(text::caption(&descriptions[gaming_desc])),
+                        XwaylandDescaling::Fractional,
                         Some(page.comp_config_descale_xwayland),
                         Message::SetXwaylandDescaling,
                     )
@@ -219,9 +222,21 @@ pub fn legacy_application_scaling() -> Section<crate::pages::Message> {
                 .add(widget::settings::item_row(vec![
                     widget::radio(
                         widget::column()
-                            .push(text::body(&descriptions[native]))
-                            .push(text::caption(&descriptions[native_desc])),
-                        true,
+                            .push(text::body(&descriptions[apps]))
+                            .push(text::caption(&descriptions[apps_desc])),
+                        XwaylandDescaling::Enabled,
+                        Some(page.comp_config_descale_xwayland),
+                        Message::SetXwaylandDescaling,
+                    )
+                    .width(Length::Fill)
+                    .into(),
+                ]))
+                .add(widget::settings::item_row(vec![
+                    widget::radio(
+                        widget::column()
+                            .push(text::body(&descriptions[compat]))
+                            .push(text::caption(&descriptions[compat_desc])),
+                        XwaylandDescaling::Disabled,
                         Some(page.comp_config_descale_xwayland),
                         Message::SetXwaylandDescaling,
                     )

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -834,10 +834,14 @@ legacy-app-global-shortcuts = Global Shortcuts in X11 Applications
     .mouse = Mouse button events in X11 applications
 
 legacy-app-scaling = X11 Window System Application Scaling
-    .scaled-by-system = Scale all X11 Applications
-    .system-description = X11 applications will appear blurry on HiDPI screens.
-    .scaled-natively = Render X11 Applications at native resolution
-    .native-description = X11 applications that don't support scaling will be small when HiDPI displays are in use. Enable for games to utilize the full monitor resolution.
+    .scaled-gaming = Optimize for gaming and full-screen apps
+    .gaming-description = X11 applications may appear slightly larger/smaller compared to Wayland apps.
+    .scaled-applications = Optimize for applications
+    .applications-description = Games and full-screen X11 apps may not match your display resolution. 
+    .scaled-compatibility = Maximum compatibility mode
+    .compatibility-description = X11 applications may appear blurry on HiDPI screens.
+    .preferred-display = Preferred display for games and full screen X11 applications
+    .no-display = <None>
 
 ## System
 


### PR DESCRIPTION
Introduces the new scaling modes and preferred output settings from https://github.com/pop-os/cosmic-comp/pull/1337.

Should be merged after:
- [ ] https://github.com/pop-os/cosmic-protocols/pull/57
- [ ] https://github.com/pop-os/cosmic-randr/pull/39
- [ ] and https://github.com/pop-os/cosmic-comp/pull/1337