### PR TITLE
fix(wallpaper): skip ImageHandle::from_rgba when source and fit unchanged

### DIFF
--- a/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
+++ b/cosmic-settings/src/pages/desktop/wallpaper/mod.rs
@@ -155,6 +155,13 @@ pub struct Page {
     /// Cache for storing the image used by the display preview.
     cached_display_handle: Option<ImageHandle>,
 
+    /// The DefaultKey and fit mode of the last successfully rendered display image.
+    /// Used to skip redundant ImageHandle::from_rgba calls: each call produces a unique
+    /// ID via AtomicU64::fetch_add (pop-os/iced core/src/image.rs:216), so calling it
+    /// when the source is unchanged leaks entries into the wgpu raster cache indefinitely.
+    cached_display_key: Option<DefaultKey>,
+    cached_display_fit: Option<usize>,
+
     /// Model for the category dropdown, which has categories and recent folders.
     categories: dropdown::multi::Model<String, Category>,
 
@@ -227,6 +234,8 @@ impl page::Page<crate::pages::Message> for Page {
     fn on_leave(&mut self) -> Task<crate::pages::Message> {
         // Reclaim memory
         self.cached_display_handle = None;
+        self.cached_display_key = None;
+        self.cached_display_fit = None;
         self.selection = Context::default();
         self.outputs = SingleSelectModel::default();
 
@@ -287,6 +296,8 @@ impl Default for Page {
             show_tab_bar: false,
             active_output: None,
             cached_display_handle: None,
+            cached_display_key: None,
+            cached_display_fit: None,
             categories: {
                 let mut categories = dropdown::multi::model();
 
@@ -388,22 +399,44 @@ impl Page {
     }
 
     fn cache_display_image(&mut self) {
-        self.cached_display_handle = None;
-
-        let choice = match self.selection.active {
-            Choice::Wallpaper(id) => self.selection.display_images.get(id),
+        // Resolve which wallpaper DefaultKey we would render.
+        // Computed before the early-return check so the Slideshow lookup isn't duplicated.
+        let resolved_key: Option<DefaultKey> = match self.selection.active {
+            Choice::Wallpaper(id) => Some(id),
 
             Choice::Slideshow => self
                 .config_output()
                 .and_then(|output| match self.config.current_image(output)? {
-                    Source::Path(path) => {
-                        let id = self.wallpaper_id_from_path(&path)?;
-                        Some(&self.selection.display_images[id])
-                    }
-
-                    Source::Color(_color) => None,
+                    Source::Path(path) => self.wallpaper_id_from_path(&path),
+                    Source::Color(_) => None,
                 })
-                .or(self.selection.display_images.values().next()),
+                .or_else(|| self.selection.display_images.keys().next()),
+
+            Choice::Color(_) => None,
+        };
+
+        // Short-circuit: reuse the existing handle when neither the source image nor the
+        // fit mode has changed.  Without this guard, ImageHandle::from_rgba is called on
+        // every UpdateState event (each wallpaper rotation); because from_rgba always calls
+        // Id::unique() (AtomicU64::fetch_add, pop-os/iced core/src/image.rs:216), every
+        // call inserts an un-evictable entry into the wgpu raster cache
+        // (wgpu/src/image/raster.rs), causing unbounded RSS growth (~9 GB/hour).
+        if self.cached_display_handle.is_some()
+            && resolved_key == self.cached_display_key
+            && Some(self.selected_fit) == self.cached_display_fit
+        {
+            return;
+        }
+
+        self.cached_display_handle = None;
+        self.cached_display_key = None;
+        self.cached_display_fit = None;
+
+        let choice = match self.selection.active {
+            Choice::Wallpaper(id) => self.selection.display_images.get(id),
+
+            Choice::Slideshow => resolved_key
+                .and_then(|id| self.selection.display_images.get(id)),
 
             Choice::Color(_) => None,
         };
@@ -450,6 +483,8 @@ impl Page {
             image.height(),
             image.to_vec(),
         ));
+        self.cached_display_key = resolved_key;
+        self.cached_display_fit = Some(self.selected_fit);
     }
 
     fn config_output(&self) -> Option<&str> {
@@ -720,6 +755,8 @@ impl Page {
                             }
 
                             self.cached_display_handle = None;
+                            self.cached_display_key = None;
+                            self.cached_display_fit = None;
                             self.selection.replace_active_custom(color.clone());
                             self.config_apply();
 
@@ -812,6 +849,8 @@ impl Page {
             Message::ColorSelect(color) => {
                 self.selection.active = Choice::Color(color);
                 self.cached_display_handle = None;
+                self.cached_display_key = None;
+                self.cached_display_fit = None;
             }
 
             Message::Fit(selection) => {


### PR DESCRIPTION
## Problem

`cosmic-settings desktop` leaks ~9 GB/hour of RSS when running as a persistent background daemon with slideshow mode active. The process is eventually OOM-killed after exhausting swap, which starves the Wayland compositor of CPU time and freezes the display. This is a reproduction of #843.

## Root Cause

`cache_display_image()` calls `ImageHandle::from_rgba()` on every `Message::UpdateState` event (fired once per wallpaper rotation by the inotify watcher on the cosmic-bg state file). `from_rgba` unconditionally calls `Id::unique()`:

```rust
// pop-os/iced core/src/image.rs:216
static NEXT_ID: AtomicU64 = AtomicU64::new(0);
Self(_Id::Unique(NEXT_ID.fetch_add(1, atomic::Ordering::Relaxed)))
```

Every call produces a monotonically-increasing unique ID, making cache hits in the wgpu raster cache (`wgpu/src/image/raster.rs` — `FxHashMap<image::Id, Memory>`) structurally impossible.

Eviction only happens inside `trim()` (`raster.rs:78`), which is only called from `draw()` (`wgpu/src/lib.rs:162`), which is only called from `present()`. When the Wayland compositor suppresses `RedrawRequested` between rotations (DPMS off, occlusion, throttling), `present()` never fires, `trim()` never runs, and the `FxHashMap` grows unbounded — one `Memory` entry per rotation interval.

This is the same `trim()`/`present()` gap described in iced-rs/iced#2659, triggered here by the slideshow rotation path.

## Fix

Add `cached_display_key: Option<DefaultKey>` and `cached_display_fit: Option<usize>` to `Page`. At the start of `cache_display_image()`, resolve the effective `DefaultKey` for the current selection and short-circuit if it matches the previously rendered values:

```rust
if self.cached_display_handle.is_some()
    && resolved_key == self.cached_display_key
    && Some(self.selected_fit) == self.cached_display_fit
{
    return;  // source unchanged — existing handle is valid
}
```

`ImageHandle::from_rgba` is now called only when the wallpaper or fit mode actually changes, not on every state event. All three existing `cached_display_handle = None` sites are updated to clear the new fields so state stays coherent.

## Tested

- Pop!_OS 24.04, cosmic-settings v1.0.12, NVIDIA RTX 5060 Ti + Intel iGPU (hybrid display path)
- Built from source, deployed, and monitored for 20 minutes
- RSS stable at ~243 MB (previously grew at ~9.3 GB/hour)
- Slideshow rotation continues to update the display preview correctly

## Note on complementary fix

This prevents new unique handles from accumulating. A complementary fix in `pop-os/iced` — decoupling `trim()` from `present()` so stale entries are evicted even when the compositor suppresses redraws — would provide defence-in-depth (see iced-rs/iced#2659).