### PR TITLE
fix: adding fallback for Hardware Model and Processor in the About section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
  "smithay-client-toolkit",
  "static_init",
  "sunrise",
+ "sysinfo 0.37.0",
  "tachyonix",
  "timedate-zbus",
  "tokio",
@@ -1807,7 +1808,7 @@ dependencies = [
  "concat-in-place",
  "const_format",
  "memchr",
- "sysinfo",
+ "sysinfo 0.36.1",
 ]
 
 [[package]]
@@ -7353,6 +7354,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07cec4dc2d2e357ca1e610cfb07de2fa7a10fc3e9fe89f72545f3d244ea87753"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8432,7 +8447,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,6 @@ dependencies = [
  "smithay-client-toolkit",
  "static_init",
  "sunrise",
- "sysinfo",
  "tachyonix",
  "timedate-zbus",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
  "smithay-client-toolkit",
  "static_init",
  "sunrise",
- "sysinfo 0.37.0",
+ "sysinfo",
  "tachyonix",
  "timedate-zbus",
  "tokio",
@@ -1808,7 +1808,7 @@ dependencies = [
  "concat-in-place",
  "const_format",
  "memchr",
- "sysinfo 0.36.1",
+ "sysinfo",
 ]
 
 [[package]]
@@ -7344,20 +7344,6 @@ name = "sysinfo"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.61.3",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cec4dc2d2e357ca1e610cfb07de2fa7a10fc3e9fe89f72545f3d244ea87753"
 dependencies = [
  "libc",
  "memchr",

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -89,6 +89,7 @@ async-fn-stream = "0.2.2"
 num-traits = "0.2"
 num-derive = "0.4"
 pwhash = "1"
+sysinfo = "0.37.0"
 
 [dependencies.icu]
 version = "1.5.0"

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -89,7 +89,7 @@ async-fn-stream = "0.2.2"
 num-traits = "0.2"
 num-derive = "0.4"
 pwhash = "1"
-sysinfo = "0.37.0"
+sysinfo = "0.36.0"
 
 [dependencies.icu]
 version = "1.5.0"

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -89,7 +89,6 @@ async-fn-stream = "0.2.2"
 num-traits = "0.2"
 num-derive = "0.4"
 pwhash = "1"
-sysinfo = "0.36.0"
 
 [dependencies.icu]
 version = "1.5.0"

--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -118,7 +118,6 @@ pub fn architecture(bump: &Bump, arch: &mut String) {
 
 pub fn hardware_model(bump: &Bump, hardware_model: &mut String) {
     let buffer = &mut bumpalo::collections::Vec::new_in(bump);
-
     if let Some(mut sys_vendor) = read_to_string(SYS_VENDOR, buffer) {
         sys_vendor = sys_vendor.trim();
 

--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -7,8 +7,6 @@ use std::{collections::HashSet, ffi::OsStr, io::Read};
 use concat_in_place::strcat;
 use const_format::concatcp;
 
-use sysinfo::{CpuRefreshKind, Product, RefreshKind, System};
-
 const DMI_DIR: &str = "/sys/devices/virtual/dmi/id/";
 const BOARD_NAME: &str = concatcp!(DMI_DIR, "board_name");
 const BOARD_VERSION: &str = concatcp!(DMI_DIR, "board_version");
@@ -151,7 +149,7 @@ pub fn hardware_model(bump: &Bump, hardware_model: &mut String) {
         }
     } else {
         // simple fallback to sysinfo if DMI information is not available
-        hardware_model.push_str(&Product::name().unwrap_or("".to_string()));
+        hardware_model.push_str(&sysinfo::Product::name().unwrap_or("".to_string()));
     }
 }
 
@@ -195,7 +193,7 @@ pub fn processor_name(bump: &Bump, name: &mut String) {
 
     // fallback to sysinfo if /proc/cpuinfo is not present
     let s =
-        System::new_with_specifics(RefreshKind::nothing().with_cpu(CpuRefreshKind::everything()));
+        sysinfo::System::new_with_specifics(sysinfo::RefreshKind::nothing().with_cpu(sysinfo::CpuRefreshKind::everything()));
     name.push_str(s.cpus().into_iter().nth(0).unwrap().brand());
 }
 

--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -119,8 +119,6 @@ pub fn architecture(bump: &Bump, arch: &mut String) {
 }
 
 pub fn hardware_model(bump: &Bump, hardware_model: &mut String) {
-    hardware_model.push_str(&Product::name().unwrap());
-
     let buffer = &mut bumpalo::collections::Vec::new_in(bump);
 
     if let Some(mut sys_vendor) = read_to_string(SYS_VENDOR, buffer) {
@@ -153,7 +151,7 @@ pub fn hardware_model(bump: &Bump, hardware_model: &mut String) {
         }
     } else {
         // simple fallback to sysinfo if DMI information is not available
-        hardware_model.push_str(&Product::name().unwrap());
+        hardware_model.push_str(&Product::name().unwrap_or("".to_string()));
     }
 }
 
@@ -195,7 +193,7 @@ pub fn processor_name(bump: &Bump, name: &mut String) {
         }
     }
 
-    // fallback to sysinfo if cpuinfo is not present (e.g. asahi linux on M series macs)
+    // fallback to sysinfo if /proc/cpuinfo is not present
     let s =
         System::new_with_specifics(RefreshKind::nothing().with_cpu(CpuRefreshKind::everything()));
     name.push_str(s.cpus().into_iter().nth(0).unwrap().brand());


### PR DESCRIPTION
Addresses issue https://github.com/pop-os/cosmic-settings/issues/1346

This provides fallback values for Hardware Model and Processor, using the sysinfo crate that's already used for other values on the page. This should guarantee no blank values, but currently I've only been able to test on a M1 Macbook Air running Asahi Fedora.

<img width="1313" height="812" alt="Screenshot_2025-09-08_00-22-52" src="https://github.com/user-attachments/assets/cc4c4711-6646-41bb-a71e-cea07b8c3a66" />


