### PR TITLE
fix(appearance): sync UI state with theme config on import and reset

### DIFF
--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -940,14 +940,22 @@ fn available_devices() -> Section<crate::pages::Message> {
                     ];
 
                     if device.enabled == Active::Disabled {
-                        items.push(widget::button::text(&descriptions[device_connect]).on_press(Message::ConnectDevice(path.clone())).into(), )
+                        items.push(
+                            widget::button::text(&descriptions[device_connect])
+                                .on_press(Message::ConnectDevice(path.clone()))
+                                .into(),
+                        )
                     }
 
                     if device.enabled == Active::Enabling || device.enabled == Active::Enabled {
-                        items.push(text(&descriptions[device_connecting]).class(theme::Text::Color(color!(128, 128, 128))).into(), );
+                        items.push(
+                            text(&descriptions[device_connecting])
+                                .class(theme::Text::Color(color!(128, 128, 128)))
+                                .into(),
+                        );
                     }
 
-                    Some(widget::mouse_area(settings::item_row(items)).into(), )
+                    Some(widget::mouse_area(settings::item_row(items)).into())
                 })
                 .fold(section, settings::Section::add)
                 .apply(Element::from)

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -327,6 +327,10 @@ impl Page {
                 } else {
                     ThemeBuilder::light()
                 };
+
+                self.roundness = builder.corner_radii.into();
+                self.density = Density::Standard;
+
                 self.theme_manager.set_active_hint(builder.active_hint);
 
                 self.theme_manager
@@ -482,6 +486,9 @@ impl Page {
                 {
                     tracing::error!(?err, "Error setting dark mode");
                 }
+
+                self.roundness = builder.corner_radii.into();
+                self.density = Density::Standard;
 
                 self.theme_manager
                     .selected_customizer_mut()


### PR DESCRIPTION
This PR is a clean version of the fix previously submitted in #1904. It addresses the issue where the UI selection state (Roundness and Density) was not syncing with the applied theme during Import or Reset.


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

