### PR TITLE
fix(sound): match ActiveRoute events to the correct node

### DIFF
--- a/subscriptions/sound/src/lib.rs
+++ b/subscriptions/sound/src/lib.rs
@@ -520,6 +520,15 @@ impl Model {
                 if active_device == Some(id) {
                     for (node_id, &device) in &self.device_ids {
                         if device == id && node_ids.contains(&node_id) {
+                            // Match the route to the correct node via card_profile_device,
+                            // so that devices with multiple nodes (e.g. multi-HDMI cards)
+                            // don't get their active sink switched to a wrong node.
+                            if let Some(&cpd) = self.card_profile_devices.get(node_id) {
+                                if !route.devices.contains(&(cpd as i32)) {
+                                    continue;
+                                }
+                            }
+
                             set_default_node(self, node_id);
                             break;
                         }


### PR DESCRIPTION
Fix https://github.com/pop-os/cosmic-applets/issues/1388

When a device has multiple sink/source nodes (e.g. a GPU with multiple HDMI outputs on a single ALSA card), an ActiveRoute event for the currently active device caused the handler to pick the first node from the device_ids IntMap whose device matched. IntMap iteration order is hash-based, so the first node was effectively random among nodes sharing the same device.

Use card_profile_device to disambiguate: only match a node when its card.profile.device is listed in route.devices. This mirrors the matching already done in update_device_route_name.

A LLM was used to analyze the code paths and draft the patch. The diagnosis and fix were verified end-to-end against a real multi-HDMI setup (Radeon HDMI/DP card with three sink nodes) by reproducing the stuck-volume symptom and confirming it no longer occurs after the patch is applied.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

