### PR TITLE
Don't set icon theme for GNOME

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/drawer.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/drawer.rs
@@ -203,8 +203,6 @@ impl Content {
                     if let Some(ref config) = self.tk_config {
                         _ = config.set::<String>("icon_theme", theme.id);
                     }
-
-                    tokio::spawn(icon_themes::set_gnome_icon_theme(theme.name));
                 }
             }
             IconMessage::ApplyThemeGlobal(enabled) => {

--- a/cosmic-settings/src/pages/desktop/appearance/icon_themes.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/icon_themes.rs
@@ -237,19 +237,6 @@ pub async fn fetch() -> Message {
     ))
 }
 
-/// Set the preferred icon theme for GNOME/GTK applications.
-pub async fn set_gnome_icon_theme(theme: String) {
-    let _res = tokio::process::Command::new("gsettings")
-        .args([
-            "set",
-            "org.gnome.desktop.interface",
-            "icon-theme",
-            theme.as_str(),
-        ])
-        .status()
-        .await;
-}
-
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct IconTheme {
     // COSMIC uses the file name of the folder containing the theme


### PR DESCRIPTION
It's already done by cosmic-settings-daemon when the setting is changed:
https://github.com/pop-os/cosmic-settings-daemon/blob/fbd4adede269681c07cd273f417f9296feabc26e/src/theme.rs#L298-L300