### PR TITLE
Add setting to toggle workspace wrapping

### DIFF
--- a/cosmic-settings/src/pages/desktop/workspaces.rs
+++ b/cosmic-settings/src/pages/desktop/workspaces.rs
@@ -20,6 +20,7 @@ pub enum Message {
     SetActionOnTyping(usize),
     SetWorkspaceMode(WorkspaceMode),
     SetWorkspaceLayout(WorkspaceLayout),
+    SetWorkspaceWraparound(bool),
     SetShowName(bool),
     SetShowNumber(bool),
     Surface(surface::Action),
@@ -87,6 +88,7 @@ impl page::Page<crate::pages::Message> for Page {
             sections.insert(action_on_typing()),
             sections.insert(multi_behavior()),
             sections.insert(workspace_orientation()),
+            sections.insert(workspace_navigation()),
         ])
     }
 
@@ -123,6 +125,10 @@ impl Page {
                 self.comp_workspace_config.action_on_typing = into_action(value);
                 self.action_on_typing_active =
                     into_active_selection(&self.comp_workspace_config.action_on_typing);
+                self.save_comp_config();
+            }
+            Message::SetWorkspaceWraparound(value) => {
+                self.comp_workspace_config.workspace_wraparound = value;
                 self.save_comp_config();
             }
             Message::SetShowName(value) => {
@@ -245,6 +251,27 @@ fn workspace_orientation() -> Section<crate::pages::Message> {
                     WorkspaceLayout::Horizontal,
                     Some(page.comp_workspace_config.workspace_layout),
                     Message::SetWorkspaceLayout,
+                ))
+                .apply(Element::from)
+                .map(crate::pages::Message::DesktopWorkspaces)
+        })
+}
+
+fn workspace_navigation() -> Section<crate::pages::Message> {
+    crate::slab!(descriptions {
+        description = fl!("workspaces-navigation", "wraparound");
+    });
+
+    Section::default()
+        .title(fl!("workspaces-navigation"))
+        .descriptions(descriptions)
+        .view::<Page>(move |_binder, page, section| {
+            let descriptions = &section.descriptions;
+            settings::section()
+                .title(&section.title)
+                .add(settings::item::builder(&descriptions[description]).toggler(
+                    page.comp_workspace_config.workspace_wraparound,
+                    Message::SetWorkspaceWraparound,
                 ))
                 .apply(Element::from)
                 .map(crate::pages::Message::DesktopWorkspaces)

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -521,6 +521,9 @@ workspaces-orientation = Workspaces orientation
 hot-corner = Hot Corner
     .top-left-corner = Enable top-left hot corner for Workspaces
 
+workspaces-navigation = Navigation
+    .wraparound = Move between first and last workspace using keyboard shortcuts and gestures
+
 ## Displays
 
 -requires-restart = Requires restart


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

issue: #1050

This adds a setting to toggle workspace wrapping.

changes:
- add a toggle for workspace wrapping based on the mockup 