### PR TITLE
fix(font): remove intrusive filter for fonts

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/font_config.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/font_config.rs
@@ -28,10 +28,7 @@ pub fn load_font_families() -> (Vec<Arc<str>>, Vec<Arc<str>>) {
         font_system.raw().db().faces().fold(
             (Vec::new(), Vec::new()),
             |(mut interface, mut mono), face| {
-                if face.stretch != fontdb::Stretch::Normal
-                    || face.weight != fontdb::Weight::NORMAL
-                    || face.style != fontdb::Style::Normal
-                {
+                if face.stretch != fontdb::Stretch::Normal || face.style != fontdb::Style::Normal {
                     return (interface, mono);
                 }
 


### PR DESCRIPTION
Some regular fonts that have slightly higher weights get filtered out due to the filter used in the font loading function being a little too intrusive.

Remove the condition for font weight to be regular so that all fonts will be available to be set for the interface/mono fonts.

Others like KDE, Gnome do not filter out fonts with higher weights since on the same system, other DEs allow the fonts to be selected. So there is need for Cosmic DE to filter out these fonts.

Fixes: https://github.com/pop-os/cosmic-settings/issues/859