### PR TITLE
Restart Dock and Panel when size slider is released instead of upon slider position change

### DIFF
--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -209,7 +209,9 @@ pub(crate) fn style<
                         text::body(fl!("small")).into(),
                         slider(
                             0..=4,
-                            match inner.size.as_ref().expect("inner.size is None even though inner.panel_config is Some") {
+                            match inner.size.as_ref().expect(
+                                "PageInner.size is None even though PageInner.panel_config is Some",
+                            ) {
                                 PanelSize::XS => 0,
                                 PanelSize::S => 1,
                                 PanelSize::M => 2,
@@ -606,7 +608,13 @@ impl PageInner {
                 self.size = Some(size);
             }
             Message::PanelSizeCommit => {
-                _ = panel_config.set_size(helper, self.size.as_ref().expect("PageInner.size is None even though it should be Some").clone());
+                _ = panel_config.set_size(
+                    helper,
+                    self.size
+                        .as_ref()
+                        .expect("PageInner.size is None even though it should be Some, since PageInner.panel_config is Some")
+                        .clone()
+                );
                 // Reset any size overrides the user might have set
                 _ = panel_config.set_size_center(helper, None);
                 _ = panel_config.set_size_wings(helper, None);

--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -22,9 +22,9 @@ use crate::pages::desktop::appearance::Roundness;
 pub struct PageInner {
     pub(crate) config_helper: Option<cosmic_config::Config>,
     pub(crate) panel_config: Option<CosmicPanelConfig>,
+    pub size: Option<PanelSize>,
     pub opacity: f32,
     pub opacity_changing: bool,
-    pub size: PanelSize,
     pub outputs: Vec<String>,
     pub anchors: Vec<String>,
     pub backgrounds: Vec<String>,
@@ -40,9 +40,9 @@ impl Default for PageInner {
         Self {
             config_helper: Option::default(),
             panel_config: Option::default(),
+            size: Option::default(),
             opacity: 0.0,
             opacity_changing: false,
-            size: PanelSize::M,
             outputs: vec![fl!("all-displays")],
             anchors: vec![
                 Anchor(PanelAnchor::Left).to_string(),
@@ -209,7 +209,7 @@ pub(crate) fn style<
                         text::body(fl!("small")).into(),
                         slider(
                             0..=4,
-                            match inner.size {
+                            match inner.size.as_ref().expect("inner.size is None even though inner.panel_config is Some") {
                                 PanelSize::XS => 0,
                                 PanelSize::S => 1,
                                 PanelSize::M => 2,
@@ -504,7 +504,7 @@ impl PageInner {
                     if let Err(err) = default.write_entry(config) {
                         tracing::error!(?err, "Error resetting panel config.");
                     }
-                    self.size.clone_from(&default.size);
+                    self.size = Some(default.size.clone());
                     self.system_default = Some(default.clone());
                     self.panel_config.clone_from(&self.system_default);
                 } else {
@@ -603,10 +603,10 @@ impl PageInner {
                 _ = panel_config.set_border_radius(helper, new_radius).unwrap();
             }
             Message::PanelSize(size) => {
-                self.size = size;
+                self.size = Some(size);
             }
             Message::PanelSizeCommit => {
-                _ = panel_config.set_size(helper, self.size.clone());
+                _ = panel_config.set_size(helper, self.size.as_ref().expect("PageInner.size is None even though it should be Some").clone());
                 // Reset any size overrides the user might have set
                 _ = panel_config.set_size_center(helper, None);
                 _ = panel_config.set_size_wings(helper, None);
@@ -669,7 +669,7 @@ impl PageInner {
                 }
             }
             Message::PanelConfig(c) => {
-                self.size = c.size.clone();
+                self.size = Some(c.size.clone());
                 self.panel_config = Some(*c);
                 return Task::none();
             }

--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -24,6 +24,7 @@ pub struct PageInner {
     pub(crate) panel_config: Option<CosmicPanelConfig>,
     pub opacity: f32,
     pub opacity_changing: bool,
+    pub size: PanelSize,
     pub outputs: Vec<String>,
     pub anchors: Vec<String>,
     pub backgrounds: Vec<String>,
@@ -41,6 +42,7 @@ impl Default for PageInner {
             panel_config: Option::default(),
             opacity: 0.0,
             opacity_changing: false,
+            size: PanelSize::M,
             outputs: vec![fl!("all-displays")],
             anchors: vec![
                 Anchor(PanelAnchor::Left).to_string(),
@@ -207,7 +209,7 @@ pub(crate) fn style<
                         text::body(fl!("small")).into(),
                         slider(
                             0..=4,
-                            match panel_config.size {
+                            match inner.size {
                                 PanelSize::XS => 0,
                                 PanelSize::S => 1,
                                 PanelSize::M => 2,
@@ -229,6 +231,7 @@ pub(crate) fn style<
                                 }
                             },
                         )
+                        .on_release(Message::PanelSizeCommit)
                         .width(Length::Fill)
                         .apply(cosmic::widget::container)
                         .max_width(250)
@@ -420,6 +423,7 @@ pub enum Message {
     Output(usize),
     AnchorGap(bool),
     PanelSize(PanelSize),
+    PanelSizeCommit,
     Appearance(usize),
     ExtendToEdge(bool),
     OpacityRequest(f32),
@@ -500,6 +504,7 @@ impl PageInner {
                     if let Err(err) = default.write_entry(config) {
                         tracing::error!(?err, "Error resetting panel config.");
                     }
+                    self.size.clone_from(&default.size);
                     self.system_default = Some(default.clone());
                     self.panel_config.clone_from(&self.system_default);
                 } else {
@@ -598,7 +603,10 @@ impl PageInner {
                 _ = panel_config.set_border_radius(helper, new_radius).unwrap();
             }
             Message::PanelSize(size) => {
-                _ = panel_config.set_size(helper, size);
+                self.size = size;
+            }
+            Message::PanelSizeCommit => {
+                _ = panel_config.set_size(helper, self.size.clone());
                 // Reset any size overrides the user might have set
                 _ = panel_config.set_size_center(helper, None);
                 _ = panel_config.set_size_wings(helper, None);
@@ -661,6 +669,7 @@ impl PageInner {
                 }
             }
             Message::PanelConfig(c) => {
+                self.size = c.size.clone();
                 self.panel_config = Some(*c);
                 return Task::none();
             }

--- a/cosmic-settings/src/pages/desktop/panel/mod.rs
+++ b/cosmic-settings/src/pages/desktop/panel/mod.rs
@@ -79,6 +79,7 @@ impl Default for Page {
             // If the config is not present, it will be created with the default values and the name will not match
             (panel_config.name == "Panel").then_some(panel_config)
         });
+        let size = panel_config.as_ref().map(|c| c.size.clone());
         let system_default = cosmic::cosmic_config::Config::system(
             &format!("{}.Panel", cosmic_panel_config::NAME),
             CosmicPanelConfig::VERSION,
@@ -98,6 +99,7 @@ impl Default for Page {
             inner: PageInner {
                 config_helper,
                 panel_config,
+                size,
                 container_config,
                 outputs_map: HashMap::new(),
                 system_default,


### PR DESCRIPTION
Changes behavior of the panel/dock size slider
- from: new size is committed as soon as the slider position is changed (triggers panel/dock restart),
- to: new size is committed only when slider is released.

Fulfills: #1969 

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.


