### PR TITLE
Longer screen change countdown

### DIFF
--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -453,7 +453,7 @@ impl page::Page<crate::pages::Message> for Page {
 
     /// Opens a dialog to confirm the display settings.
     ///
-    /// This dialog has a 10 (arbitrary) second counter which will
+    /// This dialog has a timed countdown which will
     /// automatically revert to the original display settings when depleted.
     ///
     /// To make a setting activate this dialog. Call the `set_dialog` method with
@@ -732,7 +732,7 @@ impl Page {
             return Task::none();
         }
         self.dialog = Some(revert_request);
-        self.dialog_countdown = 10;
+        self.dialog_countdown = 20;
         cosmic::task::future(async {
             tokio::time::sleep(time::Duration::from_secs(1)).await;
             app::Message::from(Message::DialogCountdown)

--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -457,7 +457,7 @@ impl page::Page<crate::pages::Message> for Page {
     /// automatically revert to the original display settings when depleted.
     ///
     /// To make a setting activate this dialog. Call the `set_dialog` method with
-    /// the Randr enum value which undos the current change. Makde sure the
+    /// the Randr enum value which undoes the current change. Makde sure the
     /// return value is returned with the `exec_value` return value within a batch
     /// Task.
     fn dialog(&self) -> Option<Element<'_, pages::Message>> {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

#2025 has some context on why I think 10 seconds is too short. 15s could be survivable but tight.