### PR TITLE
fix(appearance): Synchronize Roundness between dark & light mode

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -297,14 +297,7 @@ impl Page {
                 self.roundness = r;
 
                 let radii = self.roundness.into();
-
-                if let None = self
-                    .theme_manager
-                    .selected_customizer_mut()
-                    .set_corner_radii(radii)
-                {
-                    return Task::none();
-                }
+                theme_staged = self.theme_manager.set_corner_radii(radii);
 
                 #[cfg(feature = "wayland")]
                 tokio::task::spawn(async move {

--- a/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
@@ -319,6 +319,12 @@ impl Manager {
         Some(ThemeStaged::Both)
     }
 
+    pub fn set_corner_radii(&mut self, radii: CornerRadii) -> Option<ThemeStaged> {
+        self.dark.set_corner_radii(radii)?;
+        self.light.set_corner_radii(radii)?;
+        Some(ThemeStaged::Both)
+    }
+
     pub fn set_gap_size(&mut self, gap: u32) -> Option<ThemeStaged> {
         self.dark.set_gap_size(gap)?;
         self.light.set_gap_size(gap)?;


### PR DESCRIPTION
Tested it locally and now the value gets persisted on both Dark & Light mode when the selection changes in the UI.