### PR TITLE
fix: user list style and layout

### DIFF
--- a/cosmic-settings/src/pages/system/users/mod.rs
+++ b/cosmic-settings/src/pages/system/users/mod.rs
@@ -745,7 +745,7 @@ fn user_list() -> Section<crate::pages::Message> {
                     .on_input(move |name| Message::Edit(idx, EditorField::FullName, name))
                     .on_submit(move |_| Message::ApplyEdit(idx, EditorField::FullName));
 
-                    let fullname_text = text::body(if &user.full_name != "" {
+                    let fullname_text = text::body(if user.full_name != "" {
                         &user.full_name
                     } else {
                         &user.username

--- a/cosmic-settings/src/pages/system/users/mod.rs
+++ b/cosmic-settings/src/pages/system/users/mod.rs
@@ -790,6 +790,8 @@ fn user_list() -> Section<crate::pages::Message> {
 
                     let profile_icon = widget::button::icon(profile_icon_handle)
                         .large()
+                        .padding(0)
+                        .class(cosmic::theme::Button::Standard)
                         .on_press(Message::SelectProfileImage(user.id));
 
                     let account_details_content = settings::item_row(vec![
@@ -829,7 +831,7 @@ fn user_list() -> Section<crate::pages::Message> {
                 .fold(
                     widget::list_column()
                         .spacing(0)
-                        .padding(0)
+                        .padding([8, 0])
                         .divider_padding(0)
                         .list_item_padding(0),
                     widget::ListColumn::add,

--- a/cosmic-settings/src/pages/system/users/mod.rs
+++ b/cosmic-settings/src/pages/system/users/mod.rs
@@ -745,7 +745,11 @@ fn user_list() -> Section<crate::pages::Message> {
                     .on_input(move |name| Message::Edit(idx, EditorField::FullName, name))
                     .on_submit(move |_| Message::ApplyEdit(idx, EditorField::FullName));
 
-                    let fullname_text = text::body(&user.full_name);
+                    let fullname_text = text::body(if &user.full_name != "" {
+                        &user.full_name
+                    } else {
+                        &user.username
+                    });
 
                     let account_type = text::caption(if user.is_admin {
                         &descriptions[user_type_admin]


### PR DESCRIPTION
Relating to issue https://github.com/pop-os/cosmic-settings/issues/1044 - but also taking the chance to clear up a few bits.

- Individual user buttons were drawing on top of the container that had the standard rounded edges as other settings, so added some spacing at the top and bottom of that container
- General small tweaks of the layout to better match the [Figma](https://www.figma.com/design/Z6Z9Ox6WNkiiM8gcAkcElS/COSMIC-Settings-First-Release---Developer-Handoff?node-id=13918-2014&p=f)
- Added a placeholder for non pop-os distros that don't currently load the default profile image
- Added a fallback to show the username in the user list if there is no full name to show