### PR TITLE
sound page: reduce UI pop in

### DIFF
--- a/cosmic-settings/src/pages/sound.rs
+++ b/cosmic-settings/src/pages/sound.rs
@@ -231,10 +231,6 @@ fn input() -> Section<crate::pages::Message> {
         .title(fl!("sound-input"))
         .descriptions(descriptions)
         .view::<Page>(move |_binder, page, section| {
-            if page.model.sources().is_empty() {
-                return widget::row().into();
-            }
-
             let slider = if page.amplification_source {
                 widget::slider(0..=150, page.model.source_volume, |change| {
                     Message::SourceVolumeChanged(change).into()
@@ -282,20 +278,18 @@ fn input() -> Section<crate::pages::Message> {
                 ))
                 .add(settings::item(&*section.descriptions[device], devices));
 
-            if !page.model.source_profiles().is_empty() {
-                let dropdown = widget::dropdown::popup_dropdown(
-                    page.model.source_profiles(),
-                    page.model.active_source_profile(),
-                    Message::SourceProfileChanged,
-                    window::Id::RESERVED,
-                    Message::Surface,
-                    crate::Message::from,
-                )
+            let dropdown = widget::dropdown::popup_dropdown(
+                page.model.source_profiles(),
+                Some(page.model.active_source_profile().unwrap_or(0)),
+                Message::SourceProfileChanged,
+                window::Id::RESERVED,
+                Message::Surface,
+                crate::Message::from,
+            )
                 .apply(Element::from)
                 .map(crate::pages::Message::from);
 
-                controls = controls.add(settings::item(&*section.descriptions[profile], dropdown));
-            }
+            controls = controls.add(settings::item(&*section.descriptions[profile], dropdown));
 
             controls = controls.add(
                 settings::item::builder(&*section.descriptions[amplification])
@@ -376,20 +370,19 @@ fn output() -> Section<crate::pages::Message> {
                 ))
                 .add(settings::item(&*section.descriptions[device], devices));
 
-            if !page.model.sink_profiles().is_empty() {
-                let dropdown = widget::dropdown::popup_dropdown(
-                    page.model.sink_profiles(),
-                    page.model.active_sink_profile(),
-                    Message::SinkProfileChanged,
-                    window::Id::RESERVED,
-                    Message::Surface,
-                    crate::Message::from,
-                )
+            let dropdown = widget::dropdown::popup_dropdown(
+                page.model.sink_profiles(),
+                Some(page.model.active_sink_profile().unwrap_or(0)),
+                Message::SinkProfileChanged,
+                window::Id::RESERVED,
+                Message::Surface,
+                crate::Message::from,
+            )
                 .apply(Element::from)
                 .map(crate::pages::Message::from);
 
-                controls = controls.add(settings::item(&*section.descriptions[profile], dropdown));
-            }
+            controls = controls.add(settings::item(&*section.descriptions[profile], dropdown));
+
             if let Some(sink_balance) = page.model.sink_balance {
                 controls = controls.add(settings::item(
                     &*section.descriptions[balance],


### PR DESCRIPTION
Reduce pop in and resizing of UI elements in sound page by using placeholders while system information is gathered asynchronously. This can be noticeable when using professional audio equipment with lots of profiles and/or devices. Still not perfect, since the actual values are not pre-fetched before opening the page, but at least the general UI elements do not pop in.

It might be a good idea to trigger all asynchronous data collectors during the start-up of the application, so the data gets collected and updated ahead in time before a user needs to fetch the data by opening a settings page. But this would require are architectural re-design that the maintainers are willing to accept.

before:

https://github.com/user-attachments/assets/4422b3b1-0234-464f-a369-240b13347c5a



after:

https://github.com/user-attachments/assets/5da02caa-9e8d-4699-86eb-1e3edc983475


<img width="1921" height="1491" alt="Screenshot_2025-11-07_15-39-49" src="https://github.com/user-attachments/assets/fa8f57fd-72d6-43de-832c-b3b213984b31" />

