### PR TITLE
fix(vpn): set data ciphers

### DIFF
--- a/cosmic-settings/src/pages/networking/vpn/mod.rs
+++ b/cosmic-settings/src/pages/networking/vpn/mod.rs
@@ -683,6 +683,17 @@ impl Page {
                 });
             }
 
+            if let Err(why) = nmcli::add_fallback(&connection_name).await {
+                return Message::VpnDialogError(VpnDialog::Password {
+                    error: Some((ErrorKind::Config, why.to_string())),
+                    id: connection_name.clone(),
+                    uuid,
+                    username,
+                    password,
+                    password_hidden: true,
+                });
+            }
+
             if let Err(why) = nmcli::set_password_flags_none(&connection_name).await {
                 return Message::VpnDialogError(VpnDialog::Password {
                     error: Some((ErrorKind::WithPassword("password-flags"), why.to_string())),

--- a/cosmic-settings/src/pages/networking/vpn/nmcli.rs
+++ b/cosmic-settings/src/pages/networking/vpn/nmcli.rs
@@ -28,6 +28,21 @@ pub async fn set_password_flags_none(connection_name: &str) -> Result<(), String
         .apply(crate::utils::map_stderr_output)
 }
 
+pub async fn add_fallback(connection_name: &str) -> Result<(), String> {
+    tokio::process::Command::new("nmcli")
+        .args([
+            "con",
+            "mod",
+            connection_name,
+            "+vpn.data",
+            "data-ciphers=AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305:AES-256-CBC:AES-128-CBC",
+        ])
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .apply(crate::utils::map_stderr_output)
+}
+
 pub async fn set_password(connection_name: &str, password: &str) -> Result<(), String> {
     tokio::process::Command::new("nmcli")
         .args([


### PR DESCRIPTION
Adds a list of ciphers in priority order to use and fall back to. fixes #692 