### PR TITLE
ci: set apt to non-interactive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: Continuous integration
 
+env:
+  # Stops the `debconf: unable to initialize frontend: {Dialog, Readline, Teletype}` errors
+  # See https://stackoverflow.com/a/34774096
+  DEBIAN_FRONTEND: noninteractive
+
 on:
   push:
     branches: [master]

--- a/.github/workflows/validate-desktop-files.yml
+++ b/.github/workflows/validate-desktop-files.yml
@@ -1,5 +1,10 @@
 name: Validate .desktop files
 
+env:
+  # Stops the `debconf: unable to initialize frontend: {Dialog, Readline, Teletype}` errors
+  # See https://stackoverflow.com/a/34774096
+  DEBIAN_FRONTEND: noninteractive
+
 on:
   push:
     branches:


### PR DESCRIPTION
Currently, apt tries to initialize various frontends, but eventually realizes that none of them work, as it's run on CI. This commit stops it from trying in vain.