### PR TITLE
fix: switch light and dark despite suspend/time change

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
@@ -260,6 +260,13 @@ impl Manager {
         &self.mode.0
     }
 
+    /// Update the locally cached `ThemeMode` from an external source (daemon / config watcher).
+    ///
+    /// This must not write back to config, since the daemon is the source of truth.
+    pub fn sync_mode(&mut self, mode: ThemeMode) {
+        self.mode.0 = mode;
+    }
+
     #[inline]
     pub fn builder(&self) -> &ThemeBuilder {
         &self.selected_customizer().builder.0


### PR DESCRIPTION
See possible-related issues https://github.com/pop-os/cosmic-settings/issues/1552 https://github.com/pop-os/cosmic-settings/issues/1414 https://github.com/pop-os/cosmic-settings-daemon/issues/19

Companion to https://github.com/pop-os/cosmic-settings-daemon/pull/127 where the actual fix lives.