### PR TITLE
Improve panel corner radius handling

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -238,8 +238,8 @@ impl Page {
 
                 #[cfg(feature = "wayland")]
                 tokio::task::spawn(async move {
-                    Self::update_panel_radii(r);
                     Self::update_dock_padding(r);
+                    Self::update_panel_radii(r);
                 });
             }
 
@@ -520,112 +520,65 @@ impl Page {
 
     // TODO: cache panel and dock configs so that they needn't be re-read
     #[cfg(feature = "wayland")]
+    fn load_panel_config(name: &str) -> Option<(Config, CosmicPanelConfig)> {
+        let helper = CosmicPanelConfig::cosmic_config(name).ok()?;
+        let config = CosmicPanelConfig::get_entry(&helper).ok()?;
+        (config.name == name).then_some((helper, config))
+    }
+
+    #[cfg(feature = "wayland")]
     pub fn update_panel_radii(roundness: Roundness) {
-        let panel_config_helper = CosmicPanelConfig::cosmic_config("Panel").ok();
-        let dock_config_helper = CosmicPanelConfig::cosmic_config("Dock").ok();
+        let corner_radii: CornerRadii = roundness.into();
+        let radius = corner_radii.radius_xl[0] as u32;
 
-        let mut panel_config = panel_config_helper.as_ref().and_then(|config_helper| {
-            let panel_config = CosmicPanelConfig::get_entry(config_helper).ok()?;
-            (panel_config.name == "Panel").then_some(panel_config)
-        });
+        for name in ["Panel", "Dock"] {
+            let Some((helper, mut config)) = Self::load_panel_config(name) else {
+                continue;
+            };
 
-        let mut dock_config = dock_config_helper.as_ref().and_then(|config_helper| {
-            let panel_config = CosmicPanelConfig::get_entry(config_helper).ok()?;
-            (panel_config.name == "Dock").then_some(panel_config)
-        });
-
-        if let Some(panel_config_helper) = panel_config_helper.as_ref()
-            && let Some(panel_config) = panel_config.as_mut()
-        {
-            let radii = if panel_config.anchor_gap {
-                let cornder_radii: CornerRadii = roundness.into();
-                cornder_radii.radius_xl[0] as u32
-            } else if matches!(roundness, Roundness::Round) && !panel_config.expand_to_edges {
-                12
+            let new_radius = if config.anchor_gap {
+                radius
+            } else if !config.expand_to_edges {
+                radius.min(12)
             } else {
                 0
             };
 
-            if let Err(why) = panel_config.set_border_radius(panel_config_helper, radii) {
-                tracing::error!(?why, "Error updating panel corner radii");
-            }
-        }
-
-        if let Some(dock_config_helper) = dock_config_helper.as_ref()
-            && let Some(dock_config) = dock_config.as_mut()
-        {
-            let radii = if dock_config.anchor_gap {
-                let cornder_radii: CornerRadii = roundness.into();
-                cornder_radii.radius_xl[0] as u32
-            } else if matches!(roundness, Roundness::Round) && !dock_config.expand_to_edges {
-                12
-            } else {
-                0
-            };
-
-            if let Err(why) = dock_config.set_border_radius(dock_config_helper, radii) {
-                tracing::error!(?why, "Error updating dock corner radii");
+            if let Err(why) = config.set_border_radius(&helper, new_radius) {
+                tracing::error!(?why, "Error updating {name} corner radii");
             }
         }
     }
 
     #[cfg(feature = "wayland")]
     pub fn update_dock_padding(roundness: Roundness) {
-        let dock_config_helper = CosmicPanelConfig::cosmic_config("Dock").ok();
+        let Some((helper, mut config)) = Self::load_panel_config("Dock") else {
+            return;
+        };
 
-        let mut dock_config = dock_config_helper.as_ref().and_then(|config_helper| {
-            let panel_config = CosmicPanelConfig::get_entry(config_helper).ok()?;
-            (panel_config.name == "Dock").then_some(panel_config)
-        });
+        let padding = match roundness {
+            Roundness::Round | Roundness::SlightlyRound => 4,
+            Roundness::Square => 0,
+        };
 
-        if let Some(dock_config_helper) = dock_config_helper.as_ref()
-            && let Some(dock_config) = dock_config.as_mut()
-        {
-            let padding = match roundness {
-                Roundness::Round => 4,
-                Roundness::SlightlyRound => 4,
-                Roundness::Square => 0,
-            };
-
-            if let Err(why) = dock_config.set_padding(dock_config_helper, padding) {
-                tracing::error!(?why, "Error updating dock padding");
-            }
+        if let Err(why) = config.set_padding(&helper, padding) {
+            tracing::error!(?why, "Error updating dock padding");
         }
     }
 
-    // TODO: cache panel and dock configs so that they needn't be re-read
     #[cfg(feature = "wayland")]
     pub fn update_panel_spacing(density: Density) {
         let spacing: cosmic::cosmic_theme::Spacing = density.into();
-        let space_none = spacing.space_none;
-        let panel_config_helper = CosmicPanelConfig::cosmic_config("Panel").ok();
-        let dock_config_helper = CosmicPanelConfig::cosmic_config("Dock").ok();
-        let mut panel_config = panel_config_helper.as_ref().and_then(|config_helper| {
-            let panel_config = CosmicPanelConfig::get_entry(config_helper).ok()?;
-            (panel_config.name == "Panel").then_some(panel_config)
-        });
-        let mut dock_config = dock_config_helper.as_ref().and_then(|config_helper| {
-            let panel_config = CosmicPanelConfig::get_entry(config_helper).ok()?;
-            (panel_config.name == "Dock").then_some(panel_config)
-        });
+        let space_none = spacing.space_none as u32;
 
-        if let Some(panel_config_helper) = panel_config_helper.as_ref()
-            && let Some(panel_config) = panel_config.as_mut()
-        {
-            let update = panel_config.set_spacing(panel_config_helper, space_none as u32);
-            if let Err(err) = update {
-                tracing::error!(?err, "Error updating panel spacing");
+        for name in ["Panel", "Dock"] {
+            let Some((helper, mut config)) = Self::load_panel_config(name) else {
+                continue;
+            };
+            if let Err(err) = config.set_spacing(&helper, space_none) {
+                tracing::error!(?err, "Error updating {name} spacing");
             }
-        };
-
-        if let Some(dock_config_helper) = dock_config_helper.as_ref()
-            && let Some(dock_config) = dock_config.as_mut()
-        {
-            let update = dock_config.set_spacing(dock_config_helper, space_none as u32);
-            if let Err(err) = update {
-                tracing::error!(?err, "Error updating dock spacing");
-            }
-        };
+        }
     }
 
     fn can_reset(&self) -> bool {

--- a/cosmic-settings/src/pages/desktop/panel/inner.rs
+++ b/cosmic-settings/src/pages/desktop/panel/inner.rs
@@ -587,17 +587,14 @@ impl PageInner {
                 }
                 let theme = cosmic::theme::system_preference();
                 let theme = theme.cosmic();
-                let radius = theme.corner_radii;
-                let roundness: Roundness = radius.into();
-                let new_radius;
-                if enabled {
-                    let radii = theme.corner_radii.radius_xl[0] as u32;
-                    new_radius = radii;
-                } else if matches!(roundness, Roundness::Round) && !panel_config.expand_to_edges {
-                    new_radius = 12;
+                let radius = theme.corner_radii.radius_xl[0] as u32;
+                let new_radius = if enabled {
+                    radius
+                } else if !panel_config.expand_to_edges {
+                    radius.min(12)
                 } else {
-                    new_radius = 0;
-                }
+                    0
+                };
                 _ = panel_config.set_border_radius(helper, new_radius).unwrap();
             }
             Message::PanelSize(size) => {
@@ -622,17 +619,14 @@ impl PageInner {
 
                 let theme = cosmic::theme::system_preference();
                 let theme = theme.cosmic();
-                let radius = theme.corner_radii;
-                let roundness: Roundness = radius.into();
-                let new_radius;
-                if panel_config.anchor_gap {
-                    let radii = theme.corner_radii.radius_xl[0] as u32;
-                    new_radius = radii;
-                } else if matches!(roundness, Roundness::Round) && !enabled {
-                    new_radius = 12;
+                let radius = theme.corner_radii.radius_xl[0] as u32;
+                let new_radius = if panel_config.anchor_gap {
+                    radius
+                } else if !enabled {
+                    radius.min(12)
                 } else {
-                    new_radius = 0;
-                }
+                    0
+                };
                 _ = panel_config.set_border_radius(helper, new_radius).unwrap();
             }
             Message::OpacityRequest(opacity) => {


### PR DESCRIPTION
Aligns panel corner radius handling to designs.

Also extracts panel config fetching into a helper function.

Should be tested alongside https://github.com/pop-os/cosmic-panel/pull/598.

The differences are as follows:
- Slightly round now always has a corner radius of @radius_xl (8)
- Square now also has a corner radius of @radius_xl (2), instead of 0, matching applet highlights

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

