### PR TITLE
fix: preserve content when rebuilding appearance drawer

### DIFF
--- a/cosmic-settings/src/pages/desktop/appearance/drawer.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/drawer.rs
@@ -153,6 +153,16 @@ impl Content {
         }
     }
 
+    pub fn preserve_from(&mut self, previous: &mut Content) {
+        self.font_config
+            .take_families_from(&mut previous.font_config);
+
+        self.icons_fetched = previous.icons_fetched;
+        self.icon_theme_active = previous.icon_theme_active;
+        self.icon_themes = std::mem::take(&mut previous.icon_themes);
+        self.icon_handles = std::mem::take(&mut previous.icon_handles);
+    }
+
     pub fn update_font(
         &mut self,
         message: FontMessage,

--- a/cosmic-settings/src/pages/desktop/appearance/font_config.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/font_config.rs
@@ -94,6 +94,11 @@ impl Model {
         self.font_filter.clear();
     }
 
+    pub fn take_families_from(&mut self, other: &mut Model) {
+        self.interface_font_families = std::mem::take(&mut other.interface_font_families);
+        self.monospace_font_families = std::mem::take(&mut other.monospace_font_families);
+    }
+
     pub fn font_loaded(
         &mut self,
         mono: Vec<Arc<str>>,

--- a/cosmic-settings/src/pages/desktop/appearance/mod.rs
+++ b/cosmic-settings/src/pages/desktop/appearance/mod.rs
@@ -200,7 +200,9 @@ impl Page {
 
             Message::DrawerOpen(context_view) => {
                 self.context_view = Some(context_view);
-                self.drawer = drawer::Content::from(&self.theme_manager);
+                let mut previous =
+                    std::mem::replace(&mut self.drawer, drawer::Content::from(&self.theme_manager));
+                self.drawer.preserve_from(&mut previous);
                 tasks.push(cosmic::task::message(
                     crate::app::Message::OpenContextDrawer(self.entity),
                 ));


### PR DESCRIPTION
We only build the fonts list once at the start, looks like in the process of implementing frosted glass we added something to rebuild the drawer from scratch which clears the fonts list.
Instead of rebuilding the fonts list, I thought maybe we just keep it and pass it along.

Fixes https://github.com/pop-os/cosmic-settings/issues/2079

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

