### PR TITLE
fix(bluetooth): add passkey/PIN display dialogs for keyboard pairing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 name = "accounts-zbus"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -288,7 +288,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -299,7 +299,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -837,7 +837,7 @@ dependencies = [
 [[package]]
 name = "bluez-zbus"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1427,7 +1427,7 @@ dependencies = [
 [[package]]
 name = "cosmic-dbus-a11y"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "cosmic-dbus-networkmanager"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "bitflags 2.11.1",
  "derive_builder",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "cosmic-settings-daemon"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -2173,7 +2173,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2357,7 +2357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2858,21 +2858,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -3145,7 +3132,7 @@ checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 [[package]]
 name = "hostname1-zbus"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -3879,12 +3866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f2f8aeca682d874a5247084aa4fb7d1cef9ba45d889c21209a8818dcaaa0ec9"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4148,7 +4129,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4490,7 +4471,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4539,12 +4520,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lebe"
@@ -4764,7 +4739,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 [[package]]
 name = "locale1"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -5107,7 +5082,7 @@ dependencies = [
 [[package]]
 name = "nm-secret-agent-manager"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -5188,7 +5163,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5971,16 +5946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6148,12 +6113,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -6564,7 +6523,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6994,7 +6953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7233,10 +7192,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7345,7 +7304,7 @@ dependencies = [
 [[package]]
 name = "timedate-zbus"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "zbus",
 ]
@@ -7636,7 +7595,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7740,15 +7699,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "upower_dbus"
 version = "0.3.2"
-source = "git+https://github.com/pop-os/dbus-settings-bindings#507e342c21d3ce6ae41b1d4f3fa2f0ad5ee23e75"
+source = "git+https://github.com/pop-os/dbus-settings-bindings#eed01dd3609e90e3c8cd043656734c500956c793"
 dependencies = [
  "serde",
  "serde_repr",
@@ -7885,15 +7838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7946,40 +7890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -8353,7 +8263,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9045,88 +8955,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "write16"

--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -476,7 +476,10 @@ impl Page {
                 Event::UpdatedDevice(path, update) => {
                     // Dismiss passkey/pin display dialogs when pairing completes,
                     // since BlueZ may not always send Cancel after a successful pair.
-                    if update.iter().any(|u| matches!(u, DeviceUpdate::Paired(true))) {
+                    if update
+                        .iter()
+                        .any(|u| matches!(u, DeviceUpdate::Paired(true)))
+                    {
                         if matches!(
                             self.dialog,
                             Some(Dialog::DisplayPasskey { .. } | Dialog::DisplayPinCode { .. })
@@ -565,19 +568,13 @@ impl Page {
                             });
                         }
 
-                        bluez_zbus::agent1::Message::DisplayPinCode {
-                            device,
-                            pincode,
-                        } => {
+                        bluez_zbus::agent1::Message::DisplayPinCode { device, pincode } => {
                             let device = self.model.devices.get(&device).map_or_else(
                                 || device.to_string(),
                                 |device| device.alias_or_addr().to_owned(),
                             );
 
-                            self.dialog = Some(Dialog::DisplayPinCode {
-                                device,
-                                pincode,
-                            });
+                            self.dialog = Some(Dialog::DisplayPinCode { device, pincode });
                         }
 
                         bluez_zbus::agent1::Message::RequestPasskey { response, .. } => {

--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -17,23 +17,20 @@ use std::time::Duration;
 use zbus::zvariant::OwnedObjectPath;
 
 enum Dialog {
-    // RequestAuthorization {
-    //     device: OwnedObjectPath,
-    //     response: oneshot::Sender<bool>,
-    // },
     RequestConfirmation {
         device: String,
         passkey: u32,
         response: oneshot::Sender<bool>,
     },
-    // RequestPasskey {
-    //     device: OwnedObjectPath,
-    //     response: oneshot::Sender<Option<u32>>,
-    // },
-    // RequestPinCode {
-    //     device: OwnedObjectPath,
-    //     response: oneshot::Sender<Option<String>>,
-    // },
+    DisplayPasskey {
+        device: String,
+        passkey: u32,
+        entered: u16,
+    },
+    DisplayPinCode {
+        device: String,
+        pincode: String,
+    },
 }
 
 #[derive(Default)]
@@ -256,6 +253,81 @@ impl page::Page<crate::pages::Message> for Page {
 
                 Some(dialog)
             }
+
+            Dialog::DisplayPasskey {
+                device,
+                passkey,
+                entered,
+            } => {
+                let description = widget::text::body(fl!(
+                    "bluetooth-display-passkey",
+                    "description",
+                    device = device
+                ))
+                .wrapping(Wrapping::Word);
+
+                let passkey_str = format!("{passkey:06}");
+                let entered = *entered as usize;
+
+                let pin = widget::text::title1(passkey_str)
+                    .width(Length::Fill)
+                    .align_x(Alignment::Center)
+                    .wrapping(Wrapping::None);
+
+                let progress = widget::text::body(format!("{entered} / 6 keys entered"))
+                    .width(Length::Fill)
+                    .align_x(Alignment::Center)
+                    .wrapping(Wrapping::None);
+
+                let control = widget::column::with_capacity(3)
+                    .push(description)
+                    .push(pin)
+                    .push(progress)
+                    .spacing(theme::spacing().space_xxs);
+
+                let cancel_button =
+                    widget::button::standard(fl!("cancel")).on_press(Message::PinCancel);
+
+                let dialog = widget::dialog()
+                    .title(fl!("bluetooth-display-passkey"))
+                    .control(control)
+                    .secondary_action(cancel_button)
+                    .apply(Element::from)
+                    .map(Into::into);
+
+                Some(dialog)
+            }
+
+            Dialog::DisplayPinCode { device, pincode } => {
+                let description = widget::text::body(fl!(
+                    "bluetooth-display-pin",
+                    "description",
+                    device = device
+                ))
+                .wrapping(Wrapping::Word);
+
+                let pin = widget::text::title1(pincode.clone())
+                    .width(Length::Fill)
+                    .align_x(Alignment::Center)
+                    .wrapping(Wrapping::None);
+
+                let control = widget::column::with_capacity(2)
+                    .push(description)
+                    .push(pin)
+                    .spacing(theme::spacing().space_xxs);
+
+                let cancel_button =
+                    widget::button::standard(fl!("cancel")).on_press(Message::PinCancel);
+
+                let dialog = widget::dialog()
+                    .title(fl!("bluetooth-display-pin"))
+                    .control(control)
+                    .secondary_action(cancel_button)
+                    .apply(Element::from)
+                    .map(Into::into);
+
+                Some(dialog)
+            }
         }
     }
 }
@@ -402,6 +474,17 @@ impl Page {
                 }
 
                 Event::UpdatedDevice(path, update) => {
+                    // Dismiss passkey/pin display dialogs when pairing completes,
+                    // since BlueZ may not always send Cancel after a successful pair.
+                    if update.iter().any(|u| matches!(u, DeviceUpdate::Paired(true))) {
+                        if matches!(
+                            self.dialog,
+                            Some(Dialog::DisplayPasskey { .. } | Dialog::DisplayPinCode { .. })
+                        ) {
+                            self.dialog = None;
+                        }
+                    }
+
                     if let Some(existing) = self.model.devices.get_mut(&path) {
                         tracing::debug!("Device {} updated", existing.address);
                         existing.update(update);
@@ -462,6 +545,38 @@ impl Page {
                                 device,
                                 passkey,
                                 response,
+                            });
+                        }
+
+                        bluez_zbus::agent1::Message::DisplayPasskey {
+                            device,
+                            passkey,
+                            entered,
+                        } => {
+                            let device = self.model.devices.get(&device).map_or_else(
+                                || device.to_string(),
+                                |device| device.alias_or_addr().to_owned(),
+                            );
+
+                            self.dialog = Some(Dialog::DisplayPasskey {
+                                device,
+                                passkey,
+                                entered,
+                            });
+                        }
+
+                        bluez_zbus::agent1::Message::DisplayPinCode {
+                            device,
+                            pincode,
+                        } => {
+                            let device = self.model.devices.get(&device).map_or_else(
+                                || device.to_string(),
+                                |device| device.alias_or_addr().to_owned(),
+                            );
+
+                            self.dialog = Some(Dialog::DisplayPinCode {
+                                device,
+                                pincode,
                             });
                         }
 

--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -274,16 +274,20 @@ impl page::Page<crate::pages::Message> for Page {
                     .align_x(Alignment::Center)
                     .wrapping(Wrapping::None);
 
-                let progress = widget::text::body(format!("{entered} / 6 keys entered"))
-                    .width(Length::Fill)
-                    .align_x(Alignment::Center)
-                    .wrapping(Wrapping::None);
+                let mut control = widget::column::with_capacity(3).push(description).push(pin);
 
-                let control = widget::column::with_capacity(3)
-                    .push(description)
-                    .push(pin)
-                    .push(progress)
-                    .spacing(theme::spacing().space_xxs);
+                // Only show the key progress counter when the device actually
+                // reports keypress notifications. Most keyboards don't support
+                // this, so entered stays at 0 for the entire pairing process.
+                if entered > 0 {
+                    let progress = widget::text::body(format!("{entered} / 6 keys entered"))
+                        .width(Length::Fill)
+                        .align_x(Alignment::Center)
+                        .wrapping(Wrapping::None);
+                    control = control.push(progress);
+                }
+
+                let control = control.spacing(theme::spacing().space_xxs);
 
                 let cancel_button =
                     widget::button::standard(fl!("cancel")).on_press(Message::PinCancel);
@@ -479,13 +483,12 @@ impl Page {
                     if update
                         .iter()
                         .any(|u| matches!(u, DeviceUpdate::Paired(true)))
-                    {
-                        if matches!(
+                        && matches!(
                             self.dialog,
                             Some(Dialog::DisplayPasskey { .. } | Dialog::DisplayPinCode { .. })
-                        ) {
-                            self.dialog = None;
-                        }
+                        )
+                    {
+                        self.dialog = None;
                     }
 
                     if let Some(existing) = self.model.devices.get_mut(&path) {

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -252,6 +252,12 @@ bluetooth-paired = Previously connected devices
 bluetooth-confirm-pin = Confirm Bluetooth PIN
     .description = Please confirm that the following PIN matches the one displayed on { $device }
 
+bluetooth-display-passkey = Bluetooth Pairing
+    .description = Please type the following passkey on { $device }, then press Enter
+
+bluetooth-display-pin = Bluetooth Pairing
+    .description = Please type the following PIN on { $device }, then press Enter
+
 bluetooth-available = Nearby devices
 
 bluetooth-adapters = Bluetooth adapters

--- a/subscriptions/bluetooth/src/agent.rs
+++ b/subscriptions/bluetooth/src/agent.rs
@@ -40,7 +40,7 @@ pub async fn watch(
     bluez
         .register_agent(
             &agent_path,
-            <&'static str>::from(bluez_zbus::agent1::Capability::DisplayYesNo),
+            <&'static str>::from(bluez_zbus::agent1::Capability::KeyboardDisplay),
         )
         .await?;
 


### PR DESCRIPTION
## Summary

Bluetooth keyboards (e.g. Logitech MX Keys) require the host to display a passkey for the user to type. Previously, clicking Connect on a keyboard would show it in the connected list but pairing never completed — no passkey dialog appeared.

## Dependencies

Requires pop-os/dbus-settings-bindings#32 to be merged first (forwards `DisplayPasskey`/`DisplayPinCode` agent messages through the channel).

## Changes

- **`subscriptions/bluetooth/src/agent.rs`**: Change agent capability from `DisplayYesNo` to `KeyboardDisplay` (a desktop has both a display and keyboard)
- **`cosmic-settings/src/pages/bluetooth/mod.rs`**:
  - Add `Dialog::DisplayPasskey` variant with typed-key progress indicator
  - Add `Dialog::DisplayPinCode` variant for older keyboards
  - Handle `DisplayPasskey` and `DisplayPinCode` agent events
  - Auto-dismiss display dialogs when device reports `Paired=true` (BlueZ may not always send `Cancel` after a successful pair)
  - Only show the "X/6 keys entered" progress counter when the device actually sends Keypress Notification PDUs (most consumer keyboards do not support this Bluetooth SMP feature)
  - Fix clippy `collapsible_if` warning
- **`Cargo.lock`**: Update `dbus-settings-bindings` to `eed01dd` to include the agent message forwarding fix (see note below)
- **`i18n/en/cosmic_settings.ftl`**: Add localization strings for the new pairing dialogs

## Note on Cargo.lock diff size

The `Cargo.lock` changes account for most of the `+158 -209` diff. This is expected: `bluez-zbus` is a git dependency pointing to the `dbus-settings-bindings` workspace. Running `cargo update -p bluez-zbus` updates the entire workspace revision (`507e342` → `eed01dd`), which pulls in upstream dependency updates and cleans up stale transitive dependencies across all crates in that workspace. The net line reduction comes from these cleaned-up dependencies, not from deleted application code.

## Note on "keys entered" counter

The Bluetooth SMP (Security Manager Protocol) includes an optional feature called **Keypress Notifications**. When a keyboard supports it, BlueZ calls `display_passkey` multiple times with an incrementing `entered` value, allowing the UI to show keystroke progress. However, most consumer keyboards — including the Logitech MX Keys and Ergo K860 — do not send Keypress Notification PDUs. The keyboard buffers input locally and remains silent over the Bluetooth link until the user finishes typing and presses Enter. For these devices, the progress counter is now hidden entirely to avoid showing a misleading "0/6 keys entered" that never updates.

## Testing

Tested with a Logitech MX Keys keyboard:
1. Open Bluetooth settings, put keyboard in pairing mode
2. Click Connect — passkey dialog appears with a 6-digit code and instructions
3. Type the code on the keyboard and press Enter
4. Dialog dismisses automatically and keyboard shows as paired/connected
5. Verified: if the passkey is not typed within the timeout, the challenge refreshes with a new passkey automatically
6. Verified: no misleading "0/6 keys entered" counter on keyboards that do not support Keypress Notifications

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.