### PR TITLE
Match font and timezone selection context item styling to designs

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -996,7 +996,7 @@ impl SettingsApp {
             if section
                 .show_while
                 .as_ref()
-                .map_or(true, |func| func(model.as_ref()))
+                .is_none_or(|func| func(model.as_ref()))
             {
                 sections_column.push(
                     (section.view_fn)(&self.pages, model.as_ref(), section)
@@ -1108,7 +1108,7 @@ impl SettingsApp {
             if section
                 .show_while
                 .as_ref()
-                .map_or(true, |func| func(model.as_ref()))
+                .is_none_or(|func| func(model.as_ref()))
             {
                 let section = (section.view_fn)(&self.pages, model.as_ref(), section)
                     .map(Message::PageMessage)

--- a/cosmic-settings/src/config.rs
+++ b/cosmic-settings/src/config.rs
@@ -19,6 +19,12 @@ pub struct Config {
     state: cosmic_config::Config,
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Config {
     pub fn new() -> Self {
         let config = match cosmic_config::Config::new(NAME, 1) {

--- a/cosmic-settings/src/pages/accessibility/mod.rs
+++ b/cosmic-settings/src/pages/accessibility/mod.rs
@@ -231,7 +231,7 @@ pub fn vision() -> section::Section<crate::pages::Message> {
                         text::body(status_text).wrapping(Wrapping::Word),
                         page.wayland_available
                             .is_some()
-                            .then_some(crate::pages::Message::Page(magnifier_entity).into()),
+                            .then_some(crate::pages::Message::Page(magnifier_entity)),
                     )
                 })
                 .add(
@@ -270,7 +270,7 @@ pub fn vision() -> section::Section<crate::pages::Message> {
                         Some(page.screen_filter_selection as usize),
                         move |idx| {
                             let filter = ColorFilter::from_usize(idx).unwrap_or_default();
-                            Message::SetScreenFilterSelection(filter).into()
+                            Message::SetScreenFilterSelection(filter)
                         },
                         cosmic::iced::window::Id::RESERVED,
                         Message::Surface,

--- a/cosmic-settings/src/pages/applications/default_apps.rs
+++ b/cosmic-settings/src/pages/applications/default_apps.rs
@@ -187,16 +187,13 @@ impl Page {
                             .iter()
                             .map(|m| m.essence_str())
                             .filter(|m| m.starts_with("audio"))
-                            .chain(
-                                [
-                                    "application/ogg",
-                                    "application/x-cue",
-                                    "application/x-ogg",
-                                    "audio/mp3",
-                                    "x-content/audio-cdda",
-                                ]
-                                .into_iter(),
-                            )
+                            .chain([
+                                "application/ogg",
+                                "application/x-cue",
+                                "application/x-ogg",
+                                "audio/mp3",
+                                "x-content/audio-cdda",
+                            ])
                             .collect();
                         &mime_types
                     }),
@@ -528,7 +525,7 @@ async fn load_defaults(assocs: &BTreeMap<Arc<str>, Arc<App>>, for_mimes: &[&str]
 
 async fn xdg_mime_query_default(mime_type: &str) -> Option<String> {
     let output = tokio::process::Command::new("xdg-mime")
-        .args(&["query", "default", mime_type])
+        .args(["query", "default", mime_type])
         .output()
         .await
         .ok()?;

--- a/cosmic-settings/src/pages/applications/startup_apps.rs
+++ b/cosmic-settings/src/pages/applications/startup_apps.rs
@@ -63,9 +63,9 @@ enum Context {
     AddApplication(DirectoryType),
 }
 
-impl Into<Vec<PathBuf>> for DirectoryType {
-    fn into(self) -> Vec<PathBuf> {
-        match self {
+impl From<DirectoryType> for Vec<PathBuf> {
+    fn from(val: DirectoryType) -> Self {
+        match val {
             DirectoryType::User => vec![
                 dirs::config_dir()
                     .expect("config dir not found")
@@ -121,7 +121,7 @@ impl page::Page<crate::pages::Message> for Page {
                 Some(
                     cosmic::app::context_drawer(
                         self.add_application_context_view(directory_type.clone()),
-                        crate::pages::Message::CloseContextDrawer.into(),
+                        crate::pages::Message::CloseContextDrawer,
                     )
                     .title(fl!("startup-apps", "search-for-application"))
                     .header(search),
@@ -224,7 +224,7 @@ impl Page {
                 let directories: Vec<PathBuf> = directory_type.clone().into();
 
                 let directory_to_target =
-                    directories.get(0).expect("Always at least one directory");
+                    directories.first().expect("Always at least one directory");
 
                 _ = std::fs::create_dir_all(directory_to_target.as_path());
 
@@ -271,7 +271,7 @@ impl Page {
                     let directories: Vec<PathBuf> = directory_type.clone().into();
 
                     let directory_to_target =
-                        directories.get(0).expect("Always at least one directory");
+                        directories.first().expect("Always at least one directory");
                     if let Ok(exists) = std::fs::exists(directory_to_target.join(file_name.clone()))
                     {
                         if exists {

--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -830,7 +830,7 @@ fn connected_devices() -> Section<crate::pages::Message> {
                         .model
                         .popup_device
                         .as_deref()
-                        .map_or(false, |p| path.as_str() == p.as_str())
+                        .is_some_and(|p| path.as_str() == p.as_str())
                     {
                         widget::popover(
                             widget::button::icon(widget::icon::from_name("view-more-symbolic"))
@@ -1012,21 +1012,21 @@ mod systemd {
 
     pub fn activate_bluetooth() -> impl Future<Output = ()> + Send {
         tokio::process::Command::new("pkexec")
-            .args(&["systemctl", "start", "bluetooth"])
+            .args(["systemctl", "start", "bluetooth"])
             .status()
             .map(|_| ())
     }
 
     pub fn enable_bluetooth() -> impl Future<Output = ()> + Send {
         tokio::process::Command::new("pkexec")
-            .args(&["systemctl", "enable", "--now", "bluetooth"])
+            .args(["systemctl", "enable", "--now", "bluetooth"])
             .status()
             .map(|_| ())
     }
 
     pub fn is_bluetooth_enabled() -> bool {
         std::process::Command::new("systemctl")
-            .args(&["is-enabled", "bluetooth"])
+            .args(["is-enabled", "bluetooth"])
             .status()
             .map(|status| status.success())
             .unwrap_or(true)
@@ -1034,7 +1034,7 @@ mod systemd {
 
     pub fn is_bluetooth_active() -> bool {
         std::process::Command::new("systemctl")
-            .args(&["is-active", "bluetooth"])
+            .args(["is-active", "bluetooth"])
             .status()
             .map(|status| status.success())
             .unwrap_or(true)

--- a/cosmic-settings/src/pages/desktop/appearance/drawer.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/drawer.rs
@@ -129,7 +129,7 @@ impl Content {
     ) -> Task<app::Message> {
         match message {
             FontMessage::FontLoaded(interface, mono) => {
-                return self.font_config.font_loaded(mono, interface);
+                self.font_config.font_loaded(mono, interface)
             }
             FontMessage::Search(input) => match context_view {
                 None => Task::none(),
@@ -141,7 +141,7 @@ impl Content {
                         return task;
                     }
                 }
-                return Task::none();
+                Task::none()
             }
         }
     }

--- a/cosmic-settings/src/pages/desktop/appearance/font_config.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/font_config.rs
@@ -38,15 +38,12 @@ pub fn load_font_families() -> (Vec<Arc<str>>, Vec<Arc<str>>) {
                 };
 
                 if face.monospaced {
-                    if mono
-                        .last()
-                        .map_or(true, |name| &**name != font_name.as_str())
-                    {
+                    if mono.last().is_none_or(|name| &**name != font_name.as_str()) {
                         mono.push(Arc::from(font_name.as_str()));
                     }
                 } else if interface
                     .last()
-                    .map_or(true, |name| &**name != font_name.as_str())
+                    .is_none_or(|name| &**name != font_name.as_str())
                 {
                     interface.push(Arc::from(font_name.as_str()));
                 }
@@ -73,6 +70,12 @@ pub struct Model {
 
     monospace_font_families: Vec<Arc<str>>,
     pub monospace_font: FontConfig,
+}
+
+impl Default for Model {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Model {
@@ -118,7 +121,7 @@ impl Model {
                 };
 
                 update_config(MONOSPACE_FONT, self.monospace_font.clone());
-                return None;
+                None
             }
             ContextView::SystemFont => {
                 self.interface_font = FontConfig {
@@ -131,9 +134,9 @@ impl Model {
                 tokio::spawn(async move {
                     set_gnome_font_name(font.as_ref()).await;
                 });
-                return None;
+                None
             }
-            _ => return None,
+            _ => None,
         }
     }
 
@@ -148,7 +151,7 @@ impl Model {
                 fonts
                     .iter()
                     .filter(|f| f.to_lowercase().contains(&self.font_search))
-                    .map(|f| f.clone())
+                    .cloned()
                     .collect(),
             );
         }

--- a/cosmic-settings/src/pages/desktop/appearance/font_config.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/font_config.rs
@@ -175,7 +175,7 @@ impl Model {
         callback: impl Fn(Arc<str>) -> super::Message,
     ) -> Element<'_, super::Message> {
         let svg_accent = Rc::new(|theme: &cosmic::Theme| svg::Style {
-            color: Some(theme.cosmic().accent_color().into()),
+            color: Some(theme.cosmic().accent_text_color().into()),
         });
 
         let (mut families, current_font) = match *context_view {
@@ -195,6 +195,11 @@ impl Model {
             list.add(
                 settings::item_row(vec![
                     widget::text::body(&**family)
+                        .class(if selected {
+                            cosmic::theme::Text::Accent
+                        } else {
+                            cosmic::theme::Text::Default
+                        })
                         .wrapping(Wrapping::Word)
                         .width(cosmic::iced::Length::Fill)
                         .into(),

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -302,7 +302,7 @@ impl Page {
                 theme_staged = self
                     .theme_manager
                     .selected_customizer_mut()
-                    .set_accent(Some(c).map(Srgb::from));
+                    .set_accent(Some(Srgb::from(c)));
             }
 
             Message::Reset => {

--- a/cosmic-settings/src/pages/desktop/appearance/mode_and_colors.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mode_and_colors.rs
@@ -26,13 +26,13 @@ pub fn section() -> Section<crate::pages::Message> {
 
             let mut section = settings::section()
                 .title(&section.title)
-                .add(theme_mode(&page, section, &label_keys))
-                .add(auto_switch(&page, section, &label_keys))
-                .add(accent_color_palette(&page, section, &label_keys))
-                .add(application_background(&page, section, &label_keys))
-                .add(container_background(&page, section, &label_keys))
-                .add(interface_text(&page, section, &label_keys))
-                .add(control_tint(&page, section, &label_keys))
+                .add(theme_mode(page, section, &label_keys))
+                .add(auto_switch(page, section, &label_keys))
+                .add(accent_color_palette(page, section, &label_keys))
+                .add(application_background(page, section, &label_keys))
+                .add(container_background(page, section, &label_keys))
+                .add(interface_text(page, section, &label_keys))
+                .add(control_tint(page, section, &label_keys))
                 .add(
                     settings::item::builder(&descriptions[label_keys["window_hint_toggle"]])
                         .toggler(
@@ -196,16 +196,13 @@ fn accent_color_palette<'a>(
     let mut accent_palette_row = Vec::with_capacity(accent.len());
 
     for &color in accent {
-        accent_palette_row.push(
-            color_button(
-                Some(Message::PaletteAccent(color.into())),
-                color.into(),
-                cur_accent == color,
-                48,
-                48,
-            )
-            .into(),
-        );
+        accent_palette_row.push(color_button(
+            Some(Message::PaletteAccent(color.into())),
+            color.into(),
+            cur_accent == color,
+            48,
+            48,
+        ));
     }
 
     accent_palette_row.push(

--- a/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
@@ -85,7 +85,7 @@ impl From<(Option<Config>, Option<Config>, Option<Vec<Srgba>>)> for ThemeCustomi
             custom_window_hint: None,
         };
 
-        if let None = customizer.accent_palette {
+        if customizer.accent_palette.is_none() {
             let palette = customizer.builder.0.palette.as_ref();
             customizer.accent_palette = Some(vec![
                 palette.accent_blue,
@@ -159,7 +159,7 @@ impl Default for Manager {
 }
 
 impl Manager {
-    pub fn build_theme<'a>(&mut self, stage: ThemeStaged) -> Task<app::Message> {
+    pub fn build_theme(&mut self, stage: ThemeStaged) -> Task<app::Message> {
         macro_rules! theme_transaction {
             ($config:ident, $current_theme:ident, $new_theme:ident, { $($name:ident;)+ }) => {
                 let tx = $config.transaction();
@@ -194,10 +194,10 @@ impl Manager {
             None
         };
 
-        let mut data = std::iter::once(current).chain(other.into_iter());
+        let mut data = std::iter::once(current).chain(other);
 
         cosmic::task::future(async move {
-            while let Some((builder, config)) = data.next() {
+            for (builder, config) in data.by_ref() {
                 if let Some(config) = config {
                     let current_theme = match Theme::get_entry(&config) {
                         Ok(theme) => theme,
@@ -277,7 +277,7 @@ impl Manager {
 
     #[inline]
     pub fn custom_window_hint(&self) -> &Option<Srgb> {
-        &self.selected_customizer().custom_window_hint()
+        self.selected_customizer().custom_window_hint()
     }
 
     #[inline]

--- a/cosmic-settings/src/pages/desktop/dock/mod.rs
+++ b/cosmic-settings/src/pages/desktop/dock/mod.rs
@@ -68,7 +68,7 @@ impl Page {
             }
             Message::Inner(inner) => {
                 if let inner::Message::Surface(a) = inner {
-                    return cosmic::task::message(crate::app::Message::Surface(a));
+                    cosmic::task::message(crate::app::Message::Surface(a))
                 } else {
                     self.inner
                         .update(inner)

--- a/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/applets_inner.rs
@@ -590,7 +590,7 @@ impl Applet<'static> {
     }
 }
 
-impl<'a> Applet<'a> {
+impl Applet<'_> {
     fn into_owned(self) -> Applet<'static> {
         Applet {
             id: Cow::from(self.id.into_owned()),
@@ -641,7 +641,7 @@ impl<'a, Message: 'static + Clone> AppletReorderList<'a, Message> {
             .into_iter()
             .map(|info| {
                 let id_clone = info.id.to_string();
-                let is_dragged = active_dnd.as_ref().map_or(false, |dnd| dnd.id == info.id);
+                let is_dragged = active_dnd.as_ref().is_some_and(|dnd| dnd.id == info.id);
 
                 let content = if is_dragged {
                     row::with_capacity(0).height(Length::Fixed(32.0))
@@ -859,8 +859,8 @@ pub fn dnd_icon(info: Applet<'static>, layout: &layout::Layout) -> AppletReorder
     }
 }
 
-impl<'a, Message: 'static> Widget<Message, cosmic::Theme, cosmic::Renderer>
-    for AppletReorderList<'a, Message>
+impl<Message: 'static> Widget<Message, cosmic::Theme, cosmic::Renderer>
+    for AppletReorderList<'_, Message>
 where
     Message: Clone,
 {

--- a/cosmic-settings/src/pages/desktop/panel/mod.rs
+++ b/cosmic-settings/src/pages/desktop/panel/mod.rs
@@ -24,7 +24,7 @@ pub struct Message(pub inner::Message);
 impl Page {
     pub fn update(&mut self, message: Message) -> Task<crate::app::Message> {
         if let inner::Message::Surface(a) = message.0 {
-            return cosmic::task::message(crate::app::Message::Surface(a));
+            cosmic::task::message(crate::app::Message::Surface(a))
         } else {
             self.inner
                 .update(message.0)

--- a/cosmic-settings/src/pages/desktop/wallpaper/config.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/config.rs
@@ -14,7 +14,7 @@ const CURRENT_FOLDER: &str = "current-folder";
 const CUSTOM_COLORS: &str = "custom-colors";
 const CUSTOM_IMAGES: &str = "custom-images";
 const RECENT_FOLDERS: &str = "recent-folders";
-const BACKGROUNDS_DIR: &'static str = "backgrounds";
+const BACKGROUNDS_DIR: &str = "backgrounds";
 
 #[derive(Debug, Default)]
 pub struct Config {

--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -1213,7 +1213,7 @@ pub fn settings() -> Section<crate::pages::Message> {
             let mut slideshow_enabled = page
                 .config_output()
                 .and_then(|output| page.wallpaper_service_config.entry(output))
-                .map_or(false, |entry| {
+                .is_some_and(|entry| {
                     if let Source::Path(path) = &entry.source {
                         path.is_dir()
                     } else {

--- a/cosmic-settings/src/pages/desktop/wallpaper/widgets.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/widgets.rs
@@ -118,11 +118,7 @@ pub fn color_select_options(
             })
             .chain(wallpaper::DEFAULT_COLORS.iter().map(|color| (color, false)))
             .map(|(color, removable)| {
-                color_button(
-                    color.clone(),
-                    removable,
-                    selected.map_or(false, |selection| selection == color),
-                )
+                color_button(color.clone(), removable, selected == Some(color))
             })
             .collect::<Vec<_>>(),
     )
@@ -146,7 +142,7 @@ pub fn wallpaper_select_options(
                 handle,
                 *id,
                 true,
-                selected.map_or(false, |selection| id == &selection),
+                selected.is_some_and(|selection| id == &selection),
             ));
         }
     }
@@ -157,12 +153,7 @@ pub fn wallpaper_select_options(
             continue;
         }
 
-        vec.push(wallpaper_button(
-            handle,
-            id,
-            false,
-            selected.map_or(false, |selection| id == selection),
-        ));
+        vec.push(wallpaper_button(handle, id, false, selected == Some(id)));
     }
 
     flex_select_row(vec)

--- a/cosmic-settings/src/pages/display/arrangement.rs
+++ b/cosmic-settings/src/pages/display/arrangement.rs
@@ -79,7 +79,7 @@ impl<'a, Message> Arrangement<'a, Message> {
     }
 }
 
-impl<'a, Message: Clone> Widget<Message, cosmic::Theme, Renderer> for Arrangement<'a, Message> {
+impl<Message: Clone> Widget<Message, cosmic::Theme, Renderer> for Arrangement<'_, Message> {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<State>()
     }
@@ -119,7 +119,7 @@ impl<'a, Message: Clone> Widget<Message, cosmic::Theme, Renderer> for Arrangemen
                 continue;
             };
 
-            let (mut width, mut height) = if output.transform.map_or(true, is_landscape) {
+            let (mut width, mut height) = if output.transform.is_none_or(is_landscape) {
                 (mode.size.0, mode.size.1)
             } else {
                 (mode.size.1, mode.size.0)
@@ -420,7 +420,7 @@ fn display_regions<'a>(
                 (mode.size.1 as f32 / output.scale as f32) / UNIT_PIXELS,
             );
 
-            (width, height) = if output.transform.map_or(true, is_landscape) {
+            (width, height) = if output.transform.is_none_or(is_landscape) {
                 (width, height)
             } else {
                 (height, width)

--- a/cosmic-settings/src/pages/input/keyboard/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/mod.rs
@@ -223,7 +223,6 @@ fn popover_menu(id: DefaultKey) -> cosmic::Element<'static, Message> {
                 color: background.component.divider.into(),
                 width: 1.0,
                 radius: cosmic.corner_radii.radius_s.into(),
-                ..Border::default()
             },
             shadow: Default::default(),
         }

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
@@ -253,7 +253,7 @@ impl Model {
         self.shortcut_context = None;
         self.editing = None;
 
-        return Task::none();
+        Task::none()
     }
 
     pub(super) fn on_context_drawer_close(&mut self) {
@@ -637,9 +637,7 @@ impl Model {
                     if matches!(
                         key,
                         Key::Named(Named::Super | Named::Alt | Named::Control | Named::Shift)
-                    ) {
-                        return None;
-                    } else if matches!((&key, modifiers), (Key::Named(Named::Tab), modifiers) if modifiers.is_empty() || modifiers == Modifiers::SHIFT)
+                    ) || matches!((&key, modifiers), (Key::Named(Named::Tab), modifiers) if modifiers.is_empty() || modifiers == Modifiers::SHIFT)
                     {
                         return None;
                     }

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/custom.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/custom.rs
@@ -281,7 +281,7 @@ impl Page {
                                 widget::text_input::focus(widget::Id::unique()),
                                 iced_winit::platform_specific::commands::keyboard_shortcuts_inhibit::inhibit_shortcuts(false).discard(),
                             ]);
-                        } else if (old.alt || old.ctrl || old.shift) {
+                        } else if old.alt || old.ctrl || old.shift {
                             self.add_shortcut = Default::default();
                             _ = self.model.on_enter();
 
@@ -564,7 +564,7 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn on_leave(&mut self) -> Task<crate::pages::Message> {
-        _ = self.model.on_clear();
+        self.model.on_clear();
         iced_winit::platform_specific::commands::keyboard_shortcuts_inhibit::inhibit_shortcuts(
             false,
         )
@@ -595,9 +595,7 @@ impl page::Page<crate::pages::Message> for Page {
                         if matches!(
                             key,
                             Key::Named(Named::Super | Named::Alt | Named::Control | Named::Shift)
-                        ) {
-                            return None;
-                        } else if matches!((&key, modifiers), (Key::Named(Named::Tab), modifiers) if modifiers.is_empty() || modifiers == Modifiers::SHIFT)
+                        ) || matches!((&key, modifiers), (Key::Named(Named::Tab), modifiers) if modifiers.is_empty() || modifiers == Modifiers::SHIFT)
                         {
                             return None;
                         }

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/manage_windows.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/manage_windows.rs
@@ -69,7 +69,7 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn on_leave(&mut self) -> Task<crate::pages::Message> {
-        _ = self.model.on_clear();
+        self.model.on_clear();
         cosmic::iced_winit::platform_specific::commands::keyboard_shortcuts_inhibit::inhibit_shortcuts(
             false,
         )

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/move_window.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/move_window.rs
@@ -69,7 +69,7 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn on_leave(&mut self) -> Task<crate::pages::Message> {
-        _ = self.model.on_clear();
+        self.model.on_clear();
         cosmic::iced_winit::platform_specific::commands::keyboard_shortcuts_inhibit::inhibit_shortcuts(
             false,
         )

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/nav.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/nav.rs
@@ -70,7 +70,7 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn on_leave(&mut self) -> Task<crate::pages::Message> {
-        _ = self.model.on_clear();
+        self.model.on_clear();
         cosmic::iced_winit::platform_specific::commands::keyboard_shortcuts_inhibit::inhibit_shortcuts(
             false,
         )

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/system.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/system.rs
@@ -69,7 +69,7 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn on_leave(&mut self) -> Task<crate::pages::Message> {
-        _ = self.model.on_clear();
+        self.model.on_clear();
         cosmic::iced_winit::platform_specific::commands::keyboard_shortcuts_inhibit::inhibit_shortcuts(
             false,
         )

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/tiling.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/tiling.rs
@@ -69,7 +69,7 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn on_leave(&mut self) -> Task<crate::pages::Message> {
-        _ = self.model.on_clear();
+        self.model.on_clear();
         cosmic::iced_winit::platform_specific::commands::keyboard_shortcuts_inhibit::inhibit_shortcuts(
             false,
         )

--- a/cosmic-settings/src/pages/input/mod.rs
+++ b/cosmic-settings/src/pages/input/mod.rs
@@ -219,6 +219,6 @@ fn system_has_touchpad() -> bool {
     devices.any(|device| {
         device
             .property_value("ID_INPUT_TOUCHPAD")
-            .map_or(false, |value| value == "1")
+            .is_some_and(|value| value == "1")
     })
 }

--- a/cosmic-settings/src/pages/input/mouse.rs
+++ b/cosmic-settings/src/pages/input/mouse.rs
@@ -106,7 +106,7 @@ fn mouse() -> Section<crate::pages::Message> {
                                 .input_default
                                 .acceleration
                                 .as_ref()
-                                .map_or(true, |x| x.profile == Some(AccelProfile::Adaptive)),
+                                .is_none_or(|x| x.profile == Some(AccelProfile::Adaptive)),
                             |x| Message::SetAcceleration(x, false),
                         ),
                 )

--- a/cosmic-settings/src/pages/input/touchpad.rs
+++ b/cosmic-settings/src/pages/input/touchpad.rs
@@ -124,7 +124,7 @@ fn touchpad() -> Section<crate::pages::Message> {
                                 .input_touchpad
                                 .acceleration
                                 .as_ref()
-                                .map_or(true, |x| x.profile == Some(AccelProfile::Adaptive)),
+                                .is_none_or(|x| x.profile == Some(AccelProfile::Adaptive)),
                             |x| Message::SetAcceleration(x, true),
                         ),
                 )
@@ -193,7 +193,7 @@ fn click_behavior() -> Section<crate::pages::Message> {
                         page.input_touchpad
                             .tap_config
                             .as_ref()
-                            .map_or(false, |x| x.enabled),
+                            .is_some_and(|x| x.enabled),
                         Message::TapToClick,
                     ),
                 )
@@ -288,7 +288,7 @@ fn scrolling() -> Section<crate::pages::Message> {
                             page.input_touchpad
                                 .scroll_config
                                 .as_ref()
-                                .map_or(false, |conf| conf.natural_scroll.unwrap_or(false)),
+                                .is_some_and(|conf| conf.natural_scroll.unwrap_or(false)),
                             |enabled| Message::SetNaturalScroll(enabled, true),
                         ),
                 )

--- a/cosmic-settings/src/pages/networking/mod.rs
+++ b/cosmic-settings/src/pages/networking/mod.rs
@@ -227,7 +227,7 @@ impl page::Page<crate::pages::Message> for Page {
                     .context("failed to create system dbus connection")
                     .map_or_else(
                         |why| Message::Error(why.to_string()),
-                        |conn| Message::NetworkManagerConnect(conn),
+                        Message::NetworkManagerConnect,
                     )
                     .apply(crate::pages::Message::Networking)
             });

--- a/cosmic-settings/src/pages/networking/vpn/mod.rs
+++ b/cosmic-settings/src/pages/networking/vpn/mod.rs
@@ -133,7 +133,7 @@ impl VpnConnectionSettings {
     fn password_flag(&self) -> Option<PasswordFlag> {
         self.connection_type
             .as_ref()
-            .map_or(false, |ct| match ct {
+            .is_some_and(|ct| match ct {
                 ConnectionType::Password => true,
             })
             .then_some(self.password_flag)
@@ -878,7 +878,7 @@ fn devices_view() -> Section<crate::pages::Message> {
                         let view_more: Option<Element<_>> = if page
                             .view_more_popup
                             .as_deref()
-                            .map_or(false, |id| id == uuid.as_ref())
+                            .is_some_and(|id| id == uuid.as_ref())
                         {
                             widget::popover(view_more_button.on_press(Message::ViewMore(None)))
                                 .position(widget::popover::Position::Bottom)
@@ -1018,12 +1018,8 @@ fn add_network() -> Task<crate::app::Message> {
                         Err(why) => Message::Error(ErrorKind::Config, why.to_string()),
                     }
                 }
-                Err(cosmic::dialog::file_chooser::Error::Cancelled) => {
-                    return Message::CancelDialog;
-                }
-                Err(why) => {
-                    return Message::Error(ErrorKind::Config, why.to_string());
-                }
+                Err(cosmic::dialog::file_chooser::Error::Cancelled) => Message::CancelDialog,
+                Err(why) => Message::Error(ErrorKind::Config, why.to_string()),
             }
         })
         .apply(cosmic::task::future)

--- a/cosmic-settings/src/pages/networking/vpn/nmcli.rs
+++ b/cosmic-settings/src/pages/networking/vpn/nmcli.rs
@@ -6,7 +6,7 @@ use std::process::Stdio;
 
 pub async fn set_username(connection_name: &str, username: &str) -> Result<(), String> {
     tokio::process::Command::new("nmcli")
-        .args(&["con", "mod", connection_name, "vpn.user-name", username])
+        .args(["con", "mod", connection_name, "vpn.user-name", username])
         .stderr(Stdio::piped())
         .output()
         .await
@@ -60,7 +60,7 @@ pub async fn set_password(connection_name: &str, password: &str) -> Result<(), S
 
 pub async fn connect(connection_name: &str) -> Result<(), String> {
     tokio::process::Command::new("nmcli")
-        .args(&["con", "up", &connection_name])
+        .args(["con", "up", connection_name])
         .stderr(Stdio::piped())
         .output()
         .await

--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -726,7 +726,7 @@ fn devices_view() -> Section<crate::pages::Message> {
                         let view_more: Option<Element<_>> = if page
                             .view_more_popup
                             .as_deref()
-                            .map_or(false, |id| id == network.ssid.as_ref())
+                            .is_some_and(|id| id == network.ssid.as_ref())
                         {
                             widget::popover(view_more_button.on_press(Message::ViewMore(None)))
                                 .position(widget::popover::Position::Bottom)

--- a/cosmic-settings/src/pages/networking/wired.rs
+++ b/cosmic-settings/src/pages/networking/wired.rs
@@ -504,7 +504,7 @@ impl Page {
                     let view_more: Option<Element<_>> = if self
                         .view_more_popup
                         .as_deref()
-                        .map_or(false, |id| id == connection.uuid.as_ref())
+                        .is_some_and(|id| id == connection.uuid.as_ref())
                     {
                         widget::popover(view_more_button.on_press(Message::ViewMore(None)))
                             .position(widget::popover::Position::Bottom)

--- a/cosmic-settings/src/pages/power/backend/mod.rs
+++ b/cosmic-settings/src/pages/power/backend/mod.rs
@@ -516,15 +516,11 @@ impl ConnectedDevice {
         let proxy = enumerate_devices().await;
 
         if let Ok(devices) = proxy {
-            return join_all(
-                devices
-                    .into_iter()
-                    .map(|device| Self::from_device_maybe(device)),
-            )
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
+            return join_all(devices.into_iter().map(Self::from_device_maybe))
+                .await
+                .into_iter()
+                .flatten()
+                .collect();
         }
 
         vec![]

--- a/cosmic-settings/src/pages/power/mod.rs
+++ b/cosmic-settings/src/pages/power/mod.rs
@@ -34,7 +34,7 @@ static SUSPEND_TIMES: &[Duration] = &[
     Duration::from_secs(25 * 60),
     Duration::from_secs(30 * 60),
     Duration::from_secs(45 * 60),
-    Duration::from_secs(1 * 60 * 60),
+    Duration::from_secs(60 * 60),
     Duration::from_secs(80 * 60),
     Duration::from_secs(90 * 60),
     Duration::from_secs(100 * 60),

--- a/cosmic-settings/src/pages/sound.rs
+++ b/cosmic-settings/src/pages/sound.rs
@@ -60,9 +60,9 @@ impl From<Message> for crate::Message {
     }
 }
 
-impl Into<Message> for subscription::Message {
-    fn into(self) -> Message {
-        Message::Subscription(self)
+impl From<subscription::Message> for Message {
+    fn from(val: subscription::Message) -> Self {
+        Message::Subscription(val)
     }
 }
 
@@ -110,7 +110,7 @@ impl page::Page<crate::pages::Message> for Page {
         &self,
         _core: &cosmic::Core,
     ) -> cosmic::iced::Subscription<crate::pages::Message> {
-        cosmic::iced::Subscription::run(|| subscription::watch())
+        cosmic::iced::Subscription::run(subscription::watch)
             .map(|message| Message::Subscription(message).into())
     }
 
@@ -269,7 +269,7 @@ fn input() -> Section<crate::pages::Message> {
                 Message::SourceChanged,
                 window::Id::RESERVED,
                 Message::Surface,
-                |a| crate::Message::from(a),
+                crate::Message::from,
             )
             .apply(Element::from)
             .map(crate::pages::Message::from);
@@ -289,7 +289,7 @@ fn input() -> Section<crate::pages::Message> {
                     Message::SourceProfileChanged,
                     window::Id::RESERVED,
                     Message::Surface,
-                    |a| crate::Message::from(a),
+                    crate::Message::from,
                 )
                 .apply(Element::from)
                 .map(crate::pages::Message::from);
@@ -363,7 +363,7 @@ fn output() -> Section<crate::pages::Message> {
                 Message::SinkChanged,
                 window::Id::RESERVED,
                 Message::Surface,
-                |a| crate::Message::from(a),
+                crate::Message::from,
             )
             .apply(Element::from)
             .map(crate::pages::Message::from);
@@ -383,7 +383,7 @@ fn output() -> Section<crate::pages::Message> {
                     Message::SinkProfileChanged,
                     window::Id::RESERVED,
                     Message::Surface,
-                    |a| crate::Message::from(a),
+                    crate::Message::from,
                 )
                 .apply(Element::from)
                 .map(crate::pages::Message::from);

--- a/cosmic-settings/src/pages/time/date.rs
+++ b/cosmic-settings/src/pages/time/date.rs
@@ -22,6 +22,7 @@ use icu::{
 };
 use slab::Slab;
 use slotmap::{Key, SlotMap};
+use std::rc::Rc;
 pub use timedate_zbus::TimeDateProxy;
 use tracing::error;
 
@@ -345,12 +346,36 @@ impl Page {
     }
 
     fn timezone_context_item<'a>(&self, id: usize, timezone: &'a str) -> Element<'a, Message> {
-        widget::button::custom(widget::settings::item_row(vec![
-            widget::text::body(timezone).wrapping(Wrapping::Word).into(),
-            widget::horizontal_space().into(),
-        ]))
+        let svg_accent = Rc::new(|theme: &cosmic::Theme| cosmic::widget::svg::Style {
+            color: Some(theme.cosmic().accent_text_color().into()),
+        });
+        let selected = Some(id) == self.timezone;
+
+        widget::settings::item_row(vec![
+            widget::text::body(timezone)
+                .class(if selected {
+                    cosmic::theme::Text::Accent
+                } else {
+                    cosmic::theme::Text::Default
+                })
+                .wrapping(Wrapping::Word)
+                .width(cosmic::iced::Length::Fill)
+                .into(),
+            if selected {
+                widget::icon::from_name("object-select-symbolic")
+                    .size(16)
+                    .icon()
+                    .class(cosmic::theme::Svg::Custom(svg_accent.clone()))
+                    .into()
+            } else {
+                widget::horizontal_space().width(16).into()
+            },
+        ])
+        .apply(widget::container)
+        .class(cosmic::theme::Container::List)
+        .apply(widget::button::custom)
+        .class(cosmic::theme::Button::Transparent)
         .on_press(Message::Timezone(id))
-        .class(cosmic::theme::Button::Icon)
         .into()
     }
 

--- a/cosmic-settings/src/pages/time/region.rs
+++ b/cosmic-settings/src/pages/time/region.rs
@@ -81,7 +81,7 @@ impl Ord for SystemLocale {
 
 impl PartialOrd for SystemLocale {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.display_name.partial_cmp(&other.display_name)
+        Some(self.cmp(other))
     }
 }
 
@@ -315,7 +315,7 @@ impl Page {
 
                     _ = config.set("system_locales", &locales);
 
-                    if let Some(language_code) = locales.get(0) {
+                    if let Some(language_code) = locales.first() {
                         if let Some(language) = self
                             .available_languages
                             .values()
@@ -358,9 +358,10 @@ impl Page {
                     .to_lowercase()
                     .contains(search_input)
             {
-                let is_installed = self.config.as_ref().map_or(false, |(_, locales)| {
-                    locales.contains(&available_language.lang_code)
-                });
+                let is_installed = self
+                    .config
+                    .as_ref()
+                    .is_some_and(|(_, locales)| locales.contains(&available_language.lang_code));
 
                 let button = widget::settings::item_row(vec![
                     widget::text::body(&available_language.display_name)
@@ -488,7 +489,7 @@ impl Page {
                 let is_selected = self
                     .region
                     .as_ref()
-                    .map_or(false, |l| l.lang_code == locale.lang_code);
+                    .is_some_and(|l| l.lang_code == locale.lang_code);
 
                 let button = widget::settings::item_row(vec![
                     widget::text::body(&locale.region_name)

--- a/cosmic-settings/src/pages/time/region.rs
+++ b/cosmic-settings/src/pages/time/region.rs
@@ -346,9 +346,8 @@ impl Page {
 
         let search_input = &self.add_language_search.trim().to_lowercase();
 
-        let svg_accent = Rc::new(|theme: &cosmic::Theme| {
-            let color = theme.cosmic().accent_text_color().into();
-            cosmic::widget::svg::Style { color: Some(color) }
+        let svg_accent = Rc::new(|theme: &cosmic::Theme| cosmic::widget::svg::Style {
+            color: Some(theme.cosmic().accent_text_color().into()),
         });
 
         for (id, available_language) in &self.available_languages {

--- a/cosmic-settings/src/widget/mod.rs
+++ b/cosmic-settings/src/widget/mod.rs
@@ -23,7 +23,7 @@ pub fn color_picker_context_view<'a, Message: Clone + 'static>(
     let theme = theme::active();
     let spacing = &theme.cosmic().spacing;
 
-    let description = description.map(|description| text::caption(description));
+    let description = description.map(text::caption);
 
     let color_picker = model
         .builder(on_update)

--- a/pages/system/src/about.rs
+++ b/pages/system/src/about.rs
@@ -195,7 +195,7 @@ pub fn processor_name(bump: &Bump, name: &mut String) {
     let s = sysinfo::System::new_with_specifics(
         sysinfo::RefreshKind::nothing().with_cpu(sysinfo::CpuRefreshKind::everything()),
     );
-    name.push_str(s.cpus().into_iter().nth(0).unwrap().brand());
+    name.push_str(s.cpus().iter().next().unwrap().brand());
 }
 
 pub fn read_to_string<'a, P: AsRef<OsStr>>(


### PR DESCRIPTION
Makes them match the region selectors.

Also ran `cargo clippy --fix` and did a few manual changes which weren't automatically done.