### PR TITLE
feat(appearance): support gap < active_hint

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -841,7 +841,7 @@ pub fn window_management() -> Section<crate::pages::Message> {
                         "gaps",
                         page.theme_manager.builder().gaps.1,
                         1,
-                        page.theme_manager.builder().active_hint,
+                        0,
                         500,
                         Message::GapSize,
                     )),

--- a/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/theme_manager.rs
@@ -524,12 +524,7 @@ impl ThemeCustomizer {
         let builder = &mut self.builder.0;
         let mut gaps = builder.gaps;
 
-        // Ensure that the gap is never less than what the active hint size is.
-        gaps.1 = if gap < builder.active_hint {
-            builder.active_hint
-        } else {
-            gap
-        };
+        gaps.1 = gap;
 
         if let Err(err) = builder.set_gaps(config, gaps) {
             tracing::error!(?err, "Error setting the gap");
@@ -550,7 +545,8 @@ impl ThemeCustomizer {
             return None;
         }
 
-        // Update the gap if it's less than the active hint
+        // Update the gap if it's less than the active hint.
+        // The user can still undo this if they wish.
         if active_hint > builder.gaps.1 {
             let mut gaps = builder.gaps;
             gaps.1 = active_hint;


### PR DESCRIPTION
Lets the user set gaps less than the active window hint.

I recognize that this was an intentional UX decision aimed to prevent the active window hint overlapping with other windows. So I've left this behavior unchanged except that I've made it optional now.

Behavior before:
- Increasing the active_hint also increases the gap if lower.
- The user cannot decrease the gap below the active hint.

Behavior now:
- Increasing the active_hint also increases the gap if lower.
  This is unchanged and keeps the sensible default of `gaps >= active_hint`.
- The user _can_ now decrease the gap if they wish.

Closes https://github.com/pop-os/cosmic-settings/issues/1683

***

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

