### PR TITLE
fix: resolve compiler warnings about unused variables and imports

### DIFF
--- a/cosmic-settings/src/pages/applications/startup_apps.rs
+++ b/cosmic-settings/src/pages/applications/startup_apps.rs
@@ -1,7 +1,7 @@
 use cosmic::app::ContextDrawer;
 use cosmic::iced::{Alignment, Length};
 use cosmic::widget::text_input::focus;
-use cosmic::widget::{Id, button, icon, settings, text};
+use cosmic::widget::{button, icon, settings, text};
 use cosmic::{Apply, Element, Task, task, widget};
 use cosmic_settings_page::section::Entity;
 use cosmic_settings_page::{self as page, Content, Info, Section};

--- a/cosmic-settings/src/pages/desktop/appearance/font_config.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/font_config.rs
@@ -6,7 +6,6 @@ use std::sync::{Arc, LazyLock};
 use cosmic::config::{CosmicTk, FontConfig};
 use cosmic::{Apply, Element, Task, widget};
 use cosmic_config::ConfigSet;
-use mime::FONT;
 
 use crate::app;
 use crate::widget::selection_context_item;

--- a/subscriptions/network-manager/src/devices.rs
+++ b/subscriptions/network-manager/src/devices.rs
@@ -188,7 +188,7 @@ pub fn subscription<I: 'static + Hash + Copy + Send + Sync + Debug>(
             conn,
         },
         |Wrapper {
-             id,
+             id: _,
              has_popup,
              conn,
          }| {

--- a/subscriptions/network-manager/src/lib.rs
+++ b/subscriptions/network-manager/src/lib.rs
@@ -140,7 +140,7 @@ pub fn subscription<I: Copy + Debug + std::hash::Hash + 'static>(
             self.id.hash(state);
         }
     }
-    Subscription::run_with(Wrapper { id, conn }, |Wrapper { id, conn }| {
+    Subscription::run_with(Wrapper { id, conn }, |Wrapper { id: _, conn }| {
         let conn = conn.clone();
         stream::channel(
             50,


### PR DESCRIPTION
### Description
Resolves compiler warnings about unused variables and imports in `cosmic-settings` and `cosmic-settings-network-manager-subscription` crates:

- **Unused Variables**:
  - `subscriptions/network-manager/src/devices.rs`: Ignored the unused `id` field in the destructured parameter of the `Subscription::run_with` closure using `id: _`.
  - `subscriptions/network-manager/src/lib.rs`: Ignored the unused `id` field in the destructured parameter of the `Subscription::run_with` closure using `id: _`.
- **Unused Imports**:
  - `cosmic-settings/src/pages/applications/startup_apps.rs`: Removed the unused import `Id` from `cosmic::widget`.
  - `cosmic-settings/src/pages/desktop/appearance/font_config.rs`: Removed the unused import `mime::FONT`.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
