### PR TITLE
feat: improved password workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,15 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -876,6 +885,17 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.0",
  "piper",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fa6a061124e37baba002e496d203e23ba3d7b73750be82dbfbc92913048a5b"
+dependencies = [
+ "byteorder",
+ "cipher",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1158,6 +1178,15 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1708,6 +1737,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "once_cell",
+ "pwhash",
  "regex",
  "ron 0.9.0",
  "rust-embed",
@@ -1941,6 +1971,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "css-color"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,11 +2194,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common",
 ]
 
@@ -3123,6 +3172,16 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
 
 [[package]]
 name = "hostname-validator"
@@ -4787,6 +4846,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5486,6 +5556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5968,6 +6044,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pwhash"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419a3ad8fa9f9d445e69d9b185a24878ae6e6f55c96e4512f4a0e28cd3bc5c56"
+dependencies = [
+ "blowfish",
+ "byteorder",
+ "hmac",
+ "md-5",
+ "rand",
+ "sha-1",
+ "sha2 0.9.9",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6395,7 +6486,7 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a2fcdc9f40c8dc2922842ca9add611ad19f332227fc651d015881ad1552bd9a"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
  "walkdir",
 ]
 
@@ -6663,6 +6754,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6670,7 +6774,20 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -6681,7 +6798,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6945,6 +7062,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "sunrise"

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -88,6 +88,7 @@ gettext-rs = { version = "0.7.2", features = [
 async-fn-stream = "0.2.2"
 num-traits = "0.2"
 num-derive = "0.4"
+pwhash = "1"
 
 [dependencies.cosmic-settings-subscriptions]
 git = "https://github.com/pop-os/cosmic-settings-subscriptions"
@@ -156,9 +157,7 @@ page-input = [
     "dep:cosmic-settings-config",
     "dep:udev",
 ]
-page-legacy-applications = [
-    "dep:cosmic-comp-config",
-]
+page-legacy-applications = ["dep:cosmic-comp-config"]
 page-networking = [
     "xdg-portal",
     "dep:cosmic-dbus-networkmanager",

--- a/cosmic-settings/src/pages/system/users/mod.rs
+++ b/cosmic-settings/src/pages/system/users/mod.rs
@@ -36,7 +36,6 @@ pub struct User {
     password: String,
     password_confirm: String,
     full_name_edit: bool,
-    password_edit: bool,
     username_edit: bool,
     is_admin: bool,
 }
@@ -400,7 +399,6 @@ impl Page {
                 password: String::new(),
                 password_confirm: String::new(),
                 full_name_edit: false,
-                password_edit: false,
                 username_edit: false,
             });
         }

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -30,6 +30,7 @@ network-and-wireless = Network & Wireless
 no-networks = No networks have been found.
 no-vpn = No VPN connections available.
 password = Password
+password-confirm = Confirm Password
 remove = Remove
 settings = Settings
 username = Username
@@ -154,7 +155,7 @@ magnifier = Magnifier
                 {$zoom_out} to zoom out,
         }
         Super + scroll with your mouse
-    .scroll_controls = Enable mouse or touchpad zoom with Super + Scroll 
+    .scroll_controls = Enable mouse or touchpad zoom with Super + Scroll
     .show_overlay = Show the Magnifier Overlay
     .increment = Zoom increment
     .signin = Start magnifier on sign in
@@ -837,7 +838,7 @@ legacy-app-scaling = X11 Window System Application Scaling
     .scaled-gaming = Optimize for gaming and full-screen apps
     .gaming-description = X11 applications may appear slightly larger/smaller compared to Wayland apps.
     .scaled-applications = Optimize for applications
-    .applications-description = Games and full-screen X11 apps may not match your display resolution. 
+    .applications-description = Games and full-screen X11 apps may not match your display resolution.
     .scaled-compatibility = Maximum compatibility mode
     .compatibility-description = X11 applications may appear blurry on HiDPI screens.
     .preferred-display = Preferred display for games and full screen X11 applications
@@ -888,6 +889,9 @@ administrator = Administrator
     .desc = Administrators can change settings for all users, add and remove other users.
 
 add-user = Add user
+change-password = Change password
 remove-user = Remove user
 full-name = Full name
-invalid-username = Invalid username
+invalid-username = Invalid username.
+password-mismatch = Password and confirmation must match.
+save = Save


### PR DESCRIPTION
Implementing the following from https://github.com/pop-os/cosmic-settings/issues/1127

- User creation and password update now requires double entry of matching passwords
- New flow for changing password from inline edit to separate dialog
- Password fields converted to secure_input with visibility toggles as per the greeter and network applet.

There is a separate issue of passwords never being set or updated correctly. This PR is no more or less broken than it is currently as it uses the same password update function https://github.com/pop-os/cosmic-settings/issues/844

Another existing issue with user settings that's not currently addressed in this PR is the updating of full name and username https://github.com/pop-os/cosmic-settings/issues/1128