### PR TITLE
feat(sound): add output test button with playback fallbacks

### DIFF
--- a/cosmic-settings/src/pages/sound/mod.rs
+++ b/cosmic-settings/src/pages/sound/mod.rs
@@ -34,6 +34,7 @@ pub enum Message {
     SetSinkVolume(u32),
     /// Request to change the input volume.
     SetSourceVolume(u32),
+    TestOutput,
     /// Messages handled by the sound module in cosmic-settings-subscriptions
     Subscription(subscription::Message),
     /// Surface Action
@@ -212,6 +213,10 @@ impl Page {
                     .map(|message| Message::Subscription(message).into());
             }
 
+            Message::TestOutput => {
+                self.model.test_output();
+            }
+
             Message::ToggleOverAmplificationSink(enabled) => {
                 self.amplification_sink = enabled;
 
@@ -334,6 +339,7 @@ fn output() -> Section<crate::pages::Message> {
     crate::slab!(descriptions {
         volume = fl!("sound-output", "volume");
         device = fl!("sound-output", "device");
+        test = fl!("sound-output", "test");
         _level = fl!("sound-output", "level");
         balance = fl!("sound-output", "balance");
         left = fl!("sound-output", "left");
@@ -389,6 +395,15 @@ fn output() -> Section<crate::pages::Message> {
             .apply(Element::from)
             .map(crate::pages::Message::from);
 
+            let test_output = widget::button::standard(&*section.descriptions[test])
+                .on_press_maybe(page.model.active_sink().map(|_| Message::TestOutput.into()));
+
+            let output_device_controls = widget::row::with_capacity(3)
+                .align_y(Alignment::Center)
+                .push(devices)
+                .push(horizontal_space().width(8.))
+                .push(test_output);
+
             let mut controls = settings::section()
                 .title(&section.title)
                 .add(
@@ -396,7 +411,10 @@ fn output() -> Section<crate::pages::Message> {
                         .flex_control(volume_control)
                         .align_items(Alignment::Center),
                 )
-                .add(settings::item(&*section.descriptions[device], devices))
+                .add(settings::item(
+                    &*section.descriptions[device],
+                    output_device_controls,
+                ))
                 .add(settings::item(
                     &*section.descriptions[balance],
                     widget::row::with_capacity(4)

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -588,6 +588,7 @@ sound = Sound
 sound-output = Output
     .volume = Output volume
     .device = Output device
+    .test = Test
     .level = Output level
     .config = Configuration
     .balance = Balance

--- a/subscriptions/sound/src/lib.rs
+++ b/subscriptions/sound/src/lib.rs
@@ -138,6 +138,19 @@ impl Model {
         &self.sources
     }
 
+    pub fn test_output(&self) {
+        if self.active_sink_node.is_none() {
+            tracing::warn!(target: "sound", "cannot play output test sound without an active sink");
+            return;
+        }
+
+        tokio::spawn(async {
+            if !play_output_test_sound().await {
+                tracing::warn!(target: "sound", "failed to play output test sound using available backends");
+            }
+        });
+    }
+
     pub fn clear(&mut self) {
         if let Some(handle) = self.subscription_handle.take() {
             _ = handle.cancel_tx.send(());
@@ -955,4 +968,57 @@ pub async fn set_profile(id: u32, index: u32, save: bool) {
         .stderr(Stdio::null())
         .status()
         .await;
+}
+
+async fn play_output_test_sound() -> bool {
+    if run_command("canberra-gtk-play", &["-i", "audio-test-signal"]).await {
+        return true;
+    }
+
+    let test_sound_paths = [
+        "/usr/share/sounds/freedesktop/stereo/audio-test-signal.oga",
+        "/usr/share/sounds/freedesktop/stereo/audio-test-signal.ogg",
+        "/usr/share/sounds/freedesktop/stereo/audio-test-signal.wav",
+        "/usr/share/sounds/freedesktop/stereo/bell.oga",
+        "/usr/share/sounds/freedesktop/stereo/bell.ogg",
+        "/usr/share/sounds/freedesktop/stereo/bell.wav",
+        "/usr/share/sounds/freedesktop/stereo/audio-test.ogg",
+    ];
+
+    for sound_path in test_sound_paths {
+        if run_command("paplay", &[sound_path]).await {
+            return true;
+        }
+    }
+
+    for sound_path in test_sound_paths {
+        if run_command("pw-play", &[sound_path]).await {
+            return true;
+        }
+    }
+
+    false
+}
+
+async fn run_command(command: &str, args: &[&str]) -> bool {
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::process::Command::new(command)
+            .args(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status(),
+    )
+    .await
+    {
+        Ok(Ok(status)) => status.success(),
+        Ok(Err(why)) => {
+            tracing::debug!(target: "sound", ?why, command, "failed to run test sound command");
+            false
+        }
+        Err(why) => {
+            tracing::warn!(target: "sound", ?why, command, "test sound command timed out");
+            false
+        }
+    }
 }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
---

## Summary
Adds a **Test** button to the Sound Output settings page to verify audio output devices are working. This feature was available in GNOME Settings but missing in COSMIC Settings (issue #1901).

## Before
- Users had no built-in way to test if their selected output device was working
- Had to rely on external applications or media playback to verify audio output
- No feedback mechanism to confirm the correct device was selected

## After
- Added a **Test** button next to the Output device dropdown
- Button is enabled only when an active output sink is available
- Clicking the button plays a test sound through the currently selected output device
- Multiple fallback playback methods ensure compatibility across different system configurations

## Technical Details
**UI Changes:**
- Added `TestOutput` message variant to the Sound page message enum
- Test button appears inline with the Output device selector
- Button is disabled when no active sink is available

**Backend Implementation:**
- `Model::test_output()` spawns async playback task
- Fallback chain for maximum compatibility:
  1. `canberra-gtk-play -i audio-test-signal` (GNOME-compatible sound theme)
  2. `paplay` with multiple test sound paths (`.oga`, `.ogg`, `.wav` formats)
  3. `pw-play` with same test sound paths (PipeWire-native)
- 5-second timeout per command attempt
- Comprehensive tracing for debugging playback failures

**i18n:**
- Added `sound-output.test = Test` localization key (English)
- Other locales will be handled via Weblate

## Visual Comparison

**Before**
<img width="2016" height="1332" alt="image" src="https://github.com/user-attachments/assets/7a4225f2-114e-41de-977f-289fed0f06d3" />

**After**
<img width="2010" height="1324" alt="image" src="https://github.com/user-attachments/assets/87e7e88e-e2ed-465d-a730-031cc8f24ad1" />
---

Fixes #1901