### PR TITLE
Update swedish translation for auto suspend

### DIFF
--- a/i18n/sv/cosmic_settings.ftl
+++ b/i18n/sv/cosmic_settings.ftl
@@ -614,9 +614,9 @@ power-mode = Strömalternativ
 
 power-saving = Energisparalternativ
     .turn-off-screen-after = Stäng av skärmen efter
-    .auto-suspend = Automatisk suspendering
-    .auto-suspend-ac = Automatisk suspendering vid inkoppling
-    .auto-suspend-battery = Automatisk suspendering på batteridrift
+    .auto-suspend = Automatiskt vänteläge
+    .auto-suspend-ac = Automatiskt vänteläge vid inkoppling
+    .auto-suspend-battery = Automatiskt vänteläge på batteridrift
 
 ## Input
 


### PR DESCRIPTION
Change the translation for auto suspend to use the more established word "vänteläge" (which also is used elsewhere in the translations), instead of "suspendering" which is a bit of a Swenglish term.