### PR TITLE
Add an option swap control with capslock

### DIFF
--- a/cosmic-settings/src/pages/input/keyboard/mod.rs
+++ b/cosmic-settings/src/pages/input/keyboard/mod.rs
@@ -48,6 +48,7 @@ static CAPS_LOCK_OPTIONS: &[(&str, &str)] = &[
     ("Backspace", "caps:backspace"),
     ("Super", "caps:super"),
     ("Control", "caps:ctrl_modifier"),
+    ("Swap with Control", "ctrl:swapcaps"),
 ];
 
 #[derive(Clone, Debug)]
@@ -151,11 +152,11 @@ impl SpecialKey {
         }
     }
 
-    pub fn prefix(self) -> &'static str {
+    pub fn prefixes(self) -> &'static [&'static str] {
         match self {
-            Self::Compose => "compose:",
-            Self::AlternateCharacters => "lv3:",
-            Self::CapsLock => "caps:",
+            Self::Compose => &["compose:"],
+            Self::AlternateCharacters => &["lv3:"],
+            Self::CapsLock => &["caps:", "ctrl:"],
         }
     }
 }
@@ -513,10 +514,10 @@ impl Page {
             Message::SpecialCharacterSelect(id) => {
                 if let Some(Context::SpecialCharacter(special_key)) = self.context {
                     let options = self.xkb.options.as_deref().unwrap_or_default();
-                    let prefix = special_key.prefix();
+                    let prefixes = special_key.prefixes();
                     let new_options = options
                         .split(',')
-                        .filter(|x| !x.starts_with(prefix))
+                        .filter(|x| !prefixes.iter().any(|prefix| x.starts_with(prefix)))
                         .chain(id)
                         .join(",");
 
@@ -610,13 +611,13 @@ impl Page {
             SpecialKey::AlternateCharacters => (ALTERNATE_CHARACTER_OPTIONS, None),
             SpecialKey::CapsLock => (CAPS_LOCK_OPTIONS, None),
         };
-        let prefix = special_key.prefix();
+        let prefixes = special_key.prefixes();
         let current = self
             .xkb
             .options
             .iter()
             .flat_map(|x| x.split(','))
-            .find(|x| x.starts_with(prefix));
+            .find(|x| prefixes.iter().any(|prefix| x.starts_with(prefix)));
 
         // TODO layout default
 


### PR DESCRIPTION
This adds a "Swap with Control" option to "Input Devices > Special Character Entry > Caps Lock key", which passes `ctrl:swapcaps` to XKB. `SpecialKey`'s `prefix` method is generalized in the obvious way to `prefixes` so that this can be selected through the same drop-down as for XKB options which begin with `caps:`.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

