### PR TITLE
fix(wallpaper): Wallpaper flickering when starting into the wallpaper page.

### DIFF
--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -946,7 +946,8 @@ impl Page {
                             selection.into_vec(),
                         ),
                     );
-
+                }
+                WallpaperEvent::Loaded => {
                     // `selection.active` is usually empty because `change_folder` creates a fresh context.
                     // This leads to blank previews in certain conditions when the program is restarted.
                     let fix_active = match self.selection.active {
@@ -975,8 +976,9 @@ impl Page {
                                 }
                             }
                     }
+
+                    self.cache_display_image()
                 }
-                WallpaperEvent::Loaded => self.cache_display_image(),
                 WallpaperEvent::Error(error) => {
                     tracing::error!("Failed to load wallpaper: {}", error);
                 }


### PR DESCRIPTION
Fixes: #1264

I just copied the "fix" code from `WallpaperEvent::Load` to `WallpaperEvent::Loaded`, so it only runs after we finish loading wallpapers, or at least this is what I think I did. The change isn't obvious when viewing the diff.