### PR TITLE
fix(bluetooth): improve device list UX and transitions

### DIFF
--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -903,6 +903,7 @@ fn connected_devices() -> Section<crate::pages::Message> {
 
 fn available_devices() -> Section<crate::pages::Message> {
     crate::slab!(descriptions {
+        device_connect = fl!("bluetooth", "connect");
         device_connecting = fl!("bluetooth", "connecting");
     });
 
@@ -938,18 +939,15 @@ fn available_devices() -> Section<crate::pages::Message> {
                         widget::horizontal_space().into(),
                     ];
 
-                    if device.enabled == Active::Enabling {
-                        items.push(
-                            text(&descriptions[device_connecting])
-                                .class(theme::Text::Color(color!(128, 128, 128)))
-                                .into(),
-                        );
+                    if device.enabled == Active::Disabled {
+                        items.push(widget::button::text(&descriptions[device_connect]).on_press(Message::ConnectDevice(path.clone())).into(), )
                     }
-                    Some(
-                        widget::mouse_area(settings::item_row(items))
-                            .on_press(Message::ConnectDevice(path.clone()))
-                            .into(),
-                    )
+
+                    if device.enabled == Active::Enabling || device.enabled == Active::Enabled {
+                        items.push(text(&descriptions[device_connecting]).class(theme::Text::Color(color!(128, 128, 128))).into(), );
+                    }
+
+                    Some(widget::mouse_area(settings::item_row(items)).into(), )
                 })
                 .fold(section, settings::Section::add)
                 .apply(Element::from)


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

## Summary
Improves Bluetooth devices page UX and interaction clarity.

## Before
- Discovered Bluetooth devices looked non-interactive (issue #1695)
- Users could click a device to connect, but there was:
  - no visible "Connect" button
  - no pointer cursor change
  - no clear indication that the item is actionable
- This created confusing and non-obvious interaction

When connecting:
- A device entered the **Connecting** state
- The **Connecting** indicator disappeared once the device reached the *Connected* state
- However, the device was not yet marked as *Paired* and remained in the same list for a short time
- This made the state transition feel visually unclear

## After
- Added an explicit **Connect** button for each device
- Device rows now clearly look interactive
- Interaction is more intuitive and consistent with user expectations

When connecting:
- The device state transition is now visually smoother
- Status updates feel more immediate and easier to follow
- Movement between lists better reflects the actual device state

## Consistency
The updated behavior is now more consistent with the Wi-Fi settings page,
where network items clearly indicate available actions and update immediately.

## Result
Bluetooth management now feels more responsive, predictable, and user-friendly.

## Visual Comparison
Before / After screenshots attached below.

---
Before
<img width="1367" height="1024" alt="image" src="https://github.com/user-attachments/assets/c05e8c73-dc18-4848-b639-46e4212f3ccc" />

---
After
<img width="1351" height="998" alt="image" src="https://github.com/user-attachments/assets/45ddbe89-1af8-4117-a8f1-e5a824b615a8" />