### PR TITLE
fix: show WPA3-only networks

### DIFF
--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -447,7 +447,7 @@ impl Page {
                 let escaped_ssid = escape_wifi_qr_string(ssid.as_ref());
                 let qr_string = if let Some(ref pass) = password {
                     let security = match security_type {
-                        NetworkType::PSK => "WPA",
+                        NetworkType::PskOrSae => "WPA",
                         NetworkType::EAP => "WPA",
                         NetworkType::Open => "",
                     };
@@ -921,7 +921,7 @@ fn devices_view() -> Section<crate::pages::Message> {
                             }))
                             .any(|known| known == network.ssid.as_ref());
 
-                        let is_encrypted = network.network_type != NetworkType::Open;
+                        let needs_password = network.network_type != NetworkType::Open;
 
                         let (connect_txt, connect_msg) = if is_connected {
                             (&section.descriptions[connected_txt], None)
@@ -930,7 +930,7 @@ fn devices_view() -> Section<crate::pages::Message> {
                         } else {
                             (
                                 &section.descriptions[connect_txt],
-                                Some(if is_known || !is_encrypted {
+                                Some(if is_known || !needs_password {
                                     Message::Connect(network.ssid.clone())
                                 } else {
                                     Message::PasswordRequest(network.ssid.clone())
@@ -941,7 +941,7 @@ fn devices_view() -> Section<crate::pages::Message> {
                         let identifier = widget::row::with_capacity(3)
                             .push(widget::icon::from_name(wifi_icon(network.strength)))
                             .push_maybe(
-                                is_encrypted
+                                needs_password
                                     .then(|| widget::icon::from_name("connection-secure-symbolic")),
                             )
                             .push(

--- a/subscriptions/network-manager/src/available_wifi.rs
+++ b/subscriptions/network-manager/src/available_wifi.rs
@@ -56,9 +56,9 @@ pub async fn handle_wireless_device(
             };
             let network_type = if flags.intersects(ApSecurityFlags::KEY_MGMT_802_1X) {
                 NetworkType::EAP
-            } else if flags.intersects(ApSecurityFlags::KEY_MGMTPSK) {
-                NetworkType::PSK
-            } else if flags.is_empty() {
+            } else if flags.intersects(ApSecurityFlags::KEY_MGMTPSK | ApSecurityFlags::KEY_MGMT_SAE) {
+                NetworkType::PskOrSae
+            } else if flags.intersects(ApSecurityFlags::KEY_MGMT_OWE) || flags.is_empty() {
                 NetworkType::Open
             } else {
                 continue;
@@ -111,6 +111,6 @@ pub struct AccessPoint {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NetworkType {
     Open,
-    PSK,
+    PskOrSae,
     EAP,
 }

--- a/subscriptions/network-manager/src/lib.rs
+++ b/subscriptions/network-manager/src/lib.rs
@@ -311,7 +311,7 @@ async fn start_listening(
                             if identity.is_some() {
                                 NetworkType::EAP
                             } else {
-                                NetworkType::PSK
+                                NetworkType::PskOrSae
                             },
                             interface.clone(),
                         )
@@ -490,12 +490,12 @@ async fn start_listening(
                         }
                         t => {
                             let (tx, rx) = tokio::sync::oneshot::channel();
-                            let setting_name = if matches!(t, NetworkType::PSK) {
+                            let setting_name = if matches!(t, NetworkType::PskOrSae) {
                                 "802-11-wireless-security"
                             } else {
                                 "802-1x"
                             };
-                            let pw_key = if matches!(t, NetworkType::PSK) {
+                            let pw_key = if matches!(t, NetworkType::PskOrSae) {
                                 "psk"
                             } else {
                                 "password"


### PR DESCRIPTION
Closes #1590 

Handles password protected WPA3 connections (SAE) the same as PSK and WPA3 connections without password (OWE) the same as the existing "open" network type.

OWE encrypts the connection despite not having a password, so I renamed a variable `is_encrypted` to `needs_password` to be more accurate.