### PR TITLE
From Clap to Clap_lex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,56 +246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,40 +1121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,12 +1236,6 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colorgrad"
@@ -1670,7 +1580,7 @@ dependencies = [
  "async-fn-stream",
  "bluez-zbus",
  "chrono",
- "clap",
+ "clap_lex",
  "color-eyre",
  "cosmic-bg-config",
  "cosmic-comp-config",
@@ -4204,12 +4114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5679,12 +5583,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opaque-debug"
@@ -7985,12 +7883,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -13,7 +13,7 @@ ashpd = { version = "0.9", default-features = false, features = [
 ], optional = true }
 async-channel = "2.3.1"
 chrono = "0.4.40"
-clap = { version = "4.5.32", features = ["derive"] }
+clap_lex = "0.7" 
 color-eyre = "0.6.3"
 cosmic-bg-config.workspace = true
 cosmic-comp-config = { workspace = true, optional = true }

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -784,7 +784,6 @@ impl cosmic::Application for SettingsApp {
             | cosmic::dbus_activation::Details::Open { .. } => None,
             cosmic::dbus_activation::Details::ActivateAction { action, .. } => {
                 PageCommands::from_str(&action)
-                    .ok()
                     .and_then(|action| self.subtask_to_page(&action))
                     .map(|e| self.activate_page(e))
             }

--- a/cosmic-settings/src/main.rs
+++ b/cosmic-settings/src/main.rs
@@ -21,122 +21,119 @@ pub mod theme;
 pub mod utils;
 pub mod widget;
 
-use clap::{Parser, Subcommand};
+use clap_lex::RawArgs;
 use cosmic::{app::CosmicFlags, iced::Limits};
 use i18n_embed::DesktopLanguageRequester;
-use ron::error::SpannedError;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::prelude::*;
 
-#[derive(Parser, Debug, Serialize, Deserialize, Clone)]
-#[command(author, version, about, long_about = None)]
-#[command(propagate_version = true)]
+
 pub struct Args {
-    #[command(subcommand)]
     sub_command: Option<PageCommands>,
 }
 
-#[derive(Subcommand, Debug, Serialize, Deserialize, Clone)]
+impl Args {
+    pub fn parse() -> Self {
+        let raw_args = RawArgs::from_args();
+        let mut cursor = raw_args.cursor();
+
+        // Ignore App name
+        let _ = raw_args.next_os(&mut cursor);
+
+        let sub_command = raw_args
+            .next_os(&mut cursor)
+            .and_then(|os_str| os_str.to_str())
+            .and_then(|s| <PageCommands as FromStr>::from_str(s).ok());
+
+        Args { sub_command }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PageCommands {
-    /// Accessibility settings page
-    #[cfg(feature = "page-accessibility")]
     Accessibility,
-    /// Accessibility Magnifier settings page
-    #[cfg(feature = "page-accessibility")]
     AccessibilityMagnifier,
-    /// About settings page
-    #[cfg(feature = "page-about")]
     About,
-    /// Appearance settings page
     Appearance,
-    /// Applications settings page
     Applications,
-    /// Bluetooth settings page
-    #[cfg(feature = "page-bluetooth")]
     Bluetooth,
-    /// Date & Time settings page
-    #[cfg(feature = "page-date")]
     DateTime,
-    /// Default application associations
-    #[cfg(feature = "page-default-apps")]
     DefaultApps,
-    /// Desktop settings page
     Desktop,
-    /// Displays settings page
-    #[cfg(feature = "page-display")]
     Displays,
-    /// Dock settings page
-    #[cfg(feature = "wayland")]
     Dock,
-    /// Firmware settings page
     Firmware,
-    /// Input Devices settings page
-    #[cfg(feature = "page-input")]
     Input,
-    /// Keyboard settings page
-    #[cfg(feature = "page-input")]
     Keyboard,
-    /// Legacy Applications settings page
-    #[cfg(feature = "page-legacy-applications")]
     LegacyApplications,
-    /// Mouse settings page
-    #[cfg(feature = "page-input")]
     Mouse,
-    /// Network settings page
-    #[cfg(feature = "page-networking")]
     Network,
-    /// Panel settings page
-    #[cfg(feature = "wayland")]
     Panel,
-    /// Power settings page
-    #[cfg(feature = "page-power")]
     Power,
-    /// Region & Language settings page
-    #[cfg(feature = "page-region")]
     RegionLanguage,
-    /// Sound settings page
-    #[cfg(feature = "page-sound")]
     Sound,
-    /// System & Accounts settings page
     System,
-    /// Time & Language settings page
     Time,
-    /// Touchpad settings page
-    #[cfg(feature = "page-input")]
     Touchpad,
-    /// Users settings page
-    #[cfg(feature = "page-users")]
     Users,
-    /// VPN settings page
-    #[cfg(feature = "page-networking")]
     Vpn,
-    /// Wallpaper settings page
     Wallpaper,
-    /// Window management settings page
-    #[cfg(feature = "page-window-management")]
     WindowManagement,
-    /// Wired settings page
-    #[cfg(feature = "page-networking")]
     Wired,
-    /// WiFi settings page
-    #[cfg(feature = "page-networking")]
     Wireless,
-    /// Workspaces settings page
-    #[cfg(feature = "page-workspaces")]
     Workspaces,
 }
 
+impl PageCommands {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "Accessibility" => Some(Self::Accessibility),
+            "AccessibilityMagnifier" => Some(Self::AccessibilityMagnifier),
+            "About" => Some(Self::About),
+            "Appearance" => Some(Self::Appearance),
+            "Applications" => Some(Self::Applications),
+            "Bluetooth" => Some(Self::Bluetooth),
+            "DateTime" => Some(Self::DateTime),
+            "DefaultApps" => Some(Self::DefaultApps),
+            "Desktop" => Some(Self::Desktop),
+            "Displays" => Some(Self::Displays),
+            "Dock" => Some(Self::Dock),
+            "Firmware" => Some(Self::Firmware),
+            "Input" => Some(Self::Input),
+            "Keyboard" => Some(Self::Keyboard),
+            "LegacyApplications" => Some(Self::LegacyApplications),
+            "Mouse" => Some(Self::Mouse),
+            "Network" => Some(Self::Network),
+            "Panel" => Some(Self::Panel),
+            "Power" => Some(Self::Power),
+            "RegionLanguage" => Some(Self::RegionLanguage),
+            "Sound" => Some(Self::Sound),
+            "System" => Some(Self::System),
+            "Time" => Some(Self::Time),
+            "Touchpad" => Some(Self::Touchpad),
+            "Users" => Some(Self::Users),
+            "Vpn" => Some(Self::Vpn),
+            "Wallpaper" => Some(Self::Wallpaper),
+            "WindowManagement" => Some(Self::WindowManagement),
+            "Wired" => Some(Self::Wired),
+            "Wireless" => Some(Self::Wireless),
+            "Workspaces" => Some(Self::Workspaces),
+            _ => None,
+        }
+    }
+}
+
 impl FromStr for PageCommands {
-    type Err = SpannedError;
+    type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ron::de::from_str(s)
+        PageCommands::from_str(s).ok_or(())
     }
 }
 
 impl std::fmt::Display for PageCommands {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", ron::ser::to_string(self).unwrap())
+        write!(f, "{:?}", self)
     }
 }
 

