### PR TITLE
fix(input): install defaults for input_touchpad config

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -39,4 +39,5 @@
 /usr/share/cosmic/com.system76.CosmicTheme.Light
 /usr/share/cosmic/com.system76.CosmicTheme.Light.Builder
 /usr/share/cosmic/com.system76.CosmicTheme.Mode
+/usr/share/cosmic/com.system76.CosmicComp/v1/input_touchpad
 /usr/share/icons/hicolor

--- a/resources/default_schema/com.system76.CosmicComp/v1/input_touchpad
+++ b/resources/default_schema/com.system76.CosmicComp/v1/input_touchpad
@@ -1,0 +1,1 @@
+(state:Enabled,click_method:Some(Clickfinger),scroll_config:Some((method:Some(TwoFinger),natural_scroll:None,scroll_button:None,scroll_factor:None)),tap_config:Some((enabled:false,button_map:Some(LeftRightMiddle),drag:true,drag_lock:false)))


### PR DESCRIPTION
fixes https://github.com/pop-os/cosmic-settings/issues/1573. Or should cosmic-comp should install the defaults for its config instead?