### PR TITLE
fix(wallpaper):  deduplicate custom wallpaper entries

### DIFF
--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -1154,6 +1154,10 @@ impl Context {
     }
 
     fn add_custom_image(&mut self, path: PathBuf, display: Image, selection: ImageHandle) {
+        if self.paths.values().any(|p| p == &path) {
+            return;
+        }
+
         let key = self.paths.insert(path);
         self.is_custom.insert(key, ());
         self.display_images.insert(key, display);


### PR DESCRIPTION
This fixes an issue where the same custom wallpaper could be added multiple times
to the selection list, even though it was only stored once in the config.

The UI layer did not check for existing paths before inserting new entries,
which caused duplicate items to appear.

This change ensures that custom images are deduplicated based on their path
before being added to the in-memory selection state.

Before:
<img width="687" height="378" alt="image" src="https://github.com/user-attachments/assets/a6d93961-433c-4a25-8703-c98ef9917dbe" />

After:
<img width="687" height="378" alt="image" src="https://github.com/user-attachments/assets/6c467650-4939-4035-9331-8b906c1fc5de" />


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.