### PR TITLE
sort startup applications and all apps by name for improved organization

### DIFF
--- a/cosmic-settings/src/pages/applications/startup_apps.rs
+++ b/cosmic-settings/src/pages/applications/startup_apps.rs
@@ -142,8 +142,21 @@ impl page::Page<crate::pages::Message> for Page {
             let user_entries =
                 freedesktop_desktop_entry::Iter::new(user_dirs.into_iter()).entries(Some(&locales));
 
+            let mut user_entries_vec = user_entries.collect_vec();
+            user_entries_vec.sort_by(|a, b| {
+                let name_a = a
+                    .name(&locales)
+                    .map(|n| n.to_lowercase())
+                    .unwrap_or_else(|| a.appid.to_lowercase());
+                let name_b = b
+                    .name(&locales)
+                    .map(|n| n.to_lowercase())
+                    .unwrap_or_else(|| b.appid.to_lowercase());
+                name_a.cmp(&name_b)
+            });
+
             let mut apps_hash = HashMap::with_capacity(1);
-            apps_hash.insert(DirectoryType::User, user_entries.collect_vec());
+            apps_hash.insert(DirectoryType::User, user_entries_vec);
 
             Message::UpdateStartupApplications(CachedApps {
                 apps: apps_hash,
@@ -246,6 +259,17 @@ impl Page {
                                 if let Some(target_apps) = target_apps {
                                     let mut new_apps = target_apps.clone();
                                     new_apps.push(app.clone());
+                                    new_apps.sort_by(|a, b| {
+                                        let name_a = a
+                                            .name(&cached_startup_apps.locales)
+                                            .map(|n| n.to_lowercase())
+                                            .unwrap_or_else(|| a.appid.to_lowercase());
+                                        let name_b = b
+                                            .name(&cached_startup_apps.locales)
+                                            .map(|n| n.to_lowercase())
+                                            .unwrap_or_else(|| b.appid.to_lowercase());
+                                        name_a.cmp(&name_b)
+                                    });
 
                                     cached_startup_apps
                                         .apps
@@ -472,6 +496,18 @@ fn get_all_apps(locales: Vec<String>) -> Vec<DesktopEntry> {
         result.push(entry.clone());
         dedupe.insert(app_id.to_owned());
     }
+
+    result.sort_by(|a, b| {
+        let name_a = a
+            .name(&locales)
+            .map(|n| n.to_lowercase())
+            .unwrap_or_else(|| a.appid.to_lowercase());
+        let name_b = b
+            .name(&locales)
+            .map(|n| n.to_lowercase())
+            .unwrap_or_else(|| b.appid.to_lowercase());
+        name_a.cmp(&name_b)
+    });
 
     result
 }

--- a/cosmic-settings/src/pages/applications/startup_apps.rs
+++ b/cosmic-settings/src/pages/applications/startup_apps.rs
@@ -143,17 +143,7 @@ impl page::Page<crate::pages::Message> for Page {
                 freedesktop_desktop_entry::Iter::new(user_dirs.into_iter()).entries(Some(&locales));
 
             let mut user_entries_vec = user_entries.collect_vec();
-            user_entries_vec.sort_by(|a, b| {
-                let name_a = a
-                    .name(&locales)
-                    .map(|n| n.to_lowercase())
-                    .unwrap_or_else(|| a.appid.to_lowercase());
-                let name_b = b
-                    .name(&locales)
-                    .map(|n| n.to_lowercase())
-                    .unwrap_or_else(|| b.appid.to_lowercase());
-                name_a.cmp(&name_b)
-            });
+            sort_entries_by_name(&mut user_entries_vec, &locales);
 
             let mut apps_hash = HashMap::with_capacity(1);
             apps_hash.insert(DirectoryType::User, user_entries_vec);
@@ -259,17 +249,10 @@ impl Page {
                                 if let Some(target_apps) = target_apps {
                                     let mut new_apps = target_apps.clone();
                                     new_apps.push(app.clone());
-                                    new_apps.sort_by(|a, b| {
-                                        let name_a = a
-                                            .name(&cached_startup_apps.locales)
-                                            .map(|n| n.to_lowercase())
-                                            .unwrap_or_else(|| a.appid.to_lowercase());
-                                        let name_b = b
-                                            .name(&cached_startup_apps.locales)
-                                            .map(|n| n.to_lowercase())
-                                            .unwrap_or_else(|| b.appid.to_lowercase());
-                                        name_a.cmp(&name_b)
-                                    });
+                                    sort_entries_by_name(
+                                        &mut new_apps,
+                                        &cached_startup_apps.locales,
+                                    );
 
                                     cached_startup_apps
                                         .apps
@@ -457,6 +440,14 @@ fn apps() -> Section<crate::pages::Message> {
         })
 }
 
+fn sort_entries_by_name(entries: &mut [DesktopEntry], locales: &[String]) {
+    entries.sort_by_cached_key(|e| {
+        e.name(locales)
+            .map(|n| n.to_lowercase())
+            .unwrap_or_else(|| e.appid.to_lowercase())
+    });
+}
+
 fn get_all_apps(locales: Vec<String>) -> Vec<DesktopEntry> {
     let mut dedupe = HashSet::new();
 
@@ -497,17 +488,7 @@ fn get_all_apps(locales: Vec<String>) -> Vec<DesktopEntry> {
         dedupe.insert(app_id.to_owned());
     }
 
-    result.sort_by(|a, b| {
-        let name_a = a
-            .name(&locales)
-            .map(|n| n.to_lowercase())
-            .unwrap_or_else(|| a.appid.to_lowercase());
-        let name_b = b
-            .name(&locales)
-            .map(|n| n.to_lowercase())
-            .unwrap_or_else(|| b.appid.to_lowercase());
-        name_a.cmp(&name_b)
-    });
+    sort_entries_by_name(&mut result, &locales);
 
     result
 }


### PR DESCRIPTION
# Fixes:
- Adds case-insensitive alphabetical sorting to the Startup Applications picker list
- Also sorts the configured startup apps list in the main view for consistency

Fixes https://github.com/pop-os/cosmic-settings/issues/1997


- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

