### PR TITLE
fix(appearance): reset-apply default active_hint on theme.builder config fle

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -314,6 +314,7 @@ impl Page {
                 } else {
                     ThemeBuilder::light()
                 };
+                self.theme_manager.set_active_hint(builder.active_hint);
 
                 self.theme_manager
                     .selected_customizer_mut()


### PR DESCRIPTION
This was not persisted on disk:` ~/.config/cosmic/com.system76.CosmicTheme.Dark.Builder/v1/active_hint` , only 
`~/.config/cosmic/com.system76.CosmicTheme/v1/active_hint` was updated on disk. The application memory was using the in memory theme_manager so once re-opened it returned the previous value, not the reseted default one.

fixes #1670 
