### PR TITLE
Toggle: show week number

### DIFF
--- a/cosmic-settings/src/pages/time/date.rs
+++ b/cosmic-settings/src/pages/time/date.rs
@@ -472,10 +472,8 @@ fn format() -> Section<crate::pages::Message> {
                         .toggler(page.show_date_in_top_panel, Message::ShowDate),
                 )
                 .add(
-                    settings::item::builder(&section.descriptions[show_week_numbers]).toggler(
-                        page.show_week_numbers,
-                        Message::ShowWeekNumbers,
-                    ),
+                    settings::item::builder(&section.descriptions[show_week_numbers])
+                        .toggler(page.show_week_numbers, Message::ShowWeekNumbers),
                 )
                 .apply(cosmic::Element::from)
                 .map(crate::pages::Message::DateAndTime)

--- a/cosmic-settings/src/pages/time/date.rs
+++ b/cosmic-settings/src/pages/time/date.rs
@@ -38,6 +38,7 @@ pub struct Page {
     show_seconds: bool,
     ntp_enabled: bool,
     show_date_in_top_panel: bool,
+    show_week_numbers: bool,
     timezone_context: bool,
     local_time: Option<DateTime<Gregorian>>,
     timezone: Option<usize>,
@@ -95,6 +96,16 @@ impl Default for Page {
                 true
             });
 
+        let show_week_numbers = cosmic_applet_config
+            .get("show_week_numbers")
+            .unwrap_or_else(|err| {
+                if err.is_err() {
+                    error!(?err, "Failed to read config 'show_week_numbers'");
+                }
+
+                true
+            });
+
         Self {
             entity: page::Entity::null(),
             cosmic_applet_config,
@@ -105,6 +116,7 @@ impl Default for Page {
             show_seconds,
             ntp_enabled: false,
             show_date_in_top_panel,
+            show_week_numbers,
             timezone: None,
             timezone_context: false,
             timezone_list: Vec::new(),
@@ -235,6 +247,14 @@ impl Page {
                 }
             }
 
+            Message::ShowWeekNumbers(enable) => {
+                self.show_week_numbers = enable;
+
+                if let Err(err) = self.cosmic_applet_config.set("show_week_numbers", enable) {
+                    error!(?err, "Failed to set config 'show_week_numbers'");
+                }
+            }
+
             Message::TimezoneSearch(text) => {
                 self.timezone_search = text;
             }
@@ -361,6 +381,7 @@ pub enum Message {
     FirstDayOfWeek(usize),
     Refresh(Info),
     ShowDate(bool),
+    ShowWeekNumbers(bool),
     Timezone(usize),
     TimezoneContext,
     TimezoneSearch(String),
@@ -397,6 +418,7 @@ fn format() -> Section<crate::pages::Message> {
         show_seconds = fl!("time-format", "show-seconds");
         first = fl!("time-format", "first");
         show_date = fl!("time-format", "show-date");
+        show_week_numbers = fl!("time-format", "show-week-numbers");
     });
 
     Section::default()
@@ -448,6 +470,12 @@ fn format() -> Section<crate::pages::Message> {
                 .add(
                     settings::item::builder(&section.descriptions[show_date])
                         .toggler(page.show_date_in_top_panel, Message::ShowDate),
+                )
+                .add(
+                    settings::item::builder(&section.descriptions[show_week_numbers]).toggler(
+                        page.show_week_numbers,
+                        Message::ShowWeekNumbers,
+                    ),
                 )
                 .apply(cosmic::Element::from)
                 .map(crate::pages::Message::DateAndTime)

--- a/cosmic-settings/src/pages/time/date.rs
+++ b/cosmic-settings/src/pages/time/date.rs
@@ -103,7 +103,7 @@ impl Default for Page {
                     error!(?err, "Failed to read config 'show_week_numbers'");
                 }
 
-                true
+                false
             });
 
         Self {

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -951,6 +951,7 @@ time-format = Date & time format
     .show-seconds = Show seconds
     .first = First day of week
     .show-date = Show date in the time applet
+    .show-week-numbers = Show week numbers in calendar
     .friday = Friday
     .saturday = Saturday
     .sunday = Sunday


### PR DESCRIPTION
This toggle controls a "week number" column in the cosmic-applets-time implemented in this commit: https://github.com/NicolaiSoeborg/cosmic-applets/commit/594dd5714630f9efce057634db7bbc04f65785eb / https://github.com/pop-os/cosmic-applets/pull/1429

Screenshots (dark / light theme):

(see below, first screenshot had a "cutoff" if week number column shown)

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.