### PR TITLE
chore: Use `slab!` and `with_capacity` more

### DIFF
--- a/cosmic-settings/src/pages/applications/legacy_applications.rs
+++ b/cosmic-settings/src/pages/applications/legacy_applications.rs
@@ -21,7 +21,6 @@ use cosmic_randr_shell::List;
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
 use futures::SinkExt;
-use slab::Slab;
 use slotmap::SlotMap;
 use tokio::sync::oneshot;
 use tracing::error;
@@ -265,14 +264,14 @@ impl Page {
 }
 
 pub fn legacy_application_global_shortcuts() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let desc = descriptions.insert(fl!("legacy-app-global-shortcuts", "desc"));
-    let none = descriptions.insert(fl!("legacy-app-global-shortcuts", "none"));
-    let modifiers = descriptions.insert(fl!("legacy-app-global-shortcuts", "modifiers"));
-    let combination = descriptions.insert(fl!("legacy-app-global-shortcuts", "combination"));
-    let all = descriptions.insert(fl!("legacy-app-global-shortcuts", "all"));
-    let mouse = descriptions.insert(fl!("legacy-app-global-shortcuts", "mouse"));
+    crate::slab!(descriptions {
+        desc = fl!("legacy-app-global-shortcuts", "desc");
+        none = fl!("legacy-app-global-shortcuts", "none");
+        modifiers = fl!("legacy-app-global-shortcuts", "modifiers");
+        combination = fl!("legacy-app-global-shortcuts", "combination");
+        all = fl!("legacy-app-global-shortcuts", "all");
+        mouse = fl!("legacy-app-global-shortcuts", "mouse");
+    });
 
     Section::default()
         .title(fl!("legacy-app-global-shortcuts"))
@@ -339,15 +338,16 @@ pub fn legacy_application_global_shortcuts() -> Section<crate::pages::Message> {
 }
 
 pub fn legacy_application_scaling() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
+    crate::slab!(descriptions {
+        gaming = fl!("legacy-app-scaling", "scaled-gaming");
+        gaming_desc = fl!("legacy-app-scaling", "gaming-description");
+        apps = fl!("legacy-app-scaling", "scaled-applications");
+        apps_desc = fl!("legacy-app-scaling", "applications-description");
+        compat = fl!("legacy-app-scaling", "scaled-compatibility");
+        compat_desc = fl!("legacy-app-scaling", "compatibility-description");
+        preferred_display = fl!("legacy-app-scaling", "preferred-display");
 
-    let gaming = descriptions.insert(fl!("legacy-app-scaling", "scaled-gaming"));
-    let gaming_desc = descriptions.insert(fl!("legacy-app-scaling", "gaming-description"));
-    let apps = descriptions.insert(fl!("legacy-app-scaling", "scaled-applications"));
-    let apps_desc = descriptions.insert(fl!("legacy-app-scaling", "applications-description"));
-    let compat = descriptions.insert(fl!("legacy-app-scaling", "scaled-compatibility"));
-    let compat_desc = descriptions.insert(fl!("legacy-app-scaling", "compatibility-description"));
-    let preferred_display = descriptions.insert(fl!("legacy-app-scaling", "preferred-display"));
+    });
 
     Section::default()
         .title(fl!("legacy-app-scaling"))

--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -9,7 +9,6 @@ use cosmic_settings_bluetooth_subscription::*;
 use cosmic_settings_page::{self as page, Section, section};
 use futures::channel::oneshot;
 use futures::{SinkExt, StreamExt};
-use slab::Slab;
 use slotmap::SlotMap;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -725,9 +724,9 @@ impl Page {
 }
 
 fn status() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let bluetooth = descriptions.insert(fl!("bluetooth"));
+    crate::slab!(descriptions {
+        bluetooth = fl!("bluetooth");
+    });
 
     Section::default()
         .descriptions(descriptions)
@@ -903,9 +902,9 @@ fn connected_devices() -> Section<crate::pages::Message> {
 }
 
 fn available_devices() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let device_connecting = descriptions.insert(fl!("bluetooth", "connecting"));
+    crate::slab!(descriptions {
+        device_connecting = fl!("bluetooth", "connecting");
+    });
 
     Section::default()
         .title(fl!("bluetooth-available"))
@@ -959,9 +958,9 @@ fn available_devices() -> Section<crate::pages::Message> {
 }
 
 fn multiple_adapter() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let device_connected = descriptions.insert(fl!("bluetooth", "connected"));
+    crate::slab!(descriptions {
+        device_connected = fl!("bluetooth", "connected");
+    });
 
     Section::default()
         .title(fl!("bluetooth-adapters"))

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -31,7 +31,6 @@ use cosmic_panel_config::CosmicPanelConfig;
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
 use ron::ser::PrettyConfig;
-use slab::Slab;
 use slotmap::{Key, SlotMap};
 
 use crate::app;
