### PR TITLE
tweak: broaden `enable-export` message since it applies to QT too

### DIFF
--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -264,8 +264,8 @@ control-tint = Control component tint
 frosted = Frosted glass effect on system interface
     .desc = Applies background blur to panel, dock, applets, launcher, and application library
 
-enable-export = Apply current theme to GNOME apps
-    .desc = Not all toolkits support auto-switching. Non-COSMIC apps may need to be restarted after a theme change.
+enable-export = Apply current theme to non-COSMIC apps
+    .desc = Not all apps support auto-switching: non-COSMIC apps may need to be closed and reopened after a theme change.
 
 icon-theme = Icon theme
     .desc = Applies a different set of icons to applications


### PR DESCRIPTION
The `enable-export` message is no longer specific to GNOME/gtk.

I tweaked the description to make it slightly friendlier for a non-technical user:
- "Apply current theme to <del>GNOME and KDE</del> <ins>non-COSMIC</ins> apps"
  Someone new to Linux who chose Pop!_OS might know what COSMIC is, but not what GNOME or KDE are.
- "Not all <del>toolkits</del> <ins>apps</ins> support auto-switching."
  I don't think the average user knows what a toolkit is.
- "may need to be <del>restarted</del> <ins>closed and reopened</ins>"
  To avoid conflating this with a system restart.


Related:
- https://github.com/pop-os/libcosmic/pull/1121
- https://github.com/pop-os/cosmic-settings-daemon/pull/128

For reviewer:
- Decide if you like the above tweaks or not.
- I've left the non-English translations alone. Do I need to delete them for them to show up in Weblate again?
- I think it's okay to merge this PR before https://github.com/pop-os/cosmic-settings-daemon/pull/128 since I'm not making an explicit reference to QT.

PR checklist:
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

