### PR TITLE
fix(shortcuts): stack action (Add another keybinding and Reset to Default) buttons vertically in sidebar

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
@@ -821,9 +821,9 @@ fn context_drawer<'a>(
             Some(ShortcutMessage::AddAnotherKeybinding)
         });
 
-    let button_container = widget::row::with_capacity(2)
-        .push_maybe(reset_keybinding_button)
+    let button_container = widget::column::with_capacity(2)
         .push(add_keybinding_button)
+        .push_maybe(reset_keybinding_button)
         .spacing(space_xs)
         .apply(widget::container)
         .width(Length::Fill)


### PR DESCRIPTION
## Summary
Changes the button container in the shortcut customization flyout from a `Row` to a `Column`.

## Rationale
In the narrow sidebar/flyout view, the "Add another keybinding" text was clipping or wrapping poorly because it was forced to share horizontal space. Stacking the buttons vertically allows them to take the full width of the panel, ensuring the text is readable in all languages.

## Screenshots
| Before | After |
| :--- | :--- |
| <img width="629" height="1060" alt="Screenshot_2026-01-03_15-46-13" src="https://github.com/user-attachments/assets/39a96f48-0a8e-4611-8d55-b482c0ec1998" /> | <img width="946" height="1074" alt="Screenshot_2026-01-03_16-38-22" src="https://github.com/user-attachments/assets/c4fc20a5-a3f0-4be6-b226-a6b86f113ae4" /> |

## Testing
- Verified that buttons stack correctly.
- Verified that "Add another keybinding" text no longer clips.