### PR TITLE
keyboard: Add the ability to disable the Caps Lock key entirely + Replace misleading "None" with "Default"

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/mod.rs
@@ -628,11 +628,7 @@ impl Page {
 
         let mut list = cosmic::widget::list_column();
 
-        if matches!(special_key, SpecialKey::CapsLock) {
-            list = list.add(special_char_radio_row("Caps Lock", None, current));
-        } else {
-            list = list.add(special_char_radio_row("None", None, current));
-        }
+        list = list.add(special_char_radio_row("Default", None, current));
 
         list = options
             .iter()


### PR DESCRIPTION
The Keyboards settings currently offer quite a few options to remap the caps lock key to other functions, however not disabling it completely.

Additionally, the current text for the default behavior of the Alternative Characters Key and Compose Key is `None`  and `Caps Lock` for Caps Lock. I believe a `Default` fits better and is less misleading.

I was unable to find any Contributors Guide for this project, so please feel free to ask me for any changes if necessary.