### PR TITLE
fix(wallpaper): Settings reset on entering page

### DIFF
--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -976,9 +976,7 @@ impl Page {
                             }
                     }
                 }
-                WallpaperEvent::Loaded => {
-                    self.select_first_wallpaper();
-                }
+                WallpaperEvent::Loaded => self.cache_display_image(),
                 WallpaperEvent::Error(error) => {
                     tracing::error!("Failed to load wallpaper: {}", error);
                 }


### PR DESCRIPTION
fixes: #1187 &  #1251

Edit: Here's a [relevant Mattermost dicussion](https://chat.pop-os.org/pop-os/pl/n3gnei7fi38f8mq5udmgt3jqna):

dania
[last week]
I have a personnal wallpapper. I have found that with last cosmic-settings update when you go in desktop-apparence-wallpapers the actual wallpaper is automatically replaced by the first wallapper in the gallery and I have to reselect my personnal wallpapper.  I think the problem come from commit 0508323. Best regards Dania

16 replies

doods
[last week]
As-salamu alaykum,

When you say: "last cosmic-settings update", do you mean the last commit on the master branch, or the latest version in the repos of Pop!_OS? I don't see the issue in the master branch, but I can test the latest release if that's what you're using.


dania
[last week]
yes the master branch https://github.com/pop-os/cosmic-settings . I compile myself each package of cosmic DE best regards Dania

doods
[last week]
I succeeded in reproducing it.


dania
[last week]
I have gone bacward to commit 44a1a9a, at this commit the problem is not present. I suppose commit 0508323 is the root of the problem


edfloreshz
[last week]
I also noticed this when working on loading the wallpapers with the streaming API, but realized that that was the behavior all along.  


lech
[6 days ago]
Also, the slideshow is turned off when entering the wallpaper in cosmic-settings


doods
[2 days ago]
I fixed it

[2d ago]
kind of

[2d ago]
it didn't take that long, it's just that I'm pretty deep into my final tests so I barely touched the code

[2d ago]
https://github.com/Doods0/cosmic-settings/commit/67b42e9eda8b7ac00e87eecc8abf47bdc7c346f6 

[2d ago]
It's still janky overall, but it becomes normal once it finishes loading.

[2d ago]
The slideshow issue is also fixed

[2d ago]
If you have a big directory full of images, the preview takes long to load, I think it was like that before I touched it.

[2d ago]
I confirmed it happens on master


doods
[2 days ago]
The only thing left is:

While the images folder is loading with the slideshow option, it displays the wrong image in the preview, it should be black.

I think displaying the correct preview (not black) should be a separate fix.


dania
[2 days ago]
thanks a lot  I wait the commit best regards Dania