### PR TITLE
Change wifi icon to one single icon

### DIFF
--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -703,11 +703,10 @@ fn devices_view() -> Section<crate::pages::Message> {
                         };
 
                         let identifier = widget::row::with_capacity(3)
-                            .push(widget::icon::from_name(wifi_icon(network.strength)))
-                            .push_maybe(
-                                is_encrypted
-                                    .then(|| widget::icon::from_name("connection-secure-symbolic")),
-                            )
+                            .push(widget::icon::from_name(wifi_icon(
+                                network.strength,
+                                is_encrypted,
+                            )))
                             .push(
                                 widget::text::body(network.ssid.as_ref()).wrapping(Wrapping::Glyph),
                             )
@@ -903,7 +902,27 @@ pub fn update_devices(conn: zbus::Connection) -> Task<crate::app::Message> {
     })
 }
 
-fn wifi_icon(strength: u8) -> &'static str {
+fn wifi_icon(strength: u8, is_encrypted: bool) -> &'static str {
+    if is_encrypted {
+        wifi_icon_secure(strength)
+    } else {
+        wifi_icon_open(strength)
+    }
+}
+
+fn wifi_icon_secure(strength: u8) -> &'static str {
+    if strength < 25 {
+        "network-wireless-secure-signal-weak-symbolic"
+    } else if strength < 50 {
+        "network-wireless-secure-signal-ok-symbolic"
+    } else if strength < 75 {
+        "network-wireless-secure-signal-good-symbolic"
+    } else {
+        "network-wireless-secure-signal-excellent-symbolic"
+    }
+}
+
+fn wifi_icon_open(strength: u8) -> &'static str {
     if strength < 25 {
         "network-wireless-signal-weak-symbolic"
     } else if strength < 50 {


### PR DESCRIPTION
Change the icons to one instead of using two icons.
| Before | After |
| ------------- | ------------- |
| ![Screenshot_2025-06-25_18-03-51](https://github.com/user-attachments/assets/702f594c-5670-4f14-ab6f-b2a5fcf1e9f3) | ![Screenshot_2025-06-24_18-48-33](https://github.com/user-attachments/assets/c148b79b-4227-43ee-ade4-c5ab8484a0dd)  |
