### PR TITLE
Notifications settings page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmic-notifications-config"
+version = "0.1.0"
+source = "git+https://github.com/pop-os/cosmic-notifications#b58fb29bd7e5898e4252ecb45d5bebfdecdf7cca"
+dependencies = [
+ "cosmic-config",
+ "serde",
+]
+
+[[package]]
 name = "cosmic-panel-config"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/cosmic-panel#6a783a18c3079955ff4cde1d00eaadf8e77b869c"
@@ -1678,6 +1687,7 @@ dependencies = [
  "cosmic-dbus-networkmanager",
  "cosmic-idle-config",
  "cosmic-mime-apps",
+ "cosmic-notifications-config",
  "cosmic-panel-config",
  "cosmic-protocols 0.2.0",
  "cosmic-randr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ git = "https://github.com/pop-os/cosmic-idle"
 [workspace.dependencies.cosmic-panel-config]
 git = "https://github.com/pop-os/cosmic-panel"
 
+[workspace.dependencies.cosmic-notifications-config]
+git = "https://github.com/pop-os/cosmic-notifications"
+
 [workspace.dependencies.cosmic-randr-shell]
 git = "https://github.com/pop-os/cosmic-randr"
 

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -25,6 +25,7 @@ cosmic-dbus-networkmanager = { git = "https://github.com/pop-os/dbus-settings-bi
 nm-secret-agent-manager = { git = "https://github.com/pop-os/dbus-settings-bindings", optional = true }
 cosmic-idle-config.workspace = true
 cosmic-panel-config = { workspace = true, optional = true }
+cosmic-notifications-config.workspace = true
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", optional = true }
 cosmic-randr-shell.workspace = true
 cosmic-randr = { workspace = true, optional = true }

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -569,6 +569,12 @@ impl cosmic::Application for SettingsApp {
                     }
                 }
 
+                crate::pages::Message::Notifications(message) => {
+                    if let Some(page) = self.pages.page_mut::<desktop::notifications::Page>() {
+                        return page.update(message).map(Into::into);
+                    }
+                }
+
                 #[cfg(feature = "page-region")]
                 crate::pages::Message::Region(message) => {
                     if let Some(page) = self.pages.page_mut::<time::region::Page>() {

--- a/cosmic-settings/src/pages/desktop/mod.rs
+++ b/cosmic-settings/src/pages/desktop/mod.rs
@@ -4,6 +4,7 @@
 pub mod appearance;
 #[cfg(feature = "wayland")]
 pub mod dock;
+pub mod notifications;
 #[cfg(feature = "wayland")]
 pub mod panel;
 pub mod wallpaper;
@@ -37,6 +38,7 @@ impl page::AutoBind<crate::pages::Message> for Page {
     ) -> page::Insert<crate::pages::Message> {
         page = page.sub_page::<wallpaper::Page>();
         page = page.sub_page::<appearance::Page>();
+        page = page.sub_page::<notifications::Page>();
 
         #[cfg(feature = "wayland")]
         {

--- a/cosmic-settings/src/pages/desktop/notifications.rs
+++ b/cosmic-settings/src/pages/desktop/notifications.rs
@@ -1,0 +1,307 @@
+// Copyright 2026 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! User configuration for `cosmic-notifications`.
+
+use cosmic::{
+    Apply, Element, Task,
+    cosmic_config::Config,
+    widget::{self, settings},
+};
+use cosmic_notifications_config::{Anchor, NotificationsConfig};
+use cosmic_settings_page::{self as page, AutoBind, Content, Info, Section, section};
+use slotmap::SlotMap;
+use tracing::{debug, error, instrument, warn};
+
+use crate::{app, pages, set_max_timeout};
+
+mod helpers;
+use helpers::{anchor_to_pos, load_config};
+
+pub struct Page {
+    entity: page::Entity,
+    config_helper: Option<Config>,
+    config: NotificationsConfig,
+
+    // Appearance UI helpers
+    anchor_dropdown: [String; 8],
+
+    // Timeout UI helpers
+    max_notif: String,
+    max_per_app: String,
+    max_timeout_urgent: String,
+    max_timeout_normal: String,
+    max_timeout_low: String,
+}
+
+impl Page {
+    /// Reload [`NotificationsConfig`] if it exists.
+    #[inline]
+    fn refresh(&mut self) {
+        self.config = load_config(self.config_helper.as_ref());
+    }
+
+    /// View for notification appearance config (e.g. anchor position and others).
+    fn appearance_view() -> Section<pages::Message> {
+        crate::slab!(descriptions {
+            anchor = fl!("notifications", "anchor");
+            anchor_desc = fl!("notifications", "anchor-desc");
+        });
+
+        Section::default()
+            .title(fl!("notifications", "appearance"))
+            .descriptions(descriptions)
+            .view::<Page>(move |_binder, page, section| {
+                // XXX: Anchor is trivially copyable but cosmic-notifications doesn't derive Copy.
+                let anchor_choice = Some(anchor_to_pos(page.config.anchor.clone()));
+
+                settings::section()
+                    .title(&*section.title)
+                    .add(
+                        settings::item::builder(&*section.descriptions[anchor])
+                            .description(&*section.descriptions[anchor_desc])
+                            .control(widget::dropdown(
+                                &page.anchor_dropdown,
+                                anchor_choice,
+                                Message::Anchor,
+                            )),
+                    )
+                    .apply(Element::from)
+                    .map(pages::Message::from)
+            })
+    }
+
+    /// View for notification timeout config (e.g. maximum timeout).
+    fn timeout_view() -> Section<pages::Message> {
+        crate::slab!(descriptions {
+            max_notif = fl!("notifications", "max");
+            max_notif_desc = fl!("notifications", "max-desc");
+            max_per_app = fl!("notifications", "max-per-app");
+            max_per_app_desc = fl!("notifications", "max-per-app-desc");
+            max_timeout_urgent = fl!("notifications", "max-timeout-urgent");
+            max_timeout_urgent_desc = fl!("notifications", "max-timeout-urgent-desc");
+            max_timeout_normal = fl!("notifications", "max-timeout-normal");
+            max_timeout_normal_desc = fl!("notifications", "max-timeout-normal-desc");
+            max_timeout_low = fl!("notifications", "max-timeout-low");
+            max_timeout_low_desc = fl!("notifications", "max-timeout-low-desc");
+        });
+
+        Section::default()
+            .title(fl!("notifications", "timeout"))
+            .descriptions(descriptions)
+            .view::<Page>(move |_binder, page, section| {
+                settings::section()
+                    .title(&*section.title)
+                    .add(
+                        settings::item::builder(&*section.descriptions[max_notif])
+                            .description(&*section.descriptions[max_notif_desc])
+                            .control(
+                                widget::text_input("", &page.max_notif)
+                                    .on_input(Message::MaxNotifications),
+                            ),
+                    )
+                    .add(
+                        settings::item::builder(&*section.descriptions[max_per_app])
+                            .description(&*section.descriptions[max_per_app_desc])
+                            .control(
+                                widget::text_input("", &page.max_per_app)
+                                    .on_input(Message::MaxPerApp),
+                            ),
+                    )
+                    .add(
+                        settings::item::builder(&*section.descriptions[max_timeout_urgent])
+                            .description(&*section.descriptions[max_timeout_urgent_desc])
+                            .control(
+                                widget::text_input("", &page.max_timeout_urgent)
+                                    .on_input(Message::MaxTimeoutUrgent),
+                            ),
+                    )
+                    .add(
+                        settings::item::builder(&*section.descriptions[max_timeout_normal])
+                            .description(&*section.descriptions[max_timeout_normal_desc])
+                            .control(
+                                widget::text_input("", &page.max_timeout_normal)
+                                    .on_input(Message::MaxTimeoutNormal),
+                            ),
+                    )
+                    .add(
+                        settings::item::builder(&*section.descriptions[max_timeout_low])
+                            .description(&*section.descriptions[max_timeout_low_desc])
+                            .control(
+                                widget::text_input("", &page.max_timeout_low)
+                                    .on_input(Message::MaxTimeoutLow),
+                            ),
+                    )
+                    .apply(Element::from)
+                    .map(pages::Message::from)
+            })
+    }
+
+    // View for per app notification settings.
+    // pub fn per_app_view(&self) -> Element<'static, pages::Message> {
+    //     unimplemented!()
+    // }
+
+    #[instrument(skip(self), fields(id = %cosmic_notifications_config::ID))]
+    pub fn update(&mut self, message: Message) -> Task<app::Message> {
+        match message {
+            Message::Anchor(i) => {
+                let anchor = match i {
+                    0 => Anchor::Top,
+                    1 => Anchor::Bottom,
+                    2 => Anchor::Right,
+                    3 => Anchor::Left,
+                    4 => Anchor::TopLeft,
+                    5 => Anchor::TopRight,
+                    6 => Anchor::BottomLeft,
+                    7 => Anchor::BottomRight,
+                    n => unreachable!("Dropdown for 'anchor' returned an out of bounds value: {n}"),
+                };
+
+                if let Some(helper) = self.config_helper.as_ref() {
+                    if let Err(e) = self.config.set_anchor(helper, anchor) {
+                        error!("Failed to set new anchor position: {e}");
+                    }
+                } else {
+                    warn!("Unable to set new anchor position due to missing config helper");
+                }
+            }
+            Message::MaxNotifications(s) => {
+                set_max_timeout!(
+                    self,
+                    "max_notifications",
+                    max_notifications,
+                    set_max_notifications,
+                    s
+                );
+                self.max_notif = s;
+            }
+            Message::MaxPerApp(s) => {
+                set_max_timeout!(self, "max_per_app", max_per_app, set_max_per_app, s);
+                self.max_per_app = s;
+            }
+            Message::MaxTimeoutUrgent(s) => {
+                set_max_timeout!(
+                    self,
+                    "max_timeout_urgent",
+                    max_timeout_urgent,
+                    set_max_timeout_urgent,
+                    s
+                );
+                self.max_timeout_urgent = s;
+            }
+            Message::MaxTimeoutLow(s) => {
+                set_max_timeout!(
+                    self,
+                    "max_timeout_low",
+                    max_timeout_low,
+                    set_max_timeout_low,
+                    s
+                );
+                self.max_timeout_low = s;
+            }
+            Message::MaxTimeoutNormal(s) => {
+                set_max_timeout!(
+                    self,
+                    "max_timeout_normal",
+                    max_timeout_normal,
+                    set_max_timeout_normal,
+                    s
+                );
+                self.max_timeout_normal = s;
+            }
+        }
+
+        Task::none()
+    }
+}
+
+impl Default for Page {
+    fn default() -> Self {
+        debug!(id = %cosmic_notifications_config::ID, "Loading Notifications config for the first time this instance");
+
+        let config_helper = Config::new(cosmic_notifications_config::ID, 1).ok();
+        let config = load_config(config_helper.as_ref());
+        let max_notif = config.max_notifications.to_string();
+        let max_per_app = config.max_per_app.to_string();
+        let max_timeout_urgent = config
+            .max_timeout_urgent
+            .map(|i| i.to_string())
+            .unwrap_or_default();
+        let max_timeout_normal = config
+            .max_timeout_normal
+            .map(|i| i.to_string())
+            .unwrap_or_default();
+        let max_timeout_low = config
+            .max_timeout_low
+            .map(|i| i.to_string())
+            .unwrap_or_default();
+
+        Self {
+            entity: Default::default(),
+            config_helper,
+            config,
+            anchor_dropdown: [
+                fl!("notifications", "anchor-top"),
+                fl!("notifications", "anchor-bottom"),
+                fl!("notifications", "anchor-right"),
+                fl!("notifications", "anchor-left"),
+                fl!("notifications", "anchor-top-left"),
+                fl!("notifications", "anchor-top-right"),
+                fl!("notifications", "anchor-bottom-left"),
+                fl!("notifications", "anchor-bottom-right"),
+            ],
+            max_notif,
+            max_per_app,
+            max_timeout_urgent,
+            max_timeout_normal,
+            max_timeout_low,
+        }
+    }
+}
+
+impl page::Page<pages::Message> for Page {
+    fn info(&self) -> Info {
+        Info::new("notifications", "notification-symbolic")
+            .title(fl!("notifications"))
+            .description(fl!("notifications", "desc"))
+    }
+
+    fn content(
+        &self,
+        sections: &mut SlotMap<section::Entity, Section<pages::Message>>,
+    ) -> Option<Content> {
+        Some(vec![
+            sections.insert(Self::appearance_view()),
+            sections.insert(Self::timeout_view()),
+        ])
+    }
+
+    fn on_enter(&mut self) -> Task<pages::Message> {
+        self.refresh();
+        Task::none()
+    }
+
+    fn set_id(&mut self, entity: page::Entity) {
+        self.entity = entity;
+    }
+}
+
+impl AutoBind<pages::Message> for Page {}
+
+/// Notification [`Page`] message.
+#[derive(Clone, Debug)]
+pub enum Message {
+    Anchor(usize),
+    MaxNotifications(String),
+    MaxPerApp(String),
+    MaxTimeoutUrgent(String),
+    MaxTimeoutNormal(String),
+    MaxTimeoutLow(String),
+}
+
+impl From<Message> for pages::Message {
+    fn from(message: Message) -> Self {
+        pages::Message::Notifications(message)
+    }
+}

--- a/cosmic-settings/src/pages/desktop/notifications/helpers.rs
+++ b/cosmic-settings/src/pages/desktop/notifications/helpers.rs
@@ -1,0 +1,60 @@
+// Copyright 2026 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use cosmic::cosmic_config::{Config, CosmicConfigEntry};
+use cosmic_notifications_config::{Anchor, NotificationsConfig};
+use tracing::{debug, instrument, trace, warn};
+
+/// Macro to parse and set user timeouts.
+#[macro_export]
+macro_rules! set_max_timeout {
+    ($self:expr, $name:literal, $field:ident, $setter:ident, $s:expr) => {
+        if let Some(helper) = $self.config_helper.as_ref()
+            && let Ok(max) = $s.parse::<u32>()
+            && let Err(e) = $self.config.$setter(helper, max.into())
+        {
+            error!("Failed to set '{}': {}", $name, e);
+        } else if let Some(helper) = $self.config_helper.as_ref()
+            && $s.is_empty()
+        {
+            let max = NotificationsConfig::default().$field;
+            if let Err(e) = $self.config.$setter(helper, max) {
+                error!("Failed to reset '{}' to default: {}", $name, e);
+            }
+        }
+    };
+}
+
+/// Load [`NotificationsConfig`] or return the default settings.
+#[instrument(skip(helper), fields(id = %cosmic_notifications_config::ID))]
+pub fn load_config(helper: Option<&Config>) -> NotificationsConfig {
+    trace!("Attempting to load config");
+
+    let Some(helper) = helper else {
+        debug!("Missing config helper; using default settings.");
+        return Default::default();
+    };
+
+    NotificationsConfig::get_entry(helper).unwrap_or_else(|(errors, config)| {
+        warn!("Loading config failed with: ");
+        for error in errors.iter().filter(|e| e.is_err()) {
+            warn!("\t* {error}");
+        }
+
+        config
+    })
+}
+
+#[inline]
+pub const fn anchor_to_pos(anchor: Anchor) -> usize {
+    match anchor {
+        Anchor::Top => 0,
+        Anchor::Bottom => 1,
+        Anchor::Right => 2,
+        Anchor::Left => 3,
+        Anchor::TopLeft => 4,
+        Anchor::TopRight => 5,
+        Anchor::BottomLeft => 6,
+        Anchor::BottomRight => 7,
+    }
+}

--- a/cosmic-settings/src/pages/mod.rs
+++ b/cosmic-settings/src/pages/mod.rs
@@ -75,6 +75,7 @@ pub enum Message {
     NavShortcuts(input::keyboard::shortcuts::ShortcutMessage),
     #[cfg(feature = "page-networking")]
     Networking(networking::Message),
+    Notifications(desktop::notifications::Message),
     Page(Entity),
     #[cfg(feature = "wayland")]
     Panel(desktop::panel::Message),

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -414,6 +414,31 @@ shadow-and-corners = Window shadow and corners
 ## Desktop: Notifications
 
 notifications = Notifications
+    .desc = Do Not Disturb, lockscreen notifications, and per-application settings
+    .appearance = Appearance
+
+    .anchor = Anchor
+    .anchor-desc = Screen location to display notification
+    .anchor-top = Top
+    .anchor-bottom = Bottom
+    .anchor-right = Right
+    .anchor-left = Left
+    .anchor-top-left = Top left
+    .anchor-top-right = Top right
+    .anchor-bottom-left = Bottom left
+    .anchor-bottom-right = Bottom right
+
+    .timeout = Timeout
+    .max = Maximum notifications
+    .max-desc = Maximum number of notifications that can be displayed at once
+    .max-per-app = Maximum notifications per app
+    .max-per-app-desc = Maximum number of notifications that can be displayed per app if not urgent nor constrained by "maximum notifications"
+    .max-timeout-urgent = Maximum timeout (Urgent)
+    .max-timeout-urgent-desc = Max time in milliseconds that an urgent notification will be displayed
+    .max-timeout-normal = Maximum timeout (Normal)
+    .max-timeout-normal-desc = Max time in milliseconds that a normal notification will be displayed
+    .max-timeout-low = Maximum timeout (Low)
+    .max-timeout-low-desc = Max time in milliseconds that a low priority notification will be displayed
 
 ## Desktop: Panel
 


### PR DESCRIPTION
Closes: pop-os/cosmic-notifications#97 pop-os/cosmic-notifications#83

I implemented a settings page for COSMIC Notifications so that it is easier to edit its config. COSMIC Notification already exposes a config to tweak useful options like the maximum time a notification may stay on the screen. Currently, there isn't a nice way to edit this config which can be confusing to end users.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

