### PR TITLE
fix(search): don't unload active page during search

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -1145,6 +1145,9 @@ impl SettingsApp {
                 }
 
                 for page in unload {
+                    if page == self.active_page {
+                        continue;
+                    }
                     self.loaded_pages.remove(&page);
                     self.pages.on_leave(page);
                 }


### PR DESCRIPTION
Fixes #2029

When searching on the Network & Wireless page, clearing the search left only the VPN entry visible. Wi-Fi and Wired entries disappeared until you clicked the sidebar item again.

The search unload loop in `search_changed()` was unloading any page not in the search results, including the page the user is currently viewing. For networking, `on_leave()` clears the device list and cancels the NetworkManager DBus subscription. `search_clear()` only resets the search text, so the page was left with empty state and no way to repopulate it.

The fix skips the active page in the unload loop. Search is an overlay, not navigation, so the active page's state and subscriptions should persist across search/clear cycles.

This also affects other pages with destructive `on_leave()` (bluetooth, display, power, etc.) which would have the same problem if searched while active.

Added regression tests in `page/src/binder.rs`:
- `search_finds_matching_sections`: verifies search matches by section description
- `search_unload_never_includes_active_page`: reproduces the unload logic and asserts the active page is not unloaded. Fails without the fix, passes with it.

Video proof: 

https://github.com/user-attachments/assets/b5aeeebe-32bb-448d-ae9f-a4b2d6be77ca



---

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

