### PR TITLE
fix(appearance): load theme for initial default

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -175,10 +175,18 @@ impl
             AccentPalette,
         ),
     ) -> Self {
-        let theme = if theme_mode.is_dark {
-            Theme::dark_default()
+        let theme = if let Ok(c) = if theme_mode.is_dark {
+            Theme::dark_config()
         } else {
-            Theme::light_default()
+            Theme::light_config()
+        } {
+            Theme::get_entry(&c).unwrap_or_default()
+        } else {
+            if theme_mode.is_dark {
+                Theme::dark_default()
+            } else {
+                Theme::light_default()
+            }
         };
         theme_builder = theme_builder
             .clone()


### PR DESCRIPTION
This will load the theme instead of just using light or dark defaults. Alternatively specific values from the theme config could be loaded but there are many values puled from the theme here.