### PR TITLE
feat: add simple bios version section to system/firmware page

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -646,6 +646,12 @@ impl cosmic::Application for SettingsApp {
                         return page.update(message).map(Into::into);
                     }
                 }
+
+                crate::pages::Message::Firmware(message) => {
+                    if let Some(page) = self.pages.page_mut::<system::firmware::Page>() {
+                        return page.update(message).map(Into::into);
+                    }
+                }
             },
 
             #[cfg(feature = "wayland")]

--- a/cosmic-settings/src/pages/mod.rs
+++ b/cosmic-settings/src/pages/mod.rs
@@ -55,6 +55,7 @@ pub enum Message {
         id: String,
         message: Vec<u8>,
     },
+    Firmware(system::firmware::Message),
     #[cfg(feature = "page-input")]
     Input(input::Message),
     #[cfg(feature = "page-input")]

--- a/cosmic-settings/src/pages/system/firmware.rs
+++ b/cosmic-settings/src/pages/system/firmware.rs
@@ -1,13 +1,35 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
+use cosmic::Task;
+use cosmic::widget::{settings, text};
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
+use cosmic_settings_system::about::Info;
 use slotmap::SlotMap;
+
+#[derive(Clone, Debug)]
+pub enum Message {
+    Info(Box<Info>),
+}
+
+impl From<Message> for crate::app::Message {
+    fn from(message: Message) -> Self {
+        crate::pages::Message::Firmware(message).into()
+    }
+}
+
+impl From<Message> for crate::pages::Message {
+    fn from(message: Message) -> Self {
+        crate::pages::Message::Firmware(message)
+    }
+}
 
 #[derive(Default)]
 pub struct Page {
     entity: page::Entity,
+    info: Info,
+    on_enter_handle: Option<cosmic::iced::task::Handle>,
 }
 
 impl page::Page<crate::pages::Message> for Page {
@@ -19,7 +41,7 @@ impl page::Page<crate::pages::Message> for Page {
         &self,
         sections: &mut SlotMap<section::Entity, Section<crate::pages::Message>>,
     ) -> Option<page::Content> {
-        Some(vec![sections.insert(Section::default())])
+        Some(vec![sections.insert(firmware())])
     }
 
     fn info(&self) -> page::Info {
@@ -27,6 +49,48 @@ impl page::Page<crate::pages::Message> for Page {
             .title(fl!("firmware"))
             .description(fl!("firmware", "desc"))
     }
+
+    fn on_enter(&mut self) -> Task<crate::pages::Message> {
+        let (task, handle) = Task::future(async move {
+            crate::pages::Message::Firmware(Message::Info(Box::new(Info::load())))
+        })
+        .abortable();
+
+        self.on_enter_handle = Some(handle);
+        task
+    }
+
+    fn on_leave(&mut self) -> Task<crate::pages::Message> {
+        if let Some(handle) = self.on_enter_handle.take() {
+            handle.abort();
+        }
+
+        Task::none()
+    }
+}
+
+impl Page {
+    pub fn update(&mut self, message: Message) -> cosmic::app::Task<crate::Message> {
+        match message {
+            Message::Info(info) => {
+                self.info = *info;
+            }
+        }
+
+        Task::none()
+    }
+}
+
+fn firmware() -> Section<crate::pages::Message> {
+    Section::default().view::<Page>(move |_binder, page, section| {
+        settings::section()
+            .title(&section.title)
+            .add(settings::flex_item(
+                fl!("firmware", "bios-version"),
+                text::body(&page.info.bios_version),
+            ))
+            .into()
+    })
 }
 
 impl page::AutoBind<crate::pages::Message> for Page {}

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -882,6 +882,7 @@ about-related = Related settings
 
 firmware = Firmware
     .desc = Firmware details.
+    .bios-version = BIOS version
 
 ## System: Users
 

--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -48,6 +48,9 @@ impl Info {
         processor_name(&bump, &mut info.processor);
         bump.reset();
 
+        bios_version(&bump, &mut info.bios_version);
+        bump.reset();
+
         let mut sys = sysinfo::System::new();
 
         let disks = sysinfo::Disks::new_with_refreshed_list();

--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -11,6 +11,7 @@ const DMI_DIR: &str = "/sys/devices/virtual/dmi/id/";
 const BOARD_NAME: &str = concatcp!(DMI_DIR, "board_name");
 const BOARD_VERSION: &str = concatcp!(DMI_DIR, "board_version");
 const SYS_VENDOR: &str = concatcp!(DMI_DIR, "sys_vendor");
+const BIOS_VERSION: &str = concatcp!(DMI_DIR, "bios_version");
 
 const VERSION_IGNORING_PRODUCTS: &[&str] = &["Dev One"];
 
@@ -27,6 +28,7 @@ pub struct Info {
     pub os_architecture: String,
     pub processor: String,
     pub windowing_system: String,
+    pub bios_version: String,
 }
 
 impl Info {
@@ -185,6 +187,13 @@ pub fn processor_name(bump: &Bump, name: &mut String) {
                 break;
             }
         }
+    }
+}
+
+pub fn bios_version(bump: &Bump, bios_version: &mut String) {
+    let buffer = &mut bumpalo::collections::Vec::new_in(bump);
+    if let Some(value) = read_to_string(BIOS_VERSION, buffer) {
+        bios_version.push_str(value.trim());
     }
 }
 


### PR DESCRIPTION
> disclaimer: I am a first time contributor to this project but a long time user who recently jumped to test out the 24.04 Alpha.


before: an empty page without any sections under `"System & Accounts" / "Firmware"` page

![Screenshot_2025-06-08_16-25-00](https://github.com/user-attachments/assets/4d1b82d2-b2dc-4a23-9843-2be6b7191cbc)

after: added a single section with `"BIOS version"`

![Screenshot_2025-06-08_16-28-11](https://github.com/user-attachments/assets/4bd90bf7-1d2e-4881-a01d-55bbc022f004)


---

NOTES:

- Gnome settings have it called "Firmware version" -- let me know if you prefer it renamed to that instead of "BIOS Version"
- The other thing missing from this page is "Kernel version", which I can also add but wanted to verify if everything is OK with this PR first
- One thing I don't like about this is that I reused the `Info` from `About` page which loads up a bunch of other stuff too -- if you'd prefer to have it separated to a different place then please do let me know

Thanks!