### PR TITLE
fix(shortcuts): ignore keyboard input when replace dialog is active

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
@@ -614,7 +614,7 @@ impl Model {
         &self,
         _core: &cosmic::Core,
     ) -> cosmic::iced::Subscription<ShortcutMessage> {
-        if self.editing.is_some() {
+        if self.editing.is_some() && self.replace_dialog.is_none() {
             listen_with(|event, _, _| match event {
                 iced::event::Event::Keyboard(iced::keyboard::Event::KeyPressed {
                     key,

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/custom.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/custom.rs
@@ -548,7 +548,10 @@ impl page::Page<crate::pages::Message> for Page {
         use cosmic::iced::{self, event::listen_with};
 
         cosmic::iced::Subscription::batch(vec![
-            if self.add_shortcut.active && self.add_shortcut.editing.is_some() {
+            if self.add_shortcut.active
+                && self.add_shortcut.editing.is_some()
+                && self.replace_dialog.is_empty()
+            {
                 listen_with(|event, _, _| match event {
                     iced::event::Event::Keyboard(iced::keyboard::Event::KeyPressed {
                         key,


### PR DESCRIPTION
fixes #1383 