### PR TITLE
Fix rotation frequency of wallpaper slideshow resetting

### DIFF
--- a/cosmic-settings/src/pages/desktop/wallpaper/config.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/config.rs
@@ -267,7 +267,10 @@ impl Config {
     /// # Errors
     ///
     /// Returns an error if the on-disk configuration could not be updated.
-    pub fn change_rotation_frequency(&mut self, frequency: u64) -> Result<(), cosmic_config::Error> {
+    pub fn change_rotation_frequency(
+        &mut self,
+        frequency: u64,
+    ) -> Result<(), cosmic_config::Error> {
         self.rotation_frequency = frequency;
         self.update_rotation_frequency()?;
 

--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -835,7 +835,7 @@ impl Page {
                 if let Err(err) = self.change_rotation_frequency(pos) {
                     tracing::warn!("Failed to save rotation frequency: {err}");
                 }
-            },
+            }
 
             Message::SameWallpaper(value) => {
                 self.wallpaper_service_config.same_on_all = value;


### PR DESCRIPTION
The additions/changes proposed fix the behavior that the "rotation_frequency" variable is not stored. As a result the rotation frequency of the wallpaper slideshow reset every time the settings window was closed.

This PR fixes the bug reported in #1692 