### PR TITLE
iterate XDG_DATA_DIRS when loading backgrounds

### DIFF
--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -220,7 +220,7 @@ impl page::Page<crate::pages::Message> for Page {
             return Task::none();
         }
 
-        let current_folder = self.config.current_folder().to_owned();
+        let current_folder = self.config.current_folder();
 
         let (task, on_enter_handle) = Task::future(async move {
             let (service_config, displays) = wallpaper::config().await;
@@ -490,9 +490,7 @@ impl Page {
 
         let entry = match self.selection.active {
             Choice::Slideshow => {
-                match self
-                    .config_wallpaper_entry(output, self.config.current_folder().to_path_buf())
-                {
+                match self.config_wallpaper_entry(output, self.config.current_folder()) {
                     Some(entry) => entry,
                     None => return,
                 }
@@ -588,7 +586,7 @@ impl Page {
                 if self.config.current_folder.is_some() {
                     let _ = self.config.set_current_folder(None);
                     task = cosmic::task::future(async move {
-                        let folder = change_folder(Config::default_folder().to_owned()).await;
+                        let folder = change_folder(Config::default_folder()).await;
                         Message::ChangeFolder(folder)
                     });
                 } else {
@@ -968,7 +966,7 @@ impl Page {
                 if let Choice::Wallpaper(_) | Choice::Slideshow = self.selection.active {
                     let folder = self.config.current_folder();
                     for (id, recent) in self.config.recent_folders().iter().enumerate() {
-                        if recent == folder {
+                        if &folder == recent {
                             self.categories.selected = Some(Category::RecentFolder(id));
                         }
                     }

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
@@ -11,8 +11,8 @@ use cosmic_settings_page as page;
 use slab::Slab;
 use slotmap::Key;
 use std::borrow::Cow;
-use std::{io, mem};
 use std::str::FromStr;
+use std::{io, mem};
 
 #[derive(Clone, Debug)]
 pub enum ShortcutMessage {
@@ -535,7 +535,7 @@ impl Model {
                 if let Some(model) = self.shortcut_models.get_mut(short_id) {
                     if let Some(shortcut) = model.bindings.get_mut(id) {
                         let prev_binding = mem::replace(&mut shortcut.binding, new_binding.clone());
-                        
+
                         shortcut.is_saved = true;
                         shortcut.input.clear();
 
@@ -544,7 +544,7 @@ impl Model {
                         }
 
                         let action = model.action.clone();
-                        
+
                         if shortcut.is_default {
                             self.config_add(Action::Disable, prev_binding);
                         } else {


### PR DESCRIPTION
**changes tl;dr**
- instead of using `/usr/share/backgrounds` everywhere, instead (try to) use the first `$XDG_DATA_DIRS` that has a `backgrounds` subdirectory
- if none, fallback to `/usr/share/backgrounds`

functionality remains unchanged on pop 24.04