### PR TITLE
pages/display: Fix reverting orientation changes

### DIFF
--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -913,8 +913,8 @@ impl Page {
             Some(orientation) => self.set_dialog(
                 Randr::Transform(match orientation {
                     1 => Transform::Rotate90,
-                    2 => Transform::Flipped180,
-                    3 => Transform::Flipped270,
+                    2 => Transform::Rotate180,
+                    3 => Transform::Rotate270,
                     _ => Transform::Normal,
                 }),
                 &request,


### PR DESCRIPTION
Looks like this has been wrong ever since the revert feature was introduced in https://github.com/pop-os/cosmic-settings/pull/377 :sweat_smile: 

We shouldn't use the flipped rotation values by default.
Should fix #2064.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

