### PR TITLE
fix(wifi): remove misleading search placeholder

### DIFF
--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -1176,10 +1176,9 @@ fn devices_view() -> Section<crate::pages::Message> {
 
                     // Search input (only shown when 15+ networks)
                     if show_search {
-                        let search_input =
-                            widget::search_input(fl!("type-to-search"), &page.search_query)
-                                .on_input(Message::SearchQuery)
-                                .on_clear(Message::SearchQuery(String::new()));
+                        let search_input = widget::search_input("", &page.search_query)
+                            .on_input(Message::SearchQuery)
+                            .on_clear(Message::SearchQuery(String::new()));
                         visible_section = visible_section.push(search_input);
                     }
 


### PR DESCRIPTION
Fixes #1911

The WiFi filter search input said "Type to search..." but unfocused typing on
the WiFi page still triggers the global Settings search, not the page-local
filter. Removing the placeholder brings it in line with other non-focused
search bars in the app (e.g. the Add startup application sidebar). The
filtering logic itself is unchanged.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the Developer Certificate of Origin and certify my contribution under its conditions.

## Verification
- cargo check -p cosmic-settings
- cargo build -p cosmic-settings
- cargo test -p cosmic-settings --no-run