### PR TITLE
Handle Custom panel size in cosmic-settings

### DIFF
--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -214,6 +214,7 @@ pub(crate) fn style<
                                 PanelSize::M => 2,
                                 PanelSize::L => 3,
                                 PanelSize::XL => 4,
+                                PanelSize::Custom(s) => 2,
                             },
                             |v| {
                                 if v == 0 {


### PR DESCRIPTION
Depends-on: https://github.com/pop-os/libcosmic/pull/880
Depends-on: https://github.com/pop-os/cosmic-panel/pull/396

All this involves is having a certain notch that the panel size slider is on when the panel is set to a custom size