### PR TITLE
i18n: improvements

### DIFF
--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -43,7 +43,7 @@ xdg-entry-desktop-keywords = COSMIC;Desktop;
 
 xdg-entry-displays = Displays
 xdg-entry-displays-comment = Manage display configuration settings
-xdg-entry-displays-keywords = COSMIC;Display;
+xdg-entry-displays-keywords = COSMIC;Display;Screen;Monitor;Resolution;Scale;Scaling;Orientation;Refresh;Variable;VRR;
 
 xdg-entry-dock = Dock
 xdg-entry-dock-comment = An optional bar for apps and applets


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

[displays_reset.webm](https://github.com/user-attachments/assets/0ab201ee-ec34-4d5d-b3a3-b7e73419a639)

Changes
- Makes "revert/keep display settings" dialog show proper sentences (see the video)
  - "..will revert .. in 2 seconds."
  - "..will revert .. in 1 second."
  - "..will revert .. now."
- Adds spaces to a shortcut for consistency, as most of them include spaces
- Adds missing trailing semicolons to keywords
- Adds more display related keywords
  - User is likely to search for "monitor", "screen", "resolution",..
- Fixes a few strings

Note
- I found more minor issues mostly consisting of capitalization, but I'm not sure about the changes, so I decided to not include them in this PR. I might make a separate one just for that later.
- If you want to look into it, most of them are in the Keyboard shortcuts menu
  - Input devices --> Keyboard --> View and customize shortcuts