### PR TITLE
Revert "Changes the PageInner.size field to have no explicit default.…

### DIFF
--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -22,9 +22,9 @@ use crate::pages::desktop::appearance::Roundness;
 pub struct PageInner {
     pub(crate) config_helper: Option<cosmic_config::Config>,
     pub(crate) panel_config: Option<CosmicPanelConfig>,
-    pub size: Option<PanelSize>,
     pub opacity: f32,
     pub opacity_changing: bool,
+    pub size: PanelSize,
     pub outputs: Vec<String>,
     pub anchors: Vec<String>,
     pub backgrounds: Vec<String>,
@@ -40,9 +40,9 @@ impl Default for PageInner {
         Self {
             config_helper: Option::default(),
             panel_config: Option::default(),
-            size: Option::default(),
             opacity: 0.0,
             opacity_changing: false,
+            size: PanelSize::M,
             outputs: vec![fl!("all-displays")],
             anchors: vec![
                 Anchor(PanelAnchor::Left).to_string(),
@@ -209,9 +209,7 @@ pub(crate) fn style<
                         text::body(fl!("small")).into(),
                         slider(
                             0..=4,
-                            match inner.size.as_ref().expect(
-                                "PageInner.size is None even though PageInner.panel_config is Some",
-                            ) {
+                            match inner.size {
                                 PanelSize::XS => 0,
                                 PanelSize::S => 1,
                                 PanelSize::M => 2,
@@ -506,7 +504,7 @@ impl PageInner {
                     if let Err(err) = default.write_entry(config) {
                         tracing::error!(?err, "Error resetting panel config.");
                     }
-                    self.size = Some(default.size.clone());
+                    self.size.clone_from(&default.size);
                     self.system_default = Some(default.clone());
                     self.panel_config.clone_from(&self.system_default);
                 } else {
@@ -605,16 +603,10 @@ impl PageInner {
                 _ = panel_config.set_border_radius(helper, new_radius).unwrap();
             }
             Message::PanelSize(size) => {
-                self.size = Some(size);
+                self.size = size;
             }
             Message::PanelSizeCommit => {
-                _ = panel_config.set_size(
-                    helper,
-                    self.size
-                        .as_ref()
-                        .expect("PageInner.size is None even though it should be Some, since PageInner.panel_config is Some")
-                        .clone()
-                );
+                _ = panel_config.set_size(helper, self.size.clone());
                 // Reset any size overrides the user might have set
                 _ = panel_config.set_size_center(helper, None);
                 _ = panel_config.set_size_wings(helper, None);
@@ -677,7 +669,7 @@ impl PageInner {
                 }
             }
             Message::PanelConfig(c) => {
-                self.size = Some(c.size.clone());
+                self.size = c.size.clone();
                 self.panel_config = Some(*c);
                 return Task::none();
             }

--- a/cosmic-settings/src/pages/desktop/panel/mod.rs
+++ b/cosmic-settings/src/pages/desktop/panel/mod.rs
@@ -79,7 +79,6 @@ impl Default for Page {
             // If the config is not present, it will be created with the default values and the name will not match
             (panel_config.name == "Panel").then_some(panel_config)
         });
-        let size = panel_config.as_ref().map(|c| c.size.clone());
         let system_default = cosmic::cosmic_config::Config::system(
             &format!("{}.Panel", cosmic_panel_config::NAME),
             CosmicPanelConfig::VERSION,
@@ -99,7 +98,6 @@ impl Default for Page {
             inner: PageInner {
                 config_helper,
                 panel_config,
-                size,
                 container_config,
                 outputs_map: HashMap::new(),
                 system_default,


### PR DESCRIPTION
… It is only initialized (not None) when PageInner.panel_config is initialized. This implementation fails faster and more verbose, when program is in an unintended state."

This reverts commit ba5fb65b44302d2aae5d969917d9f3d7b04c8d1e.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

