### PR TITLE
feat: allow F1-F24 function keys as modifier-less shortcut bindings

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/common.rs
@@ -557,7 +557,8 @@ impl Model {
                         if shortcut.pending.modifiers
                             != cosmic_settings_config::shortcuts::Modifiers::new()
                             || shortcut.pending.key.is_some_and(|key| {
-                                key.is_misc_function_key()
+                                key.is_function_key()
+                                    || key.is_misc_function_key()
                                     || matches!(key.raw(), 0x10080001..=0x1008FFFF)
                             })
                         {

--- a/cosmic-settings/src/pages/input/keyboard/shortcuts/custom.rs
+++ b/cosmic-settings/src/pages/input/keyboard/shortcuts/custom.rs
@@ -310,7 +310,7 @@ impl Page {
                     && self.add_shortcut.binding.modifiers
                         != cosmic_settings_config::shortcuts::Modifiers::new()
                     || self.add_shortcut.binding.key.is_some_and(|key| {
-                        key.is_misc_function_key() || matches!(key.raw(), 0x10080001..=0x1008FFFF)
+                        key.is_function_key() || key.is_misc_function_key() || matches!(key.raw(), 0x10080001..=0x1008FFFF)
                     })
                 {
                     // XX for now avoid applying the keycode


### PR DESCRIPTION
This PR targets https://github.com/pop-os/cosmic-settings/issues/597.
There is a required prerequisite PR on cosmic-settings-daemon: https://github.com/pop-os/cosmic-settings-daemon/pull/140

- The `KeyReleased` handlers currently allow special function keys (home, end, etc) via `is_misc_function_key()`.
- I've added `is_function_key()` to also validate F1-F24 key presses.

<img width="1068" height="527" alt="image" src="https://github.com/user-attachments/assets/a81d3de9-2ad6-4496-8039-d8f35282fdab" />


_Note: Enabling shortcuts on keys F13-F24 will require an xkb config update. By default these keys are overwritten by special keys (media, etc) for historical purposes. Many modern keyboards use the actual media key codes and don't require this remapping:_

```ron
// ~/.config/cosmic/com.system76.CosmicComp/v1/xkb_config
(
    rules: "",
    model: "",
    layout: "us",
    variant: "",
    options: Some("fkeys:basic_13-24"), // this line enables F13-F24
    repeat_delay: 600,
    repeat_rate: 25,
)
```

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

