### PR TITLE
fix: user admin toggle overflowing container

### DIFF
--- a/cosmic-settings/src/pages/system/users/mod.rs
+++ b/cosmic-settings/src/pages/system/users/mod.rs
@@ -251,10 +251,10 @@ impl page::Page<crate::pages::Message> for Page {
                             .add(username_input)
                             .add(password_input)
                             .add(password_confirm_input)
-                            .add(widget::container(
-                                row::with_capacity(2)
+                            .add(
+                                row::with_capacity(3)
                                     .push(
-                                        column::with_capacity(3)
+                                        column::with_capacity(2)
                                             .push(text::body(crate::fl!("administrator")))
                                             .push(text::caption(crate::fl!(
                                                 "administrator",
@@ -265,7 +265,7 @@ impl page::Page<crate::pages::Message> for Page {
                                     .push(Space::new(5, 0))
                                     .push(admin_toggler)
                                     .align_y(Alignment::Center),
-                            )),
+                            ),
                     )
                     .primary_action(add_user_button)
                     .secondary_action(cancel_button)

--- a/cosmic-settings/src/pages/system/users/mod.rs
+++ b/cosmic-settings/src/pages/system/users/mod.rs
@@ -251,20 +251,21 @@ impl page::Page<crate::pages::Message> for Page {
                             .add(username_input)
                             .add(password_input)
                             .add(password_confirm_input)
-                            .add(
-                                row::with_capacity(3)
+                            .add(widget::container(
+                                row::with_capacity(2)
                                     .push(
-                                        column::with_capacity(2)
+                                        column::with_capacity(3)
                                             .push(text::body(crate::fl!("administrator")))
                                             .push(text::caption(crate::fl!(
                                                 "administrator",
                                                 "desc"
-                                            ))),
+                                            )))
+                                            .width(Length::Fill),
                                     )
                                     .push(Space::new(5, 0))
                                     .push(admin_toggler)
                                     .align_y(Alignment::Center),
-                            ),
+                            )),
                     )
                     .primary_action(add_user_button)
                     .secondary_action(cancel_button)

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -892,7 +892,7 @@ users = Users
     .profile-add = Choose profile image
 
 administrator = Administrator
-    .desc = Administrators can change settings for all users, add and remove other users.
+    .desc = Administrators can change settings for all users, add and remove other users, add and remove other users.
 
 add-user = Add user
 change-password = Change password

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -892,7 +892,7 @@ users = Users
     .profile-add = Choose profile image
 
 administrator = Administrator
-    .desc = Administrators can change settings for all users, add and remove other users, add and remove other users.
+    .desc = Administrators can change settings for all users, add and remove other users.
 
 add-user = Add user
 change-password = Change password


### PR DESCRIPTION
Addresses https://github.com/pop-os/cosmic-settings/issues/1172

It seems if a column isn't explicitly told a width it will let a child element (like the description text here) expand it into the space the other columns need.