### PR TITLE
adjust oversized scroll area for display arrangement

### DIFF
--- a/cosmic-settings/src/pages/display/arrangement.rs
+++ b/cosmic-settings/src/pages/display/arrangement.rs
@@ -141,11 +141,11 @@ impl<Message: Clone> Widget<Message, cosmic::Theme, Renderer> for Arrangement<'_
         let state = tree.state.downcast_mut::<State>();
 
         state.max_dimensions = (
-            max_dimensions.0 as f32 / UNIT_PIXELS,
+            max_dimensions.0 as f32 / UNIT_PIXELS / 2.0,
             total_height as f32 / UNIT_PIXELS,
         );
 
-        let width = ((max_dimensions.0 as f32 * 2.0) as i32 + display_area.0) as f32 / UNIT_PIXELS;
+        let width = (max_dimensions.0 as f32 + display_area.0 as f32) / UNIT_PIXELS;
         let height = total_height as f32 * VERTICAL_OVERHEAD / UNIT_PIXELS;
 
         let limits = limits


### PR DESCRIPTION
The bounding box for the scroll area in the display arrangement configuration page was way to wide, which looks kind of broken in most situations. This properly positions and resizes the widths. 

Should fix #817 as well.

before:

https://github.com/user-attachments/assets/906df537-4d71-43be-a51c-60a8bf1c6451


after:

https://github.com/user-attachments/assets/26abfc72-60d2-471d-961d-829b0e407bb4


