### PR TITLE
fix(bluetooth): call pair() for unpaired devices before connecting

### DIFF
--- a/subscriptions/bluetooth/src/device.rs
+++ b/subscriptions/bluetooth/src/device.rs
@@ -241,6 +241,8 @@ pub async fn connect_device(connection: zbus::Connection, device_path: OwnedObje
         let result = async {
             if proxy.device.connected().await? {
                 Ok(())
+            } else if !proxy.device.paired().await.unwrap_or(false) {
+                proxy.device.pair().await
             } else {
                 proxy.device.connect().await
             }


### PR DESCRIPTION
Fixes connecting to bluetooth keyboards. At least the newer ones like Magic Keyboard.
Previously it would just call `connect()` for all devices, which skips the BlueZ pairing and bonding.

You can see this in the old cosmic-settings if you press connect on a keyboard and open `bluetoothctl` you can see the keyboard in `devices Paired` and `devices Connected` but not `devices Bonded` and `devices Trusted`. Because it was not calling `pair()` which does the secure stuff. So keyboards won't work. But with this change you should see the PIN confirmation dialog and the keyboard should properly connect.

I tested this with a Magic Keyboard and it works now when you press `connect` in the `cosmic-settings`.

Bluetooth applet does it correctly, however somehow it has issues refreshing the "other bluetooth devices" and doesn't get refreshed as well as cosmic-settings.
____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

