### PR TITLE
fix(sound): allow text for left and right to take up more space if ne…

### DIFF
--- a/cosmic-settings/src/pages/sound/mod.rs
+++ b/cosmic-settings/src/pages/sound/mod.rs
@@ -402,9 +402,13 @@ fn output() -> Section<crate::pages::Message> {
                     widget::row::with_capacity(4)
                         .align_y(Alignment::Center)
                         .push(
-                            widget::text::body(&*section.descriptions[left])
-                                .width(Length::Fixed(22.0))
-                                .align_x(Alignment::Center),
+                            widget::column::column()
+                                .align_x(Alignment::Center)
+                                .push(
+                                    widget::text::body(&*section.descriptions[left])
+                                        .align_x(Alignment::Center),
+                                )
+                                .push(horizontal_space().width(22.)),
                         )
                         .push(horizontal_space().width(8.))
                         .push(
@@ -418,9 +422,13 @@ fn output() -> Section<crate::pages::Message> {
                         )
                         .push(horizontal_space().width(8.))
                         .push(
-                            widget::text::body(&*section.descriptions[right])
-                                .width(Length::Fixed(22.0))
-                                .align_x(Alignment::Center),
+                            widget::column::column()
+                                .align_x(Alignment::Center)
+                                .push(
+                                    widget::text::body(&*section.descriptions[right])
+                                        .align_x(Alignment::Center),
+                                )
+                                .push(horizontal_space().width(22.0)),
                         ),
                 ));
 


### PR DESCRIPTION
…eded

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

