### PR TITLE
Update branches crate to fix build on pp64le

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "branches"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11502672c5570f77f6bdf573332483f8475bab6a7fda00f1fae8ddb5a6245c0"
+checksum = "6eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
 dependencies = [
  "rustc_version",
 ]


### PR DESCRIPTION
The branches crate previous to 0.4.4 breaks builds on ppc64le arch.