@@ -821,10 +820,10 @@ pub fn interface_density() -> Section<crate::pages::Message> {
 
 #[allow(clippy::too_many_lines)]
 pub fn window_management() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let active_hint = descriptions.insert(fl!("window-management-appearance", "active-hint"));
-    let gaps = descriptions.insert(fl!("window-management-appearance", "gaps"));
+    crate::slab!(descriptions {
+        active_hint = fl!("window-management-appearance", "active-hint");
+        gaps = fl!("window-management-appearance", "gaps");
+    });
 
     Section::default()
         .title(fl!("window-management-appearance"))
@@ -914,9 +913,9 @@ pub fn experimental() -> Section<crate::pages::Message> {
 
 #[allow(clippy::too_many_lines)]
 pub fn reset_button() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let reset_to_default = descriptions.insert(fl!("reset-to-default"));
+    crate::slab!(descriptions {
+        reset_to_default = fl!("reset-to-default");
+    });
 
     Section::default()
         .descriptions(descriptions)

--- a/cosmic-settings/src/pages/desktop/appearance/style.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/style.rs
@@ -3,17 +3,16 @@ use cosmic::widget::icon::{from_name, icon};
 use cosmic::widget::{button, container, settings, text};
 use cosmic::{Apply, Element};
 use cosmic_settings_page::Section;
-use slab::Slab;
 
 use super::{Message, Page, Roundness};
 
 #[allow(clippy::too_many_lines)]
 pub fn section() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let round = descriptions.insert(fl!("style", "round"));
-    let slightly_round = descriptions.insert(fl!("style", "slightly-round"));
-    let square = descriptions.insert(fl!("style", "square"));
+    crate::slab!(descriptions {
+        round = fl!("style", "round");
+        slightly_round = fl!("style", "slightly-round");
+        square = fl!("style", "square");
+    });
 
     let dark_round_style = from_name("illustration-appearance-dark-style-round").handle();
     let light_round_style = from_name("illustration-appearance-light-style-round").handle();

--- a/cosmic-settings/src/pages/desktop/dock/mod.rs
+++ b/cosmic-settings/src/pages/desktop/dock/mod.rs
@@ -8,7 +8,6 @@ use cosmic::{
 };
 use cosmic_panel_config::{CosmicPanelConfig, CosmicPanelContainerConfig};
 use cosmic_settings_page::{self as page, Section, section};
-use slab::Slab;
 use slotmap::SlotMap;
 use tracing::error;
 
@@ -158,9 +157,9 @@ impl Default for Page {
 }
 
 pub(crate) fn enable() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let dock = descriptions.insert(fl!("dock"));
+    crate::slab!(descriptions {
+        dock = fl!("dock");
+    });
 
     Section::default()
         .descriptions(descriptions)

--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -17,7 +17,6 @@ use cosmic_panel_config::{
     CosmicPanelOuput, PanelAnchor, PanelSize,
 };
 use cosmic_settings_page::{self as page, Section};
-use slab::Slab;
 use std::{collections::HashMap, time::Duration};
 
 use crate::pages::desktop::appearance::Roundness;
@@ -102,11 +101,11 @@ pub(crate) fn behavior_and_position<
     p: &P,
     msg_map: T,
 ) -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let autohide_label = descriptions.insert(p.autohide_label());
-    let position = descriptions.insert(fl!("panel-behavior-and-position", "position"));
-    let display = descriptions.insert(fl!("panel-behavior-and-position", "display"));
+    crate::slab!(descriptions {
+        autohide_label = p.autohide_label();
+        position = fl!("panel-behavior-and-position", "position");
+        display = fl!("panel-behavior-and-position", "display");
+    });
 
     Section::default()
         .title(fl!("panel-behavior-and-position"))
@@ -161,13 +160,13 @@ pub(crate) fn style<
     p: &P,
     msg_map: T,
 ) -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let gap_label = descriptions.insert(p.gap_label());
-    let extend_label = descriptions.insert(p.extend_label());
-    let appearance = descriptions.insert(fl!("panel-style", "appearance"));
-    let background_opacity = descriptions.insert(fl!("panel-style", "background-opacity"));
-    let size = descriptions.insert(fl!("panel-style", "size"));
+    crate::slab!(descriptions {
+        gap_label = p.gap_label();
+        extend_label = p.extend_label();
+        appearance = fl!("panel-style", "appearance");
+        background_opacity = fl!("panel-style", "background-opacity");
+        size = fl!("panel-style", "size");
+    });
 
     Section::default()
         .title(fl!("panel-style"))
@@ -270,9 +269,9 @@ pub(crate) fn style<
 pub(crate) fn configuration<P: page::Page<crate::pages::Message> + PanelPage>(
     p: &P,
 ) -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let applets_label = descriptions.insert(p.configure_applets_label());
+    crate::slab!(descriptions {
+        applets_label = p.configure_applets_label();
+    });
 
     Section::default()
         .title(fl!("panel-applets"))
@@ -315,9 +314,9 @@ pub(crate) fn add_panel<
 >(
     msg_map: T,
 ) -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let reset_to_default = descriptions.insert(fl!("reset-to-default"));
+    crate::slab!(descriptions {
+        reset_to_default = fl!("reset-to-default");
+    });
 
     Section::default()
         .title(fl!("panel-missing"))
@@ -338,9 +337,9 @@ pub fn reset_button<
 >(
     msg_map: T,
 ) -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let reset_to_default = descriptions.insert(fl!("reset-to-default"));
+    crate::slab!(descriptions {
+        reset_to_default = fl!("reset-to-default");
+    });
 
     Section::default()
         .descriptions(descriptions)

--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -38,7 +38,6 @@ use cosmic_settings_page::{self as page, section};
 use cosmic_settings_wallpaper::{self as wallpaper, Entry, ScalingMode};
 use image::imageops::FilterType::Lanczos3;
 use image::{ImageBuffer, Rgba};
-use slab::Slab;
 use slotmap::{DefaultKey, Key, SecondaryMap, SlotMap};
 
 use crate::subscription::WallpaperEvent;
@@ -1189,12 +1188,12 @@ impl Context {
 
 #[allow(clippy::too_many_lines)]
 pub fn settings() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let same_label = descriptions.insert(fl!("wallpaper", "same"));
-    let fit_label = descriptions.insert(fl!("wallpaper", "fit"));
-    let slide_label = descriptions.insert(fl!("wallpaper", "slide"));
-    let change_label = descriptions.insert(fl!("wallpaper", "change"));
+    crate::slab!(descriptions {
+        same_label = fl!("wallpaper", "same");
+        fit_label = fl!("wallpaper", "fit");
+        slide_label = fl!("wallpaper", "slide");
+        change_label = fl!("wallpaper", "change");
+    });
 
     Section::default()
         .descriptions(descriptions)

--- a/cosmic-settings/src/pages/desktop/window_management.rs
+++ b/cosmic-settings/src/pages/desktop/window_management.rs
@@ -13,7 +13,6 @@ use cosmic_config::{ConfigGet, ConfigSet};
 use cosmic_settings_config::{Action, Binding, Shortcuts, shortcuts};
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
-use slab::Slab;
 use slotmap::SlotMap;
 use tracing::error;
 
@@ -229,15 +228,14 @@ impl page::Page<crate::pages::Message> for Page {
 impl page::AutoBind<crate::pages::Message> for Page {}
 
 pub fn window_management() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let super_key = descriptions.insert(fl!("super-key"));
-    let _launcher = descriptions.insert(fl!("super-key", "launcher"));
-    let _workspaces = descriptions.insert(fl!("super-key", "workspaces"));
-    let _applications = descriptions.insert(fl!("super-key", "applications"));
-    let _disable = descriptions.insert(fl!("super-key", "disable"));
-
-    let edge_gravity = descriptions.insert(fl!("edge-gravity"));
+    crate::slab!(descriptions {
+        super_key = fl!("super-key");
+        _launcher = fl!("super-key", "launcher");
+        _workspaces = fl!("super-key", "workspaces");
+        _applications = fl!("super-key", "applications");
+        _disable = fl!("super-key", "disable");
+        edge_gravity = fl!("edge-gravity");
+    });
 
     Section::default()
         .descriptions(descriptions)
@@ -272,11 +270,11 @@ pub fn window_management() -> Section<crate::pages::Message> {
 }
 
 pub fn window_controls() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let maximize = descriptions.insert(fl!("window-controls", "maximize"));
-    let minimize = descriptions.insert(fl!("window-controls", "minimize"));
-    let active_window_hint = descriptions.insert(fl!("window-controls", "active-window-hint"));
+    crate::slab!(descriptions {
+        maximize = fl!("window-controls", "maximize");
+        minimize = fl!("window-controls", "minimize");
+        active_window_hint = fl!("window-controls", "active-window-hint");
+    });
 
     Section::default()
         .title(fl!("window-controls"))
@@ -304,12 +302,11 @@ pub fn window_controls() -> Section<crate::pages::Message> {
 }
 
 pub fn focus_navigation() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let focus_follows_cursor = descriptions.insert(fl!("focus-navigation", "focus-follows-cursor"));
-    let focus_follows_cursor_delay =
-        descriptions.insert(fl!("focus-navigation", "focus-follows-cursor-delay"));
-    let cursor_follows_focus = descriptions.insert(fl!("focus-navigation", "cursor-follows-focus"));
+    crate::slab!(descriptions {
+        focus_follows_cursor = fl!("focus-navigation", "focus-follows-cursor");
+        focus_follows_cursor_delay = fl!("focus-navigation", "focus-follows-cursor-delay");
+        cursor_follows_focus = fl!("focus-navigation", "cursor-follows-focus");
+    });
 
     Section::default()
         .title(fl!("focus-navigation"))

--- a/cosmic-settings/src/pages/desktop/workspaces.rs
+++ b/cosmic-settings/src/pages/desktop/workspaces.rs
@@ -13,7 +13,6 @@ use cosmic::{
 use cosmic_comp_config::workspace::{Action, WorkspaceConfig, WorkspaceLayout, WorkspaceMode};
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
-use slab::Slab;
 use slotmap::SlotMap;
 use tracing::error;
 
@@ -164,9 +163,9 @@ fn into_action(value: usize) -> Action {
 }
 
 pub fn action_on_typing() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let action_on_typing = descriptions.insert(fl!("workspaces-overview", "action-on-typing"));
+    crate::slab!(descriptions {
+        action_on_typing = fl!("workspaces-overview", "action-on-typing");
+    });
 
     Section::default()
         .title(fl!("workspaces-overview"))
@@ -198,10 +197,10 @@ pub fn action_on_typing() -> Section<crate::pages::Message> {
 }
 
 fn multi_behavior() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let span = descriptions.insert(fl!("workspaces-multi-behavior", "span"));
-    let separate = descriptions.insert(fl!("workspaces-multi-behavior", "separate"));
+    crate::slab!(descriptions {
+        span = fl!("workspaces-multi-behavior", "span");
+        separate = fl!("workspaces-multi-behavior", "separate");
+    });
 
     Section::default()
         .title(fl!("workspaces-multi-behavior"))
@@ -236,10 +235,10 @@ fn multi_behavior() -> Section<crate::pages::Message> {
 }
 
 fn workspace_orientation() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let vertical = descriptions.insert(fl!("workspaces-orientation", "vertical"));
-    let horizontal = descriptions.insert(fl!("workspaces-orientation", "horizontal"));
+    crate::slab!(descriptions {
+        vertical = fl!("workspaces-orientation", "vertical");
+        horizontal = fl!("workspaces-orientation", "horizontal");
+    });
 
     Section::default()
         .title(fl!("workspaces-orientation"))

--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -18,7 +18,6 @@ use cosmic_randr_shell::{
 use cosmic_settings_page::{self as page, Section, section};
 use futures::SinkExt;
 use indexmap::Equivalent;
-use slab::Slab;
 use slotmap::{Key, SecondaryMap, SlotMap};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
@@ -1183,10 +1182,10 @@ impl Page {
 
 /// View for the display arrangement section.
 pub fn display_arrangement() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    _ = descriptions.insert(fl!("display", "arrangement"));
-    let display_arrangement_desc = descriptions.insert(fl!("display", "arrangement-desc"));
+    crate::slab!(descriptions {
+        _display_arrangement = fl!("display", "arrangement");
+        display_arrangement_desc = fl!("display", "arrangement-desc");
+    });
 
     Section::default()
         .title(fl!("display", "arrangement"))
@@ -1227,18 +1226,18 @@ pub fn display_arrangement() -> Section<crate::pages::Message> {
 
 /// View for the display configuration section.
 pub fn display_configuration() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let _display = descriptions.insert(fl!("display"));
-    let refresh_rate = descriptions.insert(fl!("display", "refresh-rate"));
-    let vrr = descriptions.insert(fl!("vrr"));
-    let resolution = descriptions.insert(fl!("display", "resolution"));
-    let scale = descriptions.insert(fl!("display", "scale"));
-    let additional_scale_options = descriptions.insert(fl!("display", "additional-scale-options"));
-    let orientation = descriptions.insert(fl!("orientation"));
-    let enable_label = descriptions.insert(fl!("display", "enable"));
-    let options_label = descriptions.insert(fl!("display", "options"));
-    let mirroring_label = descriptions.insert(fl!("mirroring"));
+    crate::slab!(descriptions {
+        _display = fl!("display");
+        refresh_rate = fl!("display", "refresh-rate");
+        vrr = fl!("vrr");
+        resolution = fl!("display", "resolution");
+        scale = fl!("display", "scale");
+        additional_scale_options = fl!("display", "additional-scale-options");
+        orientation = fl!("orientation");
+        enable_label = fl!("display", "enable");
+        options_label = fl!("display", "options");
+        mirroring_label = fl!("mirroring");
+    });
 
     Section::default()
         .descriptions(descriptions)

--- a/cosmic-settings/src/pages/input/keyboard/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/mod.rs
@@ -16,7 +16,6 @@ use cosmic::{
 use cosmic_comp_config::{KeyboardConfig, NumlockState, XkbConfig};
 use cosmic_settings_page::{self as page, Section, section};
 use itertools::Itertools;
-use slab::Slab;
 use slotmap::{DefaultKey, Key, SlotMap};
 
 static COMPOSE_OPTIONS: &[(&str, &str)] = &[
@@ -727,11 +726,11 @@ fn input_sources() -> Section<crate::pages::Message> {
 }
 
 fn special_character_entry() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let alternate = descriptions.insert(fl!("keyboard-special-char", "alternate"));
-    let compose = descriptions.insert(fl!("keyboard-special-char", "compose"));
-    let caps = descriptions.insert(fl!("keyboard-special-char", "caps"));
+    crate::slab!(descriptions {
+        alternate = fl!("keyboard-special-char", "alternate");
+        compose = fl!("keyboard-special-char", "compose");
+        caps = fl!("keyboard-special-char", "caps");
+    });
 
     Section::default()
         .title(fl!("keyboard-special-char"))
@@ -759,9 +758,9 @@ fn special_character_entry() -> Section<crate::pages::Message> {
 }
 
 fn keyboard_shortcuts() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let shortcuts_desc = descriptions.insert(fl!("keyboard-shortcuts", "desc"));
+    crate::slab!(descriptions {
+        shortcuts_desc = fl!("keyboard-shortcuts", "desc");
+    });
 
     Section::default()
         .title(fl!("keyboard-shortcuts"))
@@ -785,14 +784,14 @@ fn keyboard_shortcuts() -> Section<crate::pages::Message> {
 }
 
 fn keyboard_typing_assist() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let repeat_delay = descriptions.insert(fl!("keyboard-typing-assist", "repeat-delay"));
-    let repeat_rate = descriptions.insert(fl!("keyboard-typing-assist", "repeat-rate"));
-    let short = descriptions.insert(fl!("short"));
-    let long = descriptions.insert(fl!("long"));
-    let slow = descriptions.insert(fl!("slow"));
-    let fast = descriptions.insert(fl!("fast"));
+    crate::slab!(descriptions {
+        repeat_delay = fl!("keyboard-typing-assist", "repeat-delay");
+        repeat_rate = fl!("keyboard-typing-assist", "repeat-rate");
+        short = fl!("short");
+        long = fl!("long");
+        slow = fl!("slow");
+        fast = fl!("fast");
+    });
 
     Section::default()
         .title(fl!("keyboard-typing-assist"))
@@ -848,9 +847,9 @@ fn keyboard_typing_assist() -> Section<crate::pages::Message> {
 }
 
 fn keyboard_num_lock() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let boot_state = descriptions.insert(fl!("keyboard-numlock-boot", "boot-state"));
+    crate::slab!(descriptions {
+        boot_state = fl!("keyboard-numlock-boot", "boot-state");
+    });
 
     Section::default()
         .title(fl!("keyboard-numlock-boot"))

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/accessibility.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/accessibility.rs
@@ -17,10 +17,13 @@ impl Default for Page {
     fn default() -> Self {
         Self {
             model: super::Model::default().actions(|defaults, keybindings| {
-                actions().iter().fold(Slab::new(), |mut slab, action| {
-                    slab.insert(ShortcutModel::new(defaults, keybindings, action.clone()));
-                    slab
-                })
+                actions().iter().cloned().fold(
+                    Slab::with_capacity(actions().len()),
+                    |mut slab, action| {
+                        slab.insert(ShortcutModel::new(defaults, keybindings, action));
+                        slab
+                    },
+                )
             }),
         }
     }
@@ -101,7 +104,7 @@ pub const fn actions() -> &'static [Action] {
 }
 
 fn shortcuts() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
+    let mut descriptions = Slab::with_capacity(actions().len());
 
     // Make these searchable in the global settings search.
     for action in actions() {

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/manage_windows.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/manage_windows.rs
@@ -102,7 +102,7 @@ pub const fn actions() -> &'static [Action] {
     ]
 }
 fn shortcuts() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
+    let mut descriptions = Slab::with_capacity(actions().len());
 
     // Make these searchable in the global settings search.
     for action in actions() {

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/mod.rs
@@ -405,28 +405,31 @@ impl Search {
                 self.localized[*id].to_lowercase().contains(&input)
                     || shortcut_search_actions.contains(action)
             })
-            .fold(Slab::new(), |mut slab, (_, action)| {
-                slab.insert(ShortcutModel::new(
-                    &self.defaults,
-                    &self.shortcuts,
-                    action.clone(),
-                ));
+            .fold(
+                Slab::with_capacity(self.actions.len()),
+                |mut slab, (_, action)| {
+                    slab.insert(ShortcutModel::new(
+                        &self.defaults,
+                        &self.shortcuts,
+                        action.clone(),
+                    ));
 
-                slab
-            })
+                    slab
+                },
+            )
     }
 }
 
 fn shortcuts() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let accessibility = descriptions.insert(fl!("accessibility"));
-    let custom_label = descriptions.insert(fl!("custom"));
-    let manage_window_label = descriptions.insert(fl!("manage-windows"));
-    let move_window_label = descriptions.insert(fl!("move-windows"));
-    let nav_label = descriptions.insert(fl!("nav-shortcuts"));
-    let system_label = descriptions.insert(fl!("system-shortcut"));
-    let window_tiling_label = descriptions.insert(fl!("window-tiling"));
+    crate::slab!(descriptions {
+        accessibility = fl!("accessibility");
+        custom_label = fl!("custom");
+        manage_window_label = fl!("manage-windows");
+        move_window_label = fl!("move-windows");
+        nav_label = fl!("nav-shortcuts");
+        system_label = fl!("system-shortcut");
+        window_tiling_label = fl!("window-tiling");
+    });
 
     Section::default()
         .descriptions(descriptions)

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/move_window.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/move_window.rs
@@ -16,10 +16,13 @@ impl Default for Page {
     fn default() -> Self {
         Self {
             model: super::Model::default().actions(|defaults, keybindings| {
-                actions().iter().fold(Slab::new(), |mut slab, action| {
-                    slab.insert(ShortcutModel::new(defaults, keybindings, action.clone()));
-                    slab
-                })
+                actions().iter().cloned().fold(
+                    Slab::with_capacity(actions().len()),
+                    |mut slab, action| {
+                        slab.insert(ShortcutModel::new(defaults, keybindings, action));
+                        slab
+                    },
+                )
             }),
         }
     }
@@ -116,7 +119,7 @@ pub const fn actions() -> &'static [Action] {
 }
 
 fn shortcuts() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
+    let mut descriptions = Slab::with_capacity(actions().len());
 
     // Make these searchable in the global settings search.
     for action in actions() {

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/nav.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/nav.rs
@@ -17,10 +17,13 @@ impl Default for Page {
     fn default() -> Self {
         Self {
             model: super::Model::default().actions(|defaults, keybindings| {
-                actions().iter().fold(Slab::new(), |mut slab, action| {
-                    slab.insert(ShortcutModel::new(defaults, keybindings, action.clone()));
-                    slab
-                })
+                actions().iter().cloned().fold(
+                    Slab::with_capacity(actions().len()),
+                    |mut slab, action| {
+                        slab.insert(ShortcutModel::new(defaults, keybindings, action));
+                        slab
+                    },
+                )
             }),
         }
     }
@@ -119,7 +122,7 @@ pub const fn actions() -> &'static [Action] {
 }
 
 fn shortcuts() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
+    let mut descriptions = Slab::with_capacity(actions().len());
 
     // Make these searchable in the global settings search.
     for action in actions() {

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/system.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/system.rs
@@ -16,10 +16,13 @@ impl Default for Page {
     fn default() -> Self {
         Self {
             model: super::Model::default().actions(|defaults, keybindings| {
-                actions().iter().fold(Slab::new(), |mut slab, action| {
-                    slab.insert(ShortcutModel::new(defaults, keybindings, action.clone()));
-                    slab
-                })
+                actions().iter().cloned().fold(
+                    Slab::with_capacity(actions().len()),
+                    |mut slab, action| {
+                        slab.insert(ShortcutModel::new(defaults, keybindings, action));
+                        slab
+                    },
+                )
             }),
         }
     }
@@ -122,7 +125,7 @@ pub const fn actions() -> &'static [Action] {
 }
 
 fn shortcuts() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
+    let mut descriptions = Slab::with_capacity(actions().len());
 
     // Make these searchable in the global settings search.
     for action in actions() {

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/tiling.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/tiling.rs
@@ -16,10 +16,13 @@ impl Default for Page {
     fn default() -> Self {
         Self {
             model: super::Model::default().actions(|defaults, keybindings| {
-                actions().iter().fold(Slab::new(), |mut slab, action| {
-                    slab.insert(ShortcutModel::new(defaults, keybindings, action.clone()));
-                    slab
-                })
+                actions().iter().cloned().fold(
+                    Slab::with_capacity(actions().len()),
+                    |mut slab, action| {
+                        slab.insert(ShortcutModel::new(defaults, keybindings, action));
+                        slab
+                    },
+                )
             }),
         }
     }
@@ -103,7 +106,7 @@ pub fn actions() -> &'static [Action] {
 }
 
 fn shortcuts() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
+    let mut descriptions = Slab::with_capacity(actions().len());
 
     // Make these searchable in the global settings search.
     for action in actions() {

--- a/cosmic-settings/src/pages/input/mouse.rs
+++ b/cosmic-settings/src/pages/input/mouse.rs
@@ -7,7 +7,6 @@ use cosmic::{Apply, Element};
 use cosmic_comp_config::input::AccelProfile;
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
-use slab::Slab;
 use slotmap::SlotMap;
 
 use super::Message;
@@ -48,12 +47,12 @@ impl page::Page<crate::pages::Message> for Page {
 impl page::AutoBind<crate::pages::Message> for Page {}
 
 fn mouse() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let mouse_acceleration = descriptions.insert(fl!("mouse", "acceleration"));
-    let mouse_speed = descriptions.insert(fl!("mouse", "speed"));
-    let primary_button = descriptions.insert(fl!("primary-button"));
-    let acceleration_desc = descriptions.insert(fl!("acceleration-desc"));
+    crate::slab!(descriptions {
+        mouse_acceleration = fl!("mouse", "acceleration");
+        mouse_speed = fl!("mouse", "speed");
+        primary_button = fl!("primary-button");
+        acceleration_desc = fl!("acceleration-desc");
+    });
 
     Section::default()
         .descriptions(descriptions)
@@ -116,11 +115,11 @@ fn mouse() -> Section<crate::pages::Message> {
 }
 
 fn scrolling() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let natural = descriptions.insert(fl!("scrolling", "natural"));
-    let natural_desc = descriptions.insert(fl!("scrolling", "natural-desc"));
-    let scroll_speed = descriptions.insert(fl!("scrolling", "speed"));
+    crate::slab!(descriptions {
+        natural = fl!("scrolling", "natural");
+        natural_desc = fl!("scrolling", "natural-desc");
+        scroll_speed = fl!("scrolling", "speed");
+    });
 
     Section::default()
         .title(fl!("scrolling"))

--- a/cosmic-settings/src/pages/input/touchpad.rs
+++ b/cosmic-settings/src/pages/input/touchpad.rs
@@ -10,7 +10,6 @@ use cosmic_comp_config::input::{AccelProfile, ClickMethod, ScrollMethod};
 use cosmic_comp_config::workspace::{WorkspaceConfig, WorkspaceLayout};
 use cosmic_settings_page::Section;
 use cosmic_settings_page::{self as page, section};
-use slab::Slab;
 use slotmap::SlotMap;
 use tracing::error;
 
@@ -59,14 +58,14 @@ impl page::Page<crate::pages::Message> for Page {
 impl page::AutoBind<crate::pages::Message> for Page {}
 
 fn touchpad() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let primary_button = descriptions.insert(fl!("primary-button"));
-    let primary_button_desc = descriptions.insert(fl!("primary-button", "desc"));
-    let touchpad_speed = descriptions.insert(fl!("touchpad", "speed"));
-    let acceleration = descriptions.insert(fl!("touchpad", "acceleration"));
-    let acceleration_desc = descriptions.insert(fl!("acceleration-desc"));
-    let disable_while_typing = descriptions.insert(fl!("disable-while-typing"));
+    crate::slab!(descriptions {
+        primary_button = fl!("primary-button");
+        primary_button_desc = fl!("primary-button", "desc");
+        touchpad_speed = fl!("touchpad", "speed");
+        acceleration = fl!("touchpad", "acceleration");
+        acceleration_desc = fl!("acceleration-desc");
+        disable_while_typing = fl!("disable-while-typing");
+    });
 
     Section::default()
         .descriptions(descriptions)
@@ -148,12 +147,12 @@ fn touchpad() -> Section<crate::pages::Message> {
 }
 
 fn click_behavior() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let click_finger = descriptions.insert(fl!("click-behavior", "click-finger"));
-    let button_areas = descriptions.insert(fl!("click-behavior", "button-areas"));
-    let tap_to_click = descriptions.insert(fl!("tap-to-click"));
-    let _tap_to_click_desc = descriptions.insert(fl!("tap-to-click", "desc"));
+    crate::slab!(descriptions {
+        click_finger = fl!("click-behavior", "click-finger");
+        button_areas = fl!("click-behavior", "button-areas");
+        tap_to_click = fl!("tap-to-click");
+        _tap_to_click_desc = fl!("tap-to-click", "desc");
+    });
 
     Section::default()
         .title(fl!("click-behavior"))
@@ -203,13 +202,13 @@ fn click_behavior() -> Section<crate::pages::Message> {
 }
 
 fn scrolling() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let edge = descriptions.insert(fl!("scrolling", "edge"));
-    let natural = descriptions.insert(fl!("scrolling", "natural"));
-    let natural_desc = descriptions.insert(fl!("scrolling", "natural-desc"));
-    let scroll_speed = descriptions.insert(fl!("scrolling", "speed"));
-    let two_finger = descriptions.insert(fl!("scrolling", "two-finger"));
+    crate::slab!(descriptions {
+        edge = fl!("scrolling", "edge");
+        natural = fl!("scrolling", "natural");
+        natural_desc = fl!("scrolling", "natural-desc");
+        scroll_speed = fl!("scrolling", "speed");
+        two_finger = fl!("scrolling", "two-finger");
+    });
 
     Section::default()
         .title(fl!("scrolling"))
@@ -298,7 +297,11 @@ fn scrolling() -> Section<crate::pages::Message> {
 }
 
 fn gestures() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
+    crate::slab!(descriptions {
+        switch_workspaces = fl!("switch-workspaces");
+        switch_workspaces_horizontal = fl!("switch-workspaces", "horizontal");
+        switch_workspaces_vertical = fl!("switch-workspaces", "vertical");
+    });
 
     // let four_finger_down = descriptions.insert(fl!("gestures", "four-finger-down"));
     // let four_finger_left = descriptions.insert(fl!("gestures", "four-finger-left"));
@@ -309,10 +312,6 @@ fn gestures() -> Section<crate::pages::Message> {
     // let open_application_library = descriptions.insert(fl!("open-application-library"));
     // let open_workspaces_view = descriptions.insert(fl!("open-workspaces-view"));
     // let switch_between_windows = descriptions.insert(fl!("switch-between-windows"));
-
-    let switch_workspaces = descriptions.insert(fl!("switch-workspaces"));
-    let switch_workspaces_horizontal = descriptions.insert(fl!("switch-workspaces", "horizontal"));
-    let switch_workspaces_vertical = descriptions.insert(fl!("switch-workspaces", "vertical"));
 
     Section::default()
         .title(fl!("gestures"))

--- a/cosmic-settings/src/pages/power/mod.rs
+++ b/cosmic-settings/src/pages/power/mod.rs
@@ -490,9 +490,9 @@ fn connected_devices() -> Section<crate::pages::Message> {
 }
 
 fn profiles() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let _power_desc = descriptions.insert(fl!("xdg-entry-power-comment"));
+    crate::slab!(descriptions {
+        _power_desc = fl!("xdg-entry-power-comment");
+    });
 
     Section::default()
         .title(fl!("power-mode"))

--- a/cosmic-settings/src/pages/sound/mod.rs
+++ b/cosmic-settings/src/pages/sound/mod.rs
@@ -12,7 +12,6 @@ use cosmic::{
 use cosmic_config::{Config, ConfigGet, ConfigSet};
 use cosmic_settings_page::{self as page, Section, section};
 use cosmic_settings_sound_subscription as subscription;
-use slab::Slab;
 use slotmap::SlotMap;
 
 const AUDIO_CONFIG: &str = "com.system76.CosmicAudio";
@@ -251,13 +250,13 @@ impl Page {
 }
 
 fn input() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let volume = descriptions.insert(fl!("sound-input", "volume"));
-    let device = descriptions.insert(fl!("sound-input", "device"));
-    let _level = descriptions.insert(fl!("sound-input", "level"));
-    let amplification = descriptions.insert(fl!("amplification"));
-    let amplification_desc = descriptions.insert(fl!("amplification", "desc"));
+    crate::slab!(descriptions {
+        volume = fl!("sound-input", "volume");
+        device = fl!("sound-input", "device");
+        _level = fl!("sound-input", "level");
+        amplification = fl!("amplification");
+        amplification_desc = fl!("amplification", "desc");
+    });
 
     Section::default()
         .title(fl!("sound-input"))
@@ -328,17 +327,16 @@ fn input() -> Section<crate::pages::Message> {
 }
 
 fn output() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let volume = descriptions.insert(fl!("sound-output", "volume"));
-    let device = descriptions.insert(fl!("sound-output", "device"));
-    let _level = descriptions.insert(fl!("sound-output", "level"));
-    let balance = descriptions.insert(fl!("sound-output", "balance"));
-    let left = descriptions.insert(fl!("sound-output", "left"));
-    let right = descriptions.insert(fl!("sound-output", "right"));
-    // let balance = descriptions.insert(fl!("sound-output", "balance"));
-    let amplification = descriptions.insert(fl!("amplification"));
-    let amplification_desc = descriptions.insert(fl!("amplification", "desc"));
+    crate::slab!(descriptions {
+        volume = fl!("sound-output", "volume");
+        device = fl!("sound-output", "device");
+        _level = fl!("sound-output", "level");
+        balance = fl!("sound-output", "balance");
+        left = fl!("sound-output", "left");
+        right = fl!("sound-output", "right");
+        amplification = fl!("amplification");
+        amplification_desc = fl!("amplification", "desc");
+    });
 
     Section::default()
         .title(fl!("sound-output"))

--- a/cosmic-settings/src/pages/system/about.rs
+++ b/cosmic-settings/src/pages/system/about.rs
@@ -6,7 +6,6 @@ use cosmic_settings_page::{self as page, Section, section};
 use super::info::Info;
 use cosmic::widget::{editable_input, list_column, settings, text};
 use cosmic::{Apply, Task};
-use slab::Slab;
 use slotmap::SlotMap;
 
 #[derive(Clone, Debug)]
@@ -162,10 +161,10 @@ async fn set_hostname_impl(hostname: &str) -> Result<(), String> {
 }
 
 fn device() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let device = descriptions.insert(fl!("about-device"));
-    let device_desc = descriptions.insert(fl!("about-device", "desc"));
+    crate::slab!(descriptions {
+        device = fl!("about-device");
+        device_desc = fl!("about-device", "desc");
+    });
 
     Section::default()
         .descriptions(descriptions)
@@ -195,13 +194,13 @@ fn device() -> Section<crate::pages::Message> {
 }
 
 fn hardware() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let model = descriptions.insert(fl!("about-hardware", "model"));
-    let memory = descriptions.insert(fl!("about-hardware", "memory"));
-    let processor = descriptions.insert(fl!("about-hardware", "processor"));
-    let graphics = descriptions.insert(fl!("about-hardware", "graphics"));
-    let disk_capacity = descriptions.insert(fl!("about-hardware", "disk-capacity"));
+    crate::slab!(descriptions {
+        model = fl!("about-hardware", "model");
+        memory = fl!("about-hardware", "memory");
+        processor = fl!("about-hardware", "processor");
+        graphics = fl!("about-hardware", "graphics");
+        disk_capacity = fl!("about-hardware", "disk-capacity");
+    });
 
     Section::default()
         .title(fl!("about-hardware"))
@@ -241,13 +240,13 @@ fn hardware() -> Section<crate::pages::Message> {
 }
 
 fn os() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let os = descriptions.insert(fl!("about-os", "os"));
-    let os_arch = descriptions.insert(fl!("about-os", "os-architecture"));
-    let kernel = descriptions.insert(fl!("about-os", "kernel"));
-    let desktop = descriptions.insert(fl!("about-os", "desktop-environment"));
-    let windowing_system = descriptions.insert(fl!("about-os", "windowing-system"));
+    crate::slab!(descriptions {
+        os = fl!("about-os", "os");
+        os_arch = fl!("about-os", "os-architecture");
+        kernel = fl!("about-os", "kernel");
+        desktop = fl!("about-os", "desktop-environment");
+        windowing_system = fl!("about-os", "windowing-system");
+    });
 
     Section::default()
         .title(fl!("about-os"))

--- a/cosmic-settings/src/pages/system/users/mod.rs
+++ b/cosmic-settings/src/pages/system/users/mod.rs
@@ -14,7 +14,6 @@ use cosmic_settings_page::{self as page, Section, section};
 use image::GenericImageView;
 use pwhash::{bcrypt, md5_crypt, sha256_crypt, sha512_crypt};
 use regex::Regex;
-use slab::Slab;
 use slotmap::SlotMap;
 use std::{
     collections::HashMap,
@@ -777,10 +776,10 @@ impl Page {
 impl page::AutoBind<crate::pages::Message> for Page {}
 
 fn user_list() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let user_type_standard = descriptions.insert(fl!("users", "standard"));
-    let user_type_admin = descriptions.insert(fl!("users", "admin"));
+    crate::slab!(descriptions {
+        user_type_standard = fl!("users", "standard");
+        user_type_admin = fl!("users", "admin");
+    });
 
     Section::default()
         .descriptions(descriptions)

--- a/cosmic-settings/src/pages/time/date.rs
+++ b/cosmic-settings/src/pages/time/date.rs
@@ -19,7 +19,6 @@ use icu::{
     },
     locale::{Locale, preferences::extensions::unicode::keywords::HourCycle},
 };
-use slab::Slab;
 use slotmap::{Key, SlotMap};
 use std::rc::Rc;
 pub use timedate_zbus::TimeDateProxy;
@@ -407,9 +406,9 @@ pub enum Message {
 impl page::AutoBind<crate::pages::Message> for Page {}
 
 fn date() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let title = descriptions.insert(fl!("time-date"));
+    crate::slab!(descriptions {
+        title = fl!("time-date");
+    });
 
     Section::default()
         .title(fl!("time-date"))
@@ -428,12 +427,12 @@ fn date() -> Section<crate::pages::Message> {
 }
 
 fn format() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let military = descriptions.insert(fl!("time-format", "twenty-four"));
-    let show_seconds = descriptions.insert(fl!("time-format", "show-seconds"));
-    let first = descriptions.insert(fl!("time-format", "first"));
-    let show_date = descriptions.insert(fl!("time-format", "show-date"));
+    crate::slab!(descriptions {
+        military = fl!("time-format", "twenty-four");
+        show_seconds = fl!("time-format", "show-seconds");
+        first = fl!("time-format", "first");
+        show_date = fl!("time-format", "show-date");
+    });
 
     Section::default()
         .title(fl!("time-format"))
@@ -491,9 +490,9 @@ fn format() -> Section<crate::pages::Message> {
 }
 
 fn timezone() -> Section<crate::pages::Message> {
-    let mut descriptions = Slab::new();
-
-    let time_zone = descriptions.insert(fl!("time-zone"));
+    crate::slab!(descriptions {
+        time_zone = fl!("time-zone");
+    });
 
     Section::default()
         .title(fl!("time-zone"))


### PR DESCRIPTION
COSMIC Setting's code is a mix of `crate::slab!` and manually creating a Slab. Newer code seems to use the macro, so I replaced the older code with the macro for consistency and cleanliness.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

