### PR TITLE
window-management: add 'Raise window on focus' toggle

### DIFF
--- a/cosmic-settings/src/pages/desktop/window_management.rs
+++ b/cosmic-settings/src/pages/desktop/window_management.rs
@@ -17,6 +17,7 @@ pub enum Message {
     SuperKey(usize),
     CompConfigUpdate(Box<CosmicCompConfig>),
     SetFocusFollowsCursor(bool),
+    SetFocusFollowsCursorRaise(bool),
     SaveFocusFollowsCursorDelay(bool),
     SetFocusFollowsCursorDelay(String),
     SetCursorFollowsFocus(bool),
@@ -32,6 +33,9 @@ pub struct Page {
     pub super_key_active: Option<usize>,
     comp_config: cosmic_config::Config,
     focus_follows_cursor: bool,
+    // Whether a window focused by the cursor is also raised. Only meaningful
+    // when `focus_follows_cursor` is enabled.
+    focus_follows_cursor_raise: bool,
     focus_follows_cursor_delay: u64,
     focus_delay_text: String,
     cursor_follows_focus: bool,
@@ -49,6 +53,16 @@ impl Default for Page {
                     error!(?err, "Failed to read config 'focus_follows_cursor'");
                 }
                 false
+            });
+        // Defaults to true so that turning on focus-follows-cursor keeps the
+        // historical "focus and raise" behaviour unless the user opts out.
+        let focus_follows_cursor_raise = comp_config
+            .get("focus_follows_cursor_raise")
+            .unwrap_or_else(|err| {
+                if err.is_err() {
+                    error!(?err, "Failed to read config 'focus_follows_cursor_raise'");
+                }
+                true
             });
         let cursor_follows_focus = comp_config
             .get("cursor_follows_focus")
@@ -96,6 +110,7 @@ impl Default for Page {
             super_key_active: super_key_active_config(),
             comp_config,
             focus_follows_cursor,
+            focus_follows_cursor_raise,
             focus_follows_cursor_delay,
             focus_delay_text: format!("{focus_follows_cursor_delay}"),
             cursor_follows_focus,
@@ -127,6 +142,15 @@ impl Page {
                     .set("focus_follows_cursor", self.focus_follows_cursor)
                 {
                     error!(?err, "Failed to set config 'focus_follows_cursor'");
+                }
+            }
+            Message::SetFocusFollowsCursorRaise(value) => {
+                self.focus_follows_cursor_raise = value;
+                if let Err(err) = self.comp_config.set(
+                    "focus_follows_cursor_raise",
+                    self.focus_follows_cursor_raise,
+                ) {
+                    error!(?err, "Failed to set config 'focus_follows_cursor_raise'");
                 }
             }
             Message::SaveFocusFollowsCursorDelay(save) => {
@@ -300,6 +324,7 @@ pub fn window_controls() -> Section<crate::pages::Message> {
 pub fn focus_navigation() -> Section<crate::pages::Message> {
     crate::slab!(descriptions {
         focus_follows_cursor = fl!("focus-navigation", "focus-follows-cursor");
+        focus_follows_cursor_raise = fl!("focus-navigation", "focus-follows-cursor-raise");
         focus_follows_cursor_delay = fl!("focus-navigation", "focus-follows-cursor-delay");
         cursor_follows_focus = fl!("focus-navigation", "cursor-follows-focus");
     });
@@ -316,6 +341,15 @@ pub fn focus_navigation() -> Section<crate::pages::Message> {
                     settings::item::builder(&descriptions[focus_follows_cursor])
                         .toggler(page.focus_follows_cursor, Message::SetFocusFollowsCursor),
                 )
+                // Sub-option of focus-follows-cursor: only shown while
+                // focus-follows-cursor is on, since raising has no effect
+                // without follow-cursor focus.
+                .add_maybe(page.focus_follows_cursor.then(|| {
+                    settings::item::builder(&descriptions[focus_follows_cursor_raise]).toggler(
+                        page.focus_follows_cursor_raise,
+                        Message::SetFocusFollowsCursorRaise,
+                    )
+                }))
                 .add(settings::item(
                     &descriptions[focus_follows_cursor_delay],
                     widget::editable_input("", &page.focus_delay_text, false, |editing| {

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -508,6 +508,7 @@ window-controls = Window controls
 
 focus-navigation = Focus navigation
     .focus-follows-cursor = Focus follows cursor
+    .focus-follows-cursor-raise = Raise window on focus
     .focus-follows-cursor-delay = Focus follows cursor delay in ms
     .cursor-follows-focus = Cursor follows focus
 

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -513,6 +513,7 @@ window-controls = Window controls
 
 focus-navigation = Focus navigation
     .focus-follows-cursor = Focus follows cursor
+    .focus-follows-cursor-raise = Raise window on focus
     .focus-follows-cursor-delay = Focus follows cursor delay in ms
     .cursor-follows-focus = Cursor follows focus
 


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Addresses pop-os/cosmic-comp#863.

## Summary

Adds a "Raise window on focus" toggle to Settings → Window Management → Focus
navigation. It controls the compositor option `focus_follows_cursor_raise`, which
lets focus-follows-cursor move focus without also raising the window ("sloppy
focus").

The toggle sits directly under "Focus follows cursor" and is only shown while
focus-follows-cursor is enabled, since raising has no effect without follow-cursor
focus.

## Relationship to cosmic-comp

This pairs with the compositor change that adds the `focus_follows_cursor_raise`
option (pop-os/cosmic-comp#2612). The two are only loosely coupled: this page
reads and writes the raw config key via `comp_config.get/set("focus_follows_cursor_raise")`,
exactly like the existing `focus_follows_cursor` toggle, so it does **not** depend
on the `cosmic-comp-config` crate carrying the new field and compiles against
current `cosmic-comp-config` as-is.

## Implementation

Mirrors the existing focus-navigation toggles:
- New `Message::SetFocusFollowsCursorRaise(bool)`.
- New `Page` field read on load (default `true`, matching the compositor default so
  existing behaviour is preserved) and written on toggle.
- The row is added with `section.add_maybe(...)`, gated on `focus_follows_cursor`,
  so it appears only when focus-follows-cursor is on. (A disabled/greyed toggle was
  the first instinct, but COSMIC's `toggler` does not render a disabled switch
  state, so a gated toggle would look identical to an enabled one; hiding the row
  is unambiguous.)
- New i18n string `focus-navigation.focus-follows-cursor-raise = "Raise window on focus"`.

## Testing

- `cargo build` is clean; the changed file produces no warnings; `cargo fmt` clean.
- Verified in a running settings window: the toggle appears under "Focus follows
  cursor" only when that is enabled, and toggling it writes `focus_follows_cursor_raise`,
  which a compositor with the paired change picks up live.

Screenshots can be added if useful.

