### PR TITLE
fix: apply the toggle overflow fix to the user list

### DIFF
--- a/cosmic-settings/src/pages/system/users/mod.rs
+++ b/cosmic-settings/src/pages/system/users/mod.rs
@@ -778,8 +778,9 @@ fn user_list() -> Section<crate::pages::Message> {
                                 column::with_capacity(2)
                                     .push(text::body(crate::fl!("administrator")))
                                     .push(text::caption(crate::fl!("administrator", "desc")))
+                                    .width(Length::Fill)
                                     .into(),
-                                widget::horizontal_space().width(Length::Fill).into(),
+                                Space::new(5, 0).into(),
                                 widget::toggler(user.is_admin)
                                     .on_toggle(|enabled| {
                                         Message::SelectedUserSetAdmin(user.id, enabled)


### PR DESCRIPTION
Following on from PR https://github.com/pop-os/cosmic-settings/pull/1182 -  I didn't realise the same overflow was happening on the main user list as well as the new user dialog!