### PR TITLE
trigger cosmic-osd display identifier OSD on each screen to ease display arrangement configurations for users

### DIFF
--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -151,7 +151,7 @@ pub struct Page {
     active_display: OutputKey,
     randr_handle: Option<(oneshot::Sender<()>, cosmic::iced::task::Handle)>,
     hotplug_handle: Option<(oneshot::Sender<()>, cosmic::iced::task::Handle)>,
-    display_identifier_handle: Option<(oneshot::Sender<()>, ())>,
+    display_identifier_handle: Option<(oneshot::Sender<()>, cosmic::iced::task::Handle)>,
     display_identifier_guard: Option<DisplayIdentifierGuard>,
     config: Config,
     cache: ViewCache,
@@ -385,49 +385,51 @@ impl page::Page<crate::pages::Message> for Page {
         // Start a periodic task to send identify displays message every 0.5 seconds
         // This resets the 1-second auto-close timer in cosmic-osd
         let (identifier_cancel_tx, identifier_cancel_rx) = oneshot::channel::<()>();
-        let identifier_task = Task::stream(async_fn_stream::fn_stream(|_emitter| async move {
-            let identifier_loop = async {
-                loop {
-                    match tokio::process::Command::new("cosmic-osd")
-                        .arg("identify-displays")
-                        .output()
-                        .await
-                    {
-                        Ok(output) => {
-                            if !output.status.success() {
+        let (identifier_task, identifier_handle) =
+            Task::stream(async_fn_stream::fn_stream(|_emitter| async move {
+                let identifier_loop = async {
+                    loop {
+                        match tokio::process::Command::new("cosmic-osd")
+                            .arg("identify-displays")
+                            .output()
+                            .await
+                        {
+                            Ok(output) => {
+                                if !output.status.success() {
+                                    tracing::error!(
+                                        "cosmic-osd identify-displays failed: {}",
+                                        String::from_utf8_lossy(&output.stderr)
+                                    );
+                                }
+                            }
+                            Err(why) => {
                                 tracing::error!(
-                                    "cosmic-osd identify-displays failed: {}",
-                                    String::from_utf8_lossy(&output.stderr)
+                                    why = why.to_string(),
+                                    "failed to execute cosmic-osd identify-displays"
                                 );
                             }
                         }
-                        Err(why) => {
-                            tracing::error!(
-                                why = why.to_string(),
-                                "failed to execute cosmic-osd identify-displays"
-                            );
-                        }
+
+                        tokio::time::sleep(Duration::from_millis(500)).await;
                     }
+                };
 
-                    tokio::time::sleep(Duration::from_millis(500)).await;
+                tokio::select! {
+                    _ = identifier_cancel_rx => {
+                        let _ = tokio::process::Command::new("cosmic-osd")
+                            .arg("dismiss-display-identifiers")
+                            .output()
+                            .await;
+                    }
+                    _ = identifier_loop => {
+                        // Loop will never complete, but this branch is needed for tokio::select
+                    }
                 }
-            };
-
-            tokio::select! {
-                _ = identifier_cancel_rx => {
-                    let _ = tokio::process::Command::new("cosmic-osd")
-                        .arg("dismiss-display-identifiers")
-                        .output()
-                        .await;
-                }
-                _ = identifier_loop => {
-                    // Loop will never complete, but this branch is needed for tokio::select
-                }
-            }
-        }));
+            }))
+            .abortable();
 
         tasks.push(identifier_task);
-        self.display_identifier_handle = Some((identifier_cancel_tx, ()));
+        self.display_identifier_handle = Some((identifier_cancel_tx, identifier_handle));
         // Create guard that will dismiss identifiers immediately if the app is killed
         self.display_identifier_guard = Some(DisplayIdentifierGuard);
 
@@ -445,8 +447,9 @@ impl page::Page<crate::pages::Message> for Page {
             handle.abort();
         }
 
-        if let Some((canceller, ())) = self.display_identifier_handle.take() {
+        if let Some((canceller, handle)) = self.display_identifier_handle.take() {
             _ = canceller.send(());
+            handle.abort();
         }
 
         // Remove the guard so it doesn't dismiss again after the async task completes


### PR DESCRIPTION
implements #885

requires https://github.com/pop-os/cosmic-osd/pull/151

preview:

https://github.com/user-attachments/assets/2b008908-1b79-4662-9b92-fa876353c445

