### PR TITLE
fix(wallpapers): follow symlinks when scanning wallpaper directories

### DIFF
--- a/pages/wallpapers/src/lib.rs
+++ b/pages/wallpapers/src/lib.rs
@@ -104,6 +104,7 @@ pub async fn load_each_from_path(
 ) -> Pin<Box<dyn Send + Stream<Item = (PathBuf, RgbaImage, RgbaImage)>>> {
     let candidate_paths: Vec<_> = WalkDir::new(path)
         .max_depth(3)
+        .follow_links(true)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|entry| entry.file_type().is_file())


### PR DESCRIPTION
On NixOS, /run/current-system/sw/share/backgrounds lists all wallpapers installed on the system. The folder entries are symbolic links to the actual PNG files (each in a dedicated nix store path). Previously WalkDir would skip over these, resulting in cosmic-settings displaying an empty wallpaper list.

By following symbolic links, the list is now properly populated.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

