### PR TITLE
fix(bluetooth): read Alias instead of Name on initial discovery

### DIFF
--- a/subscriptions/bluetooth/src/device.rs
+++ b/subscriptions/bluetooth/src/device.rs
@@ -103,7 +103,9 @@ impl Device {
     pub fn update(&mut self, updates: Vec<DeviceUpdate>) {
         for udpate in updates {
             match udpate {
-                DeviceUpdate::Alias(alias) => self.alias = alias,
+                DeviceUpdate::Alias(alias) => {
+                    self.alias = alias.filter(|a| a.replace('-', ":") != self.address);
+                }
                 DeviceUpdate::Enabled(enabled) => {
                     self.enabled = match (self.enabled, enabled) {
                         (Active::Enabling, Active::Enabled) => Active::Enabled,


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
## Summary

Read Bluetooth device `Alias` instead of raw `Name` on initial device discovery, and normalize hyphenated-MAC aliases on both code paths.

The variable was already named `alias` but was reading `proxy.device.name()`. The `Alias` D-Bus property returns the user-friendly name when set and falls back to `Name` when no alias exists, per BlueZ documentation.

For unnamed devices, BlueZ's `Alias` falls back to the device address using hyphens (e.g., `29-A1-FF-34-A4-5B`), while the `Address` property uses colons. Since `has_alias()` checks `is_some()`, these hyphenated-MAC aliases would cause unnamed BLE devices to appear in the device list.

**Both code paths now normalize:**
- `from_device()` (initial load): filters alias where `alias.replace('-', ":") == address`
- `Device::update()` (live property changes via `DeviceUpdate::Alias`): applies the same filter

This closes a code-path parity gap where initial load and live updates previously handled aliases differently.

Closes #1880.

Companion PR for the applet: pop-os/cosmic-applets#1338.

## Test plan

- [x] Devices without aliases display the same name as before
- [x] Devices with custom aliases display the alias on initial discovery
- [x] Unnamed BLE devices (BlueZ Alias = hyphenated MAC) are filtered out on initial load
- [x] Unnamed BLE devices are also filtered on live property updates (PropertiesChanged)
- [x] Existing unit test `test_update_device_with_intermediary_state` passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
