### PR TITLE
fix: increased hard-coded wallpapers limit from 100 to 500

### DIFF
--- a/pages/wallpapers/src/lib.rs
+++ b/pages/wallpapers/src/lib.rs
@@ -134,7 +134,7 @@ pub async fn load_each_from_path(
         })
         .buffered(4)
         .filter_map(|value| async { value.ok().flatten() })
-        .take(100);
+        .take(500);
 
     Box::pin(future)
 }


### PR DESCRIPTION
### Increase wallpaper directory load limit

This PR raises the hard-coded limit for loading wallpapers from a directory from **100 to 500**.

fixes: #1356

The current limit of 100 is unnecessarily restrictive for users who use folders as wallpaper sources (e.g. slideshow-style setups) and is not configurable or user-visible, making the behavior appear unintended.

This change does not increase peak resource usage:
- loading is already throttled via `buffered(4)`
- images are processed incrementally

The increase improves usability while keeping the existing design and safeguards intact.
