### PR TITLE
chore(appearance): make window gap and active hint size constraint consistent

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -802,7 +802,7 @@ pub fn window_management() -> Section<crate::pages::Message> {
                         page.theme_manager.builder().gaps.1.to_string(),
                         page.theme_manager.builder().gaps.1,
                         1,
-                        page.theme_manager.builder().active_hint,
+                        0,
                         500,
                         Message::GapSize,
                     )),

--- a/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
@@ -348,6 +348,10 @@ impl Manager {
     }
 
     pub fn set_gap_size(&mut self, gap: u32) -> Option<ThemeStaged> {
+        let active_hint = self.builder().active_hint;
+        if gap < active_hint {
+            self.set_active_hint(gap)?;
+        }
         self.dark.set_gap_size(gap)?;
         self.light.set_gap_size(gap)?;
         Some(ThemeStaged::Both)


### PR DESCRIPTION
[I created a separate PR for this, since I'm not sure if the current design is preferred.]


Keep the constraint consistent in both directions:

- increasing active_hint may increase gaps (handled in set_active_hint)
- decreasing gaps should also decrease active_hint if it would otherwise exceed gaps