### PR TITLE
fix(startup): ensure delete dialog shows when triggered from search

### DIFF
--- a/cosmic-settings/src/pages/applications/startup_apps.rs
+++ b/cosmic-settings/src/pages/applications/startup_apps.rs
@@ -132,6 +132,9 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn on_enter(&mut self) -> Task<crate::pages::Message> {
+        if self.app_to_remove.is_some() {
+            return Task::none();
+        }
         let (task, on_enter_handle) = Task::future(async move {
             let locales = freedesktop_desktop_entry::get_languages_from_env();
 


### PR DESCRIPTION
This PR fixes an issue where the deletion confirmation dialog for startup applications would not appear when the delete action was triggered from the global search view (Issue #1770).
Modified the update logic for Message::RemoveStartupApplication. When a deletion is requested (!confirm), the page now returns a Task that requests a navigation to itself via crate::app::Message::Page(self.entity).