### PR TITLE
Sort VPN connections alphabetically (fixes #1947)

### DIFF
--- a/cosmic-settings/src/pages/networking/vpn/mod.rs
+++ b/cosmic-settings/src/pages/networking/vpn/mod.rs
@@ -428,7 +428,19 @@ impl Page {
                 }
             }
             Message::KnownConnections(connections) => {
-                self.known_connections = connections;
+                let mut connections: Vec<_> = connections.into_iter().collect();
+                connections.sort_by(|a, b| {
+                    let name_a = match &a.1 {
+                        ConnectionSettings::Vpn(s) => s.id.as_str(),
+                        ConnectionSettings::Wireguard { id } => id.as_str(),
+                    };
+                    let name_b = match &b.1 {
+                        ConnectionSettings::Vpn(s) => s.id.as_str(),
+                        ConnectionSettings::Wireguard { id } => id.as_str(),
+                    };
+                    name_a.to_lowercase().cmp(&name_b.to_lowercase())
+                });
+                self.known_connections = connections.into_iter().collect();
             }
             Message::UpdateDevices(devices) => {
                 self.update_devices(devices);
@@ -1005,7 +1017,20 @@ fn devices_view() -> Section<crate::pages::Message> {
                     widget::text::body(fl!("no-vpn")).into(),
                 ])));
             } else {
-                let known_networks = page.known_connections.iter().fold(
+                let mut known_connections: Vec<_> = page.known_connections.iter().collect();
+                known_connections.sort_by(|a, b| {
+                    let name_a = match a.1 {
+                        ConnectionSettings::Vpn(s) => s.id.as_str(),
+                        ConnectionSettings::Wireguard { id } => id.as_str(),
+                    };
+                    let name_b = match b.1 {
+                        ConnectionSettings::Vpn(s) => s.id.as_str(),
+                        ConnectionSettings::Wireguard { id } => id.as_str(),
+                    };
+                    name_a.to_lowercase().cmp(&name_b.to_lowercase())
+                });
+
+                let known_networks = known_connections.into_iter().fold(
                     vpn_connections,
                     |networks, (uuid, connection)| {
                         let id = match connection {


### PR DESCRIPTION
## Summary
- Adds case-insensitive alphabetical sorting to VPN connections list
- Connections are sorted by name when received and before display
- Makes it easier to find specific VPN profiles when multiple are configured

## Changes
Modified `cosmic-settings/src/pages/networking/vpn/mod.rs`:
- Sort connections alphabetically in the update path when handling `Message::KnownConnections`
- Sort connections alphabetically in the render path before display iteration
- Case-insensitive comparison using `to_lowercase().cmp()` for proper alphabetical order

## Testing
- `cargo check -p cosmic-settings -q` passes
- `cargo test -p cosmic-settings --no-run -q` passes

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the Developer Certificate of Origin and certify my contribution under its conditions.

## Related
Fixes #1947