### PR TITLE
fix(appearance): Density radio group is unresponsive

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use cosmic::app::{ContextDrawer, context_drawer};
 //TODO: use embedded cosmic-files for portability
 use cosmic::config::CosmicTk;
-use cosmic::cosmic_config::{Config, ConfigSet, CosmicConfigEntry};
+use cosmic::cosmic_config::{Config, ConfigGet, ConfigSet, CosmicConfigEntry};
 use cosmic::cosmic_theme::palette::{FromColor, Hsv, Srgb, Srgba};
 use cosmic::cosmic_theme::{
     CornerRadii, DARK_THEME_BUILDER_ID, Density, LIGHT_THEME_BUILDER_ID, Spacing, Theme,
@@ -857,6 +857,7 @@ impl Page {
             }
 
             Message::Density(density) => {
+                tracing::info!("Density changed: {:?}", density);
                 needs_sync = true;
 
                 if let Some(config) = self.tk_config.as_mut() {
@@ -2090,8 +2091,11 @@ pub fn interface_density() -> Section<crate::pages::Message> {
         .descriptions(descriptions)
         .view::<Page>(move |_binder, _page, section| {
             let descriptions = &section.descriptions;
-
-            let density = cosmic::config::interface_density();
+            let density = CosmicTk::config()
+                .ok()
+                .unwrap()
+                .get("interface_density")
+                .unwrap();
 
             settings::section()
                 .title(&section.title)

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -76,6 +76,7 @@ pub struct Page {
     interface_text: ColorPickerModel,
     control_component: ColorPickerModel,
     roundness: Roundness,
+    density: Density,
 
     font_config: font_config::Model,
     font_filter: Vec<Arc<str>>,
@@ -224,6 +225,7 @@ impl
             },
             context_view: None,
             roundness: theme_builder.corner_radii.into(),
+            density: cosmic::config::interface_density(),
             custom_accent: ColorPickerModel::new(
                 &*HEX,
                 &*RGB,
@@ -859,6 +861,7 @@ impl Page {
             Message::Density(density) => {
                 tracing::info!("Density changed: {:?}", density);
                 needs_sync = true;
+                self.density = density;
 
                 if let Some(config) = self.tk_config.as_mut() {
                     _ = config.set("interface_density", density);
@@ -2089,13 +2092,8 @@ pub fn interface_density() -> Section<crate::pages::Message> {
     Section::default()
         .title(fl!("interface-density"))
         .descriptions(descriptions)
-        .view::<Page>(move |_binder, _page, section| {
+        .view::<Page>(move |_binder, page, section| {
             let descriptions = &section.descriptions;
-            let density = CosmicTk::config()
-                .ok()
-                .unwrap()
-                .get("interface_density")
-                .unwrap();
 
             settings::section()
                 .title(&section.title)
@@ -2103,7 +2101,7 @@ pub fn interface_density() -> Section<crate::pages::Message> {
                     radio(
                         text::body(&descriptions[compact]),
                         Density::Compact,
-                        Some(density),
+                        Some(page.density),
                         Message::Density,
                     )
                     .width(Length::Fill)
@@ -2113,7 +2111,7 @@ pub fn interface_density() -> Section<crate::pages::Message> {
                     radio(
                         text::body(&descriptions[comfortable]),
                         Density::Standard,
-                        Some(density),
+                        Some(page.density),
                         Message::Density,
                     )
                     .width(Length::Fill)
@@ -2123,7 +2121,7 @@ pub fn interface_density() -> Section<crate::pages::Message> {
                     radio(
                         text::body(&descriptions[spacious]),
                         Density::Spacious,
-                        Some(density),
+                        Some(page.density),
                         Message::Density,
                     )
                     .width(Length::Fill)


### PR DESCRIPTION
Changed the way the update source the density value to retrieve it directly from the underlying config struct. CosmicTK currently has an issue where changes aren't propagated back to the wrapper which cause the UI to never be able to change the selected radio button on the radio group for Density.

This is most likely a temporary fix until a fix upstream in libcosmic is made.

The Config struct becomes stale when the underlying store has values changed. Getter method like the one for the interface density only ever returns the value it was initiated with:

https://github.com/pop-os/libcosmic/blob/944c6761f73f097552042912780104783f9ca62e/src/config/mod.rs#L70

As a side note, I'd like to fix the underlying issue in libcosmic myself, but it might take a bit of time for me to do that as I'm not that great at Rust, specially building UI and libraries, so I thought that even though this fix is pretty meh in terms of error handling, I thought it was an improvement over the previous state.