### PR TITLE
feat: add smooth images toggle to magnifier settings

### DIFF
--- a/cosmic-settings/src/pages/accessibility/magnifier.rs
+++ b/cosmic-settings/src/pages/accessibility/magnifier.rs
@@ -47,6 +47,7 @@ pub enum Message {
     SetIncrement(usize),
     SetSignin(bool),
     SetMovement(ZoomMovement),
+    SetSmoothImages(bool),
     Surface(surface::Action),
 }
 
@@ -204,6 +205,7 @@ pub fn magnifier(
         controls = fl!("magnifier", "controls", zoom_in = zoom_in, zoom_out = zoom_out);
         scroll_controls = fl!("magnifier", "scroll_controls");
         show_overlay = fl!("magnifier", "show_overlay");
+        smooth_images = fl!("magnifier", "smooth_images");
         increment = fl!("magnifier", "increment");
         signin = fl!("magnifier", "signin");
     });
@@ -231,6 +233,11 @@ pub fn magnifier(
                 .add(settings::item(
                     &descriptions[show_overlay],
                     widget::toggler(page.zoom_config.show_overlay).on_toggle(Message::SetOverlay),
+                ))
+                .add(settings::item(
+                    &descriptions[smooth_images],
+                    widget::toggler(page.zoom_config.smooth_images)
+                        .on_toggle(Message::SetSmoothImages),
                 ))
                 .add(settings::item(
                     &descriptions[increment],
@@ -358,6 +365,9 @@ impl Page {
                 if self.zoom_config.view_moves != comp_config.accessibility_zoom.view_moves {
                     self.zoom_config.view_moves = comp_config.accessibility_zoom.view_moves;
                 }
+                if self.zoom_config.smooth_images != comp_config.accessibility_zoom.smooth_images {
+                    self.zoom_config.smooth_images = comp_config.accessibility_zoom.smooth_images;
+                }
             }
             Message::Event(AccessibilityEvent::Magnifier(value)) => {
                 self.magnifier_state = value;
@@ -382,6 +392,16 @@ impl Page {
             }
             Message::SetOverlay(value) => {
                 self.zoom_config.show_overlay = value;
+
+                if let Err(err) = self
+                    .accessibility_config
+                    .set("accessibility_zoom", self.zoom_config)
+                {
+                    error!(?err, "Failed to set config 'accessibility_zoom'");
+                }
+            }
+            Message::SetSmoothImages(value) => {
+                self.zoom_config.smooth_images = value;
 
                 if let Err(err) = self
                     .accessibility_config

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -169,6 +169,7 @@ magnifier = Magnifier
     .show_overlay = Show the magnifier overlay
     .increment = Zoom increment
     .signin = Start magnifier on sign in
+    .smooth_images = Smooth images when zoomed
     .applet = Toggle magnifier on/off in applet on the panel
     .movement = Zoomed view moves
     .continuous = Continuously with pointer


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
## Summary

Adds a UI toggle for the `smooth_images` ZoomConfig option in the Accessibility > Magnifier settings page. When disabled, the accessibility zoom uses nearest-neighbor filtering for crisp pixel boundaries instead of bilinear smoothing.

Companion to pop-os/cosmic-comp#2161 which adds the config field and rendering behavior.

## Test plan

- [x] Toggle appears in Accessibility > Magnifier settings
- [x] Toggling updates `smooth_images` in `~/.config/cosmic/com.system76.CosmicComp/v1/accessibility_zoom`
- [x] Change is reflected immediately in zoom rendering (requires cosmic-comp#2161)

🤖 Generated with [Claude Code](https://claude.com/claude-code)