### PR TITLE
fix(default_apps): set text editor associations for application/x-zerosize

### DIFF
--- a/cosmic-settings/src/pages/applications/default_apps.rs
+++ b/cosmic-settings/src/pages/applications/default_apps.rs
@@ -231,7 +231,10 @@ impl Page {
                             "x-scheme-handler/https",
                         ],
                     ),
-                    Category::TextEditor => (DROPDOWN_TEXT_EDITOR, &["text/plain"]),
+                    Category::TextEditor => (
+                        DROPDOWN_TEXT_EDITOR,
+                        &["application/x-zerosize", "text/plain"],
+                    ),
                     Category::Mime(_mime_type) => return Task::none(),
                 };
 


### PR DESCRIPTION
When setting the default text editor, set for both so that empty files without an extension will open with the selected text editor.

Related to https://github.com/pop-os/cosmic-edit/pull/580

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

