### PR TITLE
fix: also accept "wheel" as group name for polkit authentication

### DIFF
--- a/resources/polkit-1/rules.d/cosmic-settings.rules
+++ b/resources/polkit-1/rules.d/cosmic-settings.rules
@@ -6,7 +6,7 @@ polkit.addRule(function(action, subject) {
             action.id == "org.freedesktop.hostname1.set-hostname") &&
         subject.local &&
         subject.active &&
-        subject.isInGroup ("sudo")) {
+        (subject.isInGroup("sudo") || subject.isInGroup("wheel"))) {
             return polkit.Result.YES;
         }
 });


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-settings/issues/1293