### PR TITLE
fix(network): use from_utf8_lossy for saved SSID decoding

### DIFF
--- a/subscriptions/network-manager/src/lib.rs
+++ b/subscriptions/network-manager/src/lib.rs
@@ -452,7 +452,7 @@ async fn start_listening(
                         if s.wifi
                             .clone()
                             .and_then(|w| w.ssid)
-                            .and_then(|ssid| String::from_utf8(ssid).ok())
+                            .map(|ssid| String::from_utf8_lossy(&ssid).into_owned())
                             .is_some_and(|s| s == ssid.as_ref())
                         {
                             _ = c.delete().await;
@@ -537,7 +537,7 @@ async fn start_listening(
                                         .wifi
                                         .clone()
                                         .and_then(|w| w.ssid)
-                                        .and_then(|s| String::from_utf8(s).ok())
+                                        .map(|s| String::from_utf8_lossy(&s).into_owned())
                                         && saved_ssid == ssid.as_ref()
                                     {
                                         let password = c
@@ -612,7 +612,7 @@ async fn has_saved_wifi_credentials(conn: &zbus::Connection, ssid: &str) -> bool
             if let Some(saved_ssid) = settings
                 .wifi
                 .and_then(|w| w.ssid)
-                .and_then(|ssid| String::from_utf8(ssid).ok())
+                .map(|ssid| String::from_utf8_lossy(&ssid).into_owned())
                 && saved_ssid == ssid
             {
                 return true;
@@ -855,7 +855,7 @@ impl NetworkManagerState {
                     .wifi
                     .clone()
                     .and_then(|w| w.ssid)
-                    .and_then(|ssid| String::from_utf8(ssid).ok())?;
+                    .map(|ssid| String::from_utf8_lossy(&ssid).into_owned())?;
 
                 Some(Arc::from(curr_ssid))
             }),
@@ -978,7 +978,7 @@ impl NetworkManagerState {
                     .wifi
                     .clone()
                     .and_then(|w| w.ssid)
-                    .and_then(|ssid| String::from_utf8(ssid).ok())
+                    .map(|ssid| String::from_utf8_lossy(&ssid).into_owned())
                     && cur_ssid == ssid
                 {
                     known_conn = Some(c);


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

Five callsites in the NM subscription decode saved SSIDs with `String::from_utf8().ok()`, while `current_networks.rs:52` and `available_wifi.rs:47` already use `String::from_utf8_lossy()` for access point SSIDs. This patch aligns all 5 callsites to `from_utf8_lossy`, making SSID decoding consistent within the crate.

The mismatch could cause silent failures for networks with non-UTF-8 SSIDs: the AP list would show them (with replacement characters via `from_utf8_lossy`), but saved-connection lookups would skip them (via `from_utf8().ok()` returning `None`), making forget, connect-to-known, and password retrieval silently fail. Non-UTF-8 SSIDs are rare in practice, but the inconsistency is worth fixing regardless.

## Test plan

- [ ] Verify known networks list still populates correctly
- [ ] Verify forget-network works for a saved WiFi network
- [ ] Verify connect-to-known works (password retrieval path)
- [ ] If a non-UTF-8 SSID is available: verify it appears in both the access point list and the known networks list after saving