--- a/cosmic-settings/src/main.rs
+++ b/cosmic-settings/src/main.rs
@@ -51,73 +51,153 @@ impl Args {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PageCommands {
+    /// Accessibility settings page
+    #[cfg(feature = "page-accessibility")]
     Accessibility,
+    /// Accessibility Magnifier settings page
+    #[cfg(feature = "page-accessibility")]
     AccessibilityMagnifier,
+    /// About settings page
+    #[cfg(feature = "page-about")]
     About,
+    /// Appearance settings page
     Appearance,
+    /// Applications settings page
     Applications,
+    /// Bluetooth settings page
+    #[cfg(feature = "page-bluetooth")]
     Bluetooth,
+    /// Date & Time settings page
+    #[cfg(feature = "page-date")]
     DateTime,
+    /// Default application associations
+    #[cfg(feature = "page-default-apps")]
     DefaultApps,
+    /// Desktop settings page
     Desktop,
+    /// Displays settings page
+    #[cfg(feature = "page-display")]
     Displays,
+    /// Dock settings page
+    #[cfg(feature = "wayland")]
     Dock,
+    /// Firmware settings page
     Firmware,
+    /// Input Devices settings page
+    #[cfg(feature = "page-input")]
     Input,
+    /// Keyboard settings page
+    #[cfg(feature = "page-input")]
     Keyboard,
+    /// Legacy Applications settings page
+    #[cfg(feature = "page-legacy-applications")]
     LegacyApplications,
+    /// Mouse settings page
+    #[cfg(feature = "page-input")]
     Mouse,
+    /// Network settings page
+    #[cfg(feature = "page-networking")]
     Network,
+    /// Panel settings page
+    #[cfg(feature = "wayland")]
     Panel,
+    /// Power settings page
+    #[cfg(feature = "page-power")]
     Power,
+    /// Region & Language settings page
+    #[cfg(feature = "page-region")]
     RegionLanguage,
+    /// Sound settings page
+    #[cfg(feature = "page-sound")]
     Sound,
+    /// System & Accounts settings page
     System,
+    /// Time & Language settings page
     Time,
+    /// Touchpad settings page
+    #[cfg(feature = "page-input")]
     Touchpad,
+    /// Users settings page
+    #[cfg(feature = "page-users")]
     Users,
+    /// VPN settings page
+    #[cfg(feature = "page-networking")]
     Vpn,
+    /// Wallpaper settings page
     Wallpaper,
+    /// Window management settings page
+    #[cfg(feature = "page-window-management")]
     WindowManagement,
+    /// Wired settings page
+    #[cfg(feature = "page-networking")]
     Wired,
+    /// WiFi settings page
+    #[cfg(feature = "page-networking")]
     Wireless,
+    /// Workspaces settings page
+    #[cfg(feature = "page-workspaces")]
     Workspaces,
 }
 
 impl PageCommands {
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
+            #[cfg(feature = "page-accessibility")]
             "Accessibility" => Some(Self::Accessibility),
+            #[cfg(feature = "page-accessibility")]
             "AccessibilityMagnifier" => Some(Self::AccessibilityMagnifier),
+            #[cfg(feature = "page-about")]
             "About" => Some(Self::About),
             "Appearance" => Some(Self::Appearance),
             "Applications" => Some(Self::Applications),
+            #[cfg(feature = "page-bluetooth")]
             "Bluetooth" => Some(Self::Bluetooth),
+            #[cfg(feature = "page-date")]
             "DateTime" => Some(Self::DateTime),
+            #[cfg(feature = "page-default-apps")]
             "DefaultApps" => Some(Self::DefaultApps),
             "Desktop" => Some(Self::Desktop),
+            #[cfg(feature = "page-display")]
             "Displays" => Some(Self::Displays),
+            #[cfg(feature = "wayland")]
             "Dock" => Some(Self::Dock),
             "Firmware" => Some(Self::Firmware),
+            #[cfg(feature = "page-input")]
             "Input" => Some(Self::Input),
+            #[cfg(feature = "page-input")]
             "Keyboard" => Some(Self::Keyboard),
+            #[cfg(feature = "page-legacy-applications")]
             "LegacyApplications" => Some(Self::LegacyApplications),
+            #[cfg(feature = "page-input")]
             "Mouse" => Some(Self::Mouse),
+            #[cfg(feature = "page-networking")]
             "Network" => Some(Self::Network),
+            #[cfg(feature = "wayland")]
             "Panel" => Some(Self::Panel),
+            #[cfg(feature = "page-power")]
             "Power" => Some(Self::Power),
+            #[cfg(feature = "page-region")]
             "RegionLanguage" => Some(Self::RegionLanguage),
+            #[cfg(feature = "page-sound")]
             "Sound" => Some(Self::Sound),
             "System" => Some(Self::System),
             "Time" => Some(Self::Time),
+            #[cfg(feature = "page-input")]
             "Touchpad" => Some(Self::Touchpad),
+            #[cfg(feature = "page-users")]
             "Users" => Some(Self::Users),
+            #[cfg(feature = "page-networking")]
             "Vpn" => Some(Self::Vpn),
             "Wallpaper" => Some(Self::Wallpaper),
+            #[cfg(feature = "page-window-management")]
             "WindowManagement" => Some(Self::WindowManagement),
+            #[cfg(feature = "page-networking")]
             "Wired" => Some(Self::Wired),
+            #[cfg(feature = "page-networking")]
             "Wireless" => Some(Self::Wireless),
+            #[cfg(feature = "page-workspaces")]
             "Workspaces" => Some(Self::Workspaces),
+            
             _ => None,
         }
     }

--- a/cosmic-settings/src/main.rs
+++ b/cosmic-settings/src/main.rs
@@ -27,7 +27,6 @@ use i18n_embed::DesktopLanguageRequester;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::prelude::*;
 
-
 pub struct Args {
     sub_command: Option<PageCommands>,
 }


### PR DESCRIPTION
@mmstick mentioned to me that he would like to see clap_lex instead of clap, so... here it is.

To my knowledge, it works perfectly.

The only bad news is that I removed the cfg attributes from individual functions, as they made the code really hard to read.
I think there are better ways to handle specific functionality when it's not applicable to a platform than doing it at compile time.

Feel free to hate it, but please don't leave me in the dark.