### PR TITLE
fix(sound): Use crate feature to disable auto-profile on init by default

### DIFF
--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -31,7 +31,7 @@ cosmic-settings-airplane-mode-subscription = { path = "../subscriptions/airplane
 cosmic-settings-bluetooth-subscription = { path = "../subscriptions/bluetooth", optional = true }
 cosmic-settings-network-manager-subscription = { path = "../subscriptions/network-manager", optional = true }
 cosmic-settings-upower-subscription = { path = "../subscriptions/upower", optional = true }
-cosmic-settings-sound-subscription = { path = "../subscriptions/sound", optional = true }
+cosmic-settings-sound-subscription = { path = "../subscriptions/sound", optional = true, features = ["auto-profile-init"] }
 cosmic-settings-system = { path = "../pages/system", optional = true }
 cosmic-settings-wallpaper = { path = "../pages/wallpapers" }
 cosmic-settings-daemon-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", optional = true }

--- a/subscriptions/sound/Cargo.toml
+++ b/subscriptions/sound/Cargo.toml
@@ -16,3 +16,7 @@ numtoa = "1.0.0-alpha1"
 rustix = "1.0.8"
 tokio = { version = "1.47.1", features = ["process", "rt", "time"] }
 tracing = { version = "0.1.41", default-features = false }
+
+[features]
+# Set profile on first load
+auto-profile-init = []

--- a/subscriptions/sound/src/lib.rs
+++ b/subscriptions/sound/src/lib.rs
@@ -441,7 +441,6 @@ impl Model {
                     profile.description
                 );
 
-                let index = profile.index as u32;
                 let prev = self.active_profiles.insert(id, profile.clone());
                 self.update_ui_profiles();
                 if let Some(prev) = prev {
@@ -455,14 +454,17 @@ impl Model {
                         prev.index, profile.index, profile.description
                     );
                 } else {
-                    // Use pw-cli to reset the profile in case wireplumber has invalid state.
-                    // Profiles set by us do not need to use this.
-                    tracing::debug!(
-                        target: "sound",
-                        "Device {id} initialized with profile {}: {}", index, profile.description
-                    );
+                    #[cfg(feature = "auto-profile-init")]
+                    if profile.index != 0 {
+                        // Use pw-cli to re-set the profile in case wireplumber has invalid state.
+                        // Profiles set by us do not need to use this. Only sets if profile is not `Off`.
+                        tracing::debug!(
+                            target: "sound",
+                            "Device {id} initialized with profile {}: {}", profile.index, profile.description
+                        );
 
-                    self.set_profile(id, index, false);
+                        self.set_profile(id, profile.index as u32, false);
+                    }
                 }
             }
 


### PR DESCRIPTION
Adds `auto-profile-init` feature to the subscription crate and then adds it to cosmic-settings' import. When updating the applet, this feature will be disabled by default.

Also makes a change to not auto-set the Off profile in case pipewire reports the profile to be `Off`.