### PR TITLE
fix(sound): only consider active routes when setting volume and mute-ness

### DIFF
--- a/crates/cosmic-pipewire/src/profile.rs
+++ b/crates/cosmic-pipewire/src/profile.rs
@@ -4,7 +4,7 @@
 use crate::{Availability, spa_utils::string_from_pod};
 use libspa::pod::Pod;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Profile {
     pub index: i32,
     pub priority: i32,


### PR DESCRIPTION
This should fix the audio device changing when the volume is modified. Will require syncing the same fix in cosmic-applets to get the fix there as well.