### PR TITLE
Improve device name layout with text wrapping

### DIFF
--- a/cosmic-settings/src/pages/system/about.rs
+++ b/cosmic-settings/src/pages/system/about.rs
@@ -5,6 +5,7 @@ use cosmic_settings_page::{self as page, Section, section};
 
 use cosmic::widget::{editable_input, list_column, settings, text};
 use cosmic::{Apply, Task};
+use cosmic::iced_core::text::Wrapping;
 use cosmic_settings_system::about::Info;
 use slab::Slab;
 use slotmap::SlotMap;
@@ -182,9 +183,15 @@ fn device() -> Section<crate::pages::Message> {
             .on_unfocus(Message::HostnameSubmit)
             .on_submit(|_| Message::HostnameSubmit);
 
-            let device_name = settings::item::builder(&*desc[device])
-                .description(&*desc[device_desc])
-                .flex_control(hostname_input);
+            let device_name = settings::item_row(vec![
+                cosmic::widget::column::with_capacity(2)
+                    .push(text::body(&*desc[device]))
+                    .push(text::caption(&*desc[device_desc]).wrapping(Wrapping::Word))
+                    .spacing(4)
+                    .into(),
+                cosmic::widget::horizontal_space().into(),
+                hostname_input.into(),
+            ]);
 
             list_column()
                 .add(device_name)

--- a/cosmic-settings/src/pages/system/about.rs
+++ b/cosmic-settings/src/pages/system/about.rs
@@ -178,23 +178,20 @@ fn device() -> Section<crate::pages::Message> {
                 page.editing_device_name,
                 Message::HostnameEdit,
             )
-            .width(250)
+            .width(cosmic::iced::Length::FillPortion(1))
             .on_input(Message::HostnameInput)
             .on_unfocus(Message::HostnameSubmit)
             .on_submit(|_| Message::HostnameSubmit);
 
-            let device_name = settings::item_row(vec![
-                cosmic::widget::column::with_capacity(2)
-                    .push(text::body(&*desc[device]))
-                    .push(text::caption(&*desc[device_desc]).wrapping(Wrapping::Word))
-                    .spacing(4)
-                    .into(),
-                cosmic::widget::horizontal_space().into(),
-                hostname_input.into(),
-            ]);
+            let device_name = cosmic::widget::column::with_capacity(3)
+                .push(text::body(&*desc[device]))
+                .push(text::caption(&*desc[device_desc]).wrapping(Wrapping::Word))
+                .push(cosmic::widget::vertical_space().height(cosmic::iced::Length::Fixed(8.0)))
+                .push(hostname_input.width(cosmic::iced::Length::Fill))
+                .spacing(4);
 
             list_column()
-                .add(device_name)
+                .add(settings::item_row(vec![device_name.into()]))
                 .apply(cosmic::Element::from)
                 .map(crate::pages::Message::About)
         })


### PR DESCRIPTION
## Summary
- Add text wrapping to device description text to prevent layout issues
- Convert device name settings item to use item_row for better control over layout
- Improve spacing and visual hierarchy in the device settings section

## Test plan
- Test device name section with long descriptions
- Verify text wrapping works properly
- Check that layout remains consistent across different screen sizes