### PR TITLE
feat: add confirmation for resetting panel settings

### DIFF
--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -19,6 +19,11 @@ use std::{collections::HashMap, time::Duration};
 
 use crate::pages::desktop::appearance::Roundness;
 
+pub enum PanelInnerDialog {
+    /// Confirmation dialog for reseting all panel settings
+    ResetPanelConfirmation,
+}
+
 pub struct PageInner {
     pub(crate) config_helper: Option<cosmic_config::Config>,
     pub(crate) panel_config: Option<CosmicPanelConfig>,
@@ -28,6 +33,7 @@ pub struct PageInner {
     pub outputs: Vec<String>,
     pub anchors: Vec<String>,
     pub backgrounds: Vec<String>,
+    pub(crate) dialog: Option<PanelInnerDialog>,
     pub(crate) container_config: Option<CosmicPanelContainerConfig>,
     // TODO move these into panel config
     pub(crate) outputs_map: HashMap<ObjectId, (String, WlOutput)>,
@@ -55,6 +61,7 @@ impl Default for PageInner {
                 Appearance::Light.to_string(),
                 Appearance::Dark.to_string(),
             ],
+            dialog: None,
             container_config: Option::default(),
             outputs_map: HashMap::default(),
             system_default: None,
@@ -347,7 +354,7 @@ pub fn reset_button<
                 Element::from(space())
             } else {
                 button::standard(&descriptions[reset_to_default])
-                    .on_press(Message::ResetPanel)
+                    .on_press(Message::ConfirmResetPanel)
                     .into()
             }
             .map(msg_map)
@@ -432,6 +439,8 @@ pub enum Message {
     OutputRemoved(WlOutput),
     PanelConfig(Box<CosmicPanelConfig>),
     ResetPanel,
+    ConfirmResetPanel,
+    CloseDialog,
     FullReset,
     Surface(surface::Action),
 }
@@ -673,7 +682,13 @@ impl PageInner {
                 self.panel_config = Some(*c);
                 return Task::none();
             }
-            Message::ResetPanel | Message::FullReset => {}
+            Message::ConfirmResetPanel => {
+                self.dialog = Some(PanelInnerDialog::ResetPanelConfirmation);
+            }
+            Message::CloseDialog | Message::ResetPanel => {
+                self.dialog = None;
+            }
+            Message::FullReset => {}
             Message::Surface(_) => {
                 unimplemented!()
             }

--- a/cosmic-settings/src/pages/desktop/panel/mod.rs
+++ b/cosmic-settings/src/pages/desktop/panel/mod.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
-use cosmic::{Task, cosmic_config::CosmicConfigEntry};
+use cosmic::{
+    Apply, Element, Task,
+    cosmic_config::CosmicConfigEntry,
+    widget::{self, icon},
+};
 use cosmic_panel_config::{CosmicPanelConfig, CosmicPanelContainerConfig};
 use cosmic_settings_page::{self as page, Section, section};
 use slotmap::SlotMap;
@@ -144,5 +148,26 @@ impl page::Page<crate::pages::Message> for Page {
         self.inner.update_defaults();
 
         Task::none()
+    }
+
+    fn dialog(&'_ self) -> Option<Element<'_, crate::pages::Message>> {
+        self.inner.dialog.as_ref().map(|dialog| match dialog {
+            inner::PanelInnerDialog::ResetPanelConfirmation => {
+                let primary_action = widget::button::destructive(fl!("confirm"))
+                    .on_press(inner::Message::ResetPanel);
+
+                let secondary_action =
+                    widget::button::standard(fl!("cancel")).on_press(inner::Message::CloseDialog);
+
+                widget::dialog()
+                    .title(fl!("panel-reset-dialog"))
+                    .icon(icon::from_name("dialog-warning").size(64))
+                    .body(fl!("panel-reset-dialog", "desc"))
+                    .primary_action(primary_action)
+                    .secondary_action(secondary_action)
+                    .apply(Element::from)
+                    .map(|m| crate::pages::Message::Panel(Message(m)))
+            }
+        })
     }
 }

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -460,6 +460,9 @@ panel-applets = Configuration
     .dock-desc = Configure dock applets
     .desc = Configure panel applets
 
+panel-reset-dialog = Reset panel settings
+    .desc = This action will reset all panel settings, including configured applets. This action cannot be undone.
+
 panel-missing = Panel configuration is missing
     .desc = The panel configuration file is missing due to use of a custom configuration or it is corrupted.
     .fix = Reset to default


### PR DESCRIPTION
I accidentally reset my settings, and was surprised by the lack of a confirmation for the action. This PR would address #1967. I made the assumption that this being moved from libcosmic to cosmic-settings was an indication that this is something that was worth a PR.

This PR adds a confirmation dialog for panel settings after clicking on "Reset to default". The solution is based on the dialog found in the WiFi (`pages/networking/wifi.rs`).

This only implements the fix for the panel-settings. AFAICT this could also be applied to wallpaper, appearance and shortcuts, which all three use a simple "Reset to default" without confirmation. If this gets accepted, and a similar implementation is desired for the other locations, just let me know.

P.S.: I ran `just check` in `cosmic-settings` which resulted in about 252 unrelated warnings.

Edit: Force push was because I decided to have all the `.dialog` changes in the same `match` instead of splitting between the top and bottom matches.

----

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
