### PR TITLE
chore: Stop depending on `once_cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,7 +1714,6 @@ dependencies = [
  "notify 6.1.1",
  "num-derive",
  "num-traits",
- "once_cell",
  "pwhash",
  "regex",
  "ron 0.9.0",

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -53,7 +53,6 @@ libcosmic.workspace = true
 locale1 = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
 mime-apps = { package = "cosmic-mime-apps", git = "https://github.com/pop-os/cosmic-mime-apps", optional = true }
 notify = "6.1.1"
-once_cell = "1.21.1"
 regex = "1.11.1"
 ron = "0.9.0"
 rust-embed = "8.6.0"

--- a/cosmic-settings/src/localize.rs
+++ b/cosmic-settings/src/localize.rs
@@ -5,14 +5,14 @@ use i18n_embed::{
     DefaultLocalizer, LanguageLoader, Localizer,
     fluent::{FluentLanguageLoader, fluent_language_loader},
 };
-use once_cell::sync::Lazy;
 use rust_embed::RustEmbed;
+use std::sync::LazyLock;
 
 #[derive(RustEmbed)]
 #[folder = "../i18n/"]
 struct Localizations;
 
-pub static LANGUAGE_LOADER: Lazy<FluentLanguageLoader> = Lazy::new(|| {
+pub static LANGUAGE_LOADER: LazyLock<FluentLanguageLoader> = LazyLock::new(|| {
     let loader: FluentLanguageLoader = fluent_language_loader!();
 
     loader

--- a/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
@@ -25,10 +25,14 @@ use cosmic::{
     },
     theme,
 };
-use once_cell::sync::Lazy;
 
-use std::path::PathBuf;
-use std::{borrow::Cow, fmt::Debug, mem, path::Path};
+use std::{
+    borrow::Cow,
+    fmt::Debug,
+    mem,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
 
 use crate::{app, pages};
 use cosmic_panel_config::CosmicPanelConfig;
@@ -49,7 +53,7 @@ const MIME_TYPE: &str = "text/uri-list";
 // radius is 8.0
 const DRAG_START_DISTANCE_SQUARED: f32 = 64.0;
 
-pub static APPLET_DND_ICON_ID: Lazy<window::Id> = Lazy::new(window::Id::unique);
+pub static APPLET_DND_ICON_ID: LazyLock<window::Id> = LazyLock::new(window::Id::unique);
 
 pub struct Page {
     pub(crate) entity: page::Entity,
@@ -591,7 +595,7 @@ impl Applet<'static> {
     }
 }
 
-impl<'a> Applet<'a> {
+impl Applet<'_> {
     fn into_owned(self) -> Applet<'static> {
         Applet {
             id: Cow::from(self.id.into_owned()),
@@ -642,7 +646,7 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
             .into_iter()
             .map(|info| {
                 let id_clone = info.id.to_string();
-                let is_dragged = active_dnd.as_ref().map_or(false, |dnd| dnd.id == info.id);
+                let is_dragged = active_dnd.as_ref().is_some_and(|dnd| dnd.id == info.id);
 
                 let content = if is_dragged {
                     row::with_capacity(0).height(Length::Fixed(32.0))
@@ -860,8 +864,8 @@ pub fn dnd_icon(info: Applet<'static>, layout: &layout::Layout) -> AppletReorder
     }
 }
 
-impl<'a, Message: 'static> Widget<Message, cosmic::Theme, cosmic::Renderer>
-    for AppletReorderList<'a, Message>
+impl<Message: 'static> Widget<Message, cosmic::Theme, cosmic::Renderer>
+    for AppletReorderList<'_, Message>
 where
     Message: Clone,
 {

--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -16,24 +16,30 @@ use cosmic_randr_shell::{
     AdaptiveSyncAvailability, AdaptiveSyncState, List, Output, OutputKey, Transform,
 };
 use cosmic_settings_page::{self as page, Section, section};
-use once_cell::sync::Lazy;
 use slab::Slab;
 use slotmap::{Key, SecondaryMap, SlotMap};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::{collections::BTreeMap, process::ExitStatus, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    process::ExitStatus,
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 use tokio::sync::oneshot;
 
 static DPI_SCALES: &[u32] = &[50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300];
 
-static DPI_SCALE_LABELS: Lazy<Vec<String>> =
-    Lazy::new(|| DPI_SCALES.iter().map(|scale| format!("{scale}%")).collect());
+static DPI_SCALE_LABELS: LazyLock<Vec<String>> =
+    LazyLock::new(|| DPI_SCALES.iter().map(|scale| format!("{scale}%")).collect());
 
 /// Display color depth options
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug)]
 pub struct ColorDepth(usize);
 
-/// Identifies the content to display in the context drawer
+// /// Identifies the content to display in the context drawer
 // pub enum ContextDrawer {
 //     NightLight,
 // }
@@ -234,8 +240,6 @@ impl page::Page<crate::pages::Message> for Page {
 
     #[cfg(not(feature = "test"))]
     fn on_enter(&mut self) -> Task<crate::pages::Message> {
-        use std::time::Duration;
-
         self.cache.orientations = [
             fl!("orientation", "standard"),
             fl!("orientation", "rotate-90"),


### PR DESCRIPTION
As-salamu alaykum.

In Rust 1.80, `LazyLock` was added, making `once_cell::sync::Cell` obsolete.

I couldn't resist fixing Clippy's lints in the files I changed, including a documentation bug.

I also moved `use std::time::Duration` to the top, since it was used outside the function it was defined in.