### PR TITLE
Adding a select theme section in the appearance settings

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -55,6 +55,7 @@ pub struct Page {
     can_reset: bool,
     context_view: Option<ContextView>,
     drawer: drawer::Content,
+    system_themes: Vec<(String, std::path::PathBuf, Option<std::path::PathBuf>)>,
     roundness: Roundness,
     density: Density,
 
@@ -91,6 +92,7 @@ impl From<theme_manager::Manager> for Page {
             theme_manager,
             tk_config,
             day_time: true,
+            system_themes: Vec::new(),
         }
     }
 }
@@ -156,6 +158,8 @@ pub enum Message {
     UseDefaultWindowHint(bool),
     WindowHintSize(u32),
     Daytime(bool),
+    LoadSystemThemes(Vec<(String, std::path::PathBuf, Option<std::path::PathBuf>)>),
+    ApplySystemTheme(std::path::PathBuf),
 }
 
 impl From<Message> for crate::app::Message {
@@ -505,6 +509,21 @@ impl Page {
                     self.drawer.reset(&self.theme_manager);
                 }
             }
+
+            Message::LoadSystemThemes(themes) => {
+                self.system_themes = themes;
+            }
+
+            Message::ApplySystemTheme(path) => {
+                tasks.push(cosmic::task::future(async move {
+                    let res = tokio::fs::read_to_string(path).await;
+                    if let Some(b) = res.ok().and_then(|s| ron::de::from_str(&s).ok()) {
+                        Message::ImportSuccess(Box::new(b))
+                    } else {
+                        Message::ImportError
+                    }
+                }));
+            }
         }
 
         let mut tasks = cosmic::Task::batch(tasks);
@@ -648,6 +667,7 @@ impl page::Page<crate::pages::Message> for Page {
     ) -> Option<page::Content> {
         Some(vec![
             sections.insert(mode_and_colors::section()),
+            sections.insert(system_themes_section()),
             sections.insert(style::section()),
             sections.insert(interface_density()),
             sections.insert(window_management()),
@@ -685,6 +705,28 @@ impl page::Page<crate::pages::Message> for Page {
             cosmic::task::future(async move {
                 let (interface, mono) = font_config::load_font_families();
                 Message::DrawerFont(drawer::FontMessage::FontLoaded(interface, mono))
+            })
+            .map(crate::pages::Message::Appearance),
+            cosmic::task::future(async move {
+                let mut themes = Vec::new();
+                if let Ok(mut entries) = tokio::fs::read_dir("/usr/share/cosmic-themes").await {
+                    while let Ok(Some(entry)) = entries.next_entry().await {
+                        let path = entry.path();
+                        if path.extension().and_then(|e| e.to_str()) == Some("ron") {
+                            let name = path.file_stem().unwrap_or_default()
+                                .to_string_lossy().to_string();
+                            let png = path.with_extension("png");
+                            let preview = if tokio::fs::try_exists(&png).await.unwrap_or(false) {
+                                Some(png)
+                            } else {
+                                None
+                            };
+                            themes.push((name, path, preview));
+                        }
+                    }
+                    
+                }
+                Message::LoadSystemThemes(themes)
             })
             .map(crate::pages::Message::Appearance),
         ])
@@ -871,4 +913,30 @@ pub fn reset_button() -> Section<crate::pages::Message> {
             .map(crate::pages::Message::Appearance)
         })
 }
+
+pub fn system_themes_section() -> Section<crate::pages::Message> {
+    Section::default()
+        .title(fl!("system-themes"))
+        .view::<Page>(move |_binder, page, section| {
+            let buttons: Vec<Element<Message>> = page.system_themes.iter().map(|(name, ron, png)| {
+                cosmic::iced::widget::column![
+                    button::standard(name)
+                        .on_press(Message::ApplySystemTheme(ron.clone())),
+                ]
+                .spacing(8)
+                .align_x(Alignment::Center)
+                .into()
+            }).collect();
+
+            settings::section()
+                .title(fl!("system-themes"))
+                .add(
+                    widget::flex_row(buttons)
+                        .spacing(16)
+                )
+            .apply(Element::from)
+            .map(crate::pages::Message::Appearance)
+        })
+}
+
 impl page::AutoBind<crate::pages::Message> for Page {}

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -918,7 +918,7 @@ pub fn system_themes_section() -> Section<crate::pages::Message> {
     Section::default()
         .title(fl!("system-themes"))
         .view::<Page>(move |_binder, page, section| {
-            let buttons: Vec<Element<Message>> = page.system_themes.iter().map(|(name, ron, png)| {
+            let buttons: Vec<Element<Message>> = page.system_themes.iter().map(|(name, ron, _png)| {
                 cosmic::iced::widget::column![
                     button::standard(name)
                         .on_press(Message::ApplySystemTheme(ron.clone())),

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -337,6 +337,7 @@ never = Never
 ## Desktop: Appearance
 
 appearance = Appearance
+system-themes = System Themes
 
 accent-color = Accent color
 app-background = Window background


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.


I've just installed cosmic few days ago and i saw a lack of functionality to change the theme without using the import function.
I've decided to add it.
My additions are fetching if themes exists in /usr/share/cosmic-themes and propose to the user to select them, i've tried it and it works. The buttons are clickable for sure. I've put down there two screenshots for you to see the modifications quickly.

After my pull request :
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ee8281ab-7940-4ea8-ad4e-69cafea382d2" />

Before my pull request :
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f445b19b-85fa-4fb8-bf2d-a518fa9b12c4" />

I used Claude from antrophic to read the codebase and make sure i had a full overview of the code to integrate this properly, I understand everything I did and i've done my best to follow the way of work.