### PR TITLE
network hub: gate first paint until devices arrive

### DIFF
--- a/cosmic-settings/src/pages/networking/mod.rs
+++ b/cosmic-settings/src/pages/networking/mod.rs
@@ -28,6 +28,9 @@ pub struct Page {
     entity: page::Entity,
     nm_task: Option<tokio::sync::oneshot::Sender<()>>,
     devices: Vec<Arc<network_manager::devices::DeviceInfo>>,
+    /// First device list has arrived (or was cached). Avoids painting VPN
+    /// alone then inserting Wi‑Fi/Wired above (layout shift).
+    devices_ready: bool,
     vpn: page::Entity,
     wifi: page::Entity,
     wired: page::Entity,
@@ -92,6 +95,22 @@ impl page::Page<crate::pages::Message> for Page {
         let device_list = Section::default().descriptions(descriptions).view::<Self>(
             move |_binder, page, section| {
                 let descs = &section.descriptions;
+
+                // Wait for the first NM device snapshot so Wi‑Fi/Wired and VPN
+                // rows paint together (no insert-above shift).
+                if !page.devices_ready {
+                    let loading = widget::column::with_capacity(1)
+                        .push(
+                            widget::settings::section().add(
+                                widget::settings::item_row(vec![
+                                    widget::text::body(fl!("network-and-wireless", "loading"))
+                                        .into(),
+                                ]),
+                            ),
+                        )
+                        .spacing(cosmic::theme::active().cosmic().spacing.space_s);
+                    return Element::from(loading).map(crate::pages::Message::Networking);
+                }
 
                 let multiple_wifi_adapters = page
                     .devices
@@ -242,8 +261,8 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn on_leave(&mut self) -> Task<crate::pages::Message> {
-        self.devices = Vec::new();
-
+        // Keep devices + devices_ready cached so re-opening the hub does not
+        // flash VPN alone and then re-insert Wi‑Fi/Wired.
         if let Some(cancel) = self.nm_task.take() {
             _ = cancel.send(());
         }
@@ -306,6 +325,7 @@ impl Page {
 
             Message::UpdateDevices(devices) => {
                 self.devices = devices;
+                self.devices_ready = true;
             }
         }
 

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -146,6 +146,7 @@ disconnect = Disconnect
 forget = Forget
 known-networks = Known networks
 network-and-wireless = Network & wireless
+    .loading = Loading network devices…
 network-name = Network Name
 no-networks = No networks have been found.
 no-vpn = No VPN connections available.


### PR DESCRIPTION
## Summary
Wait for the first device list before painting Network & wireless hub rows. Cache devices when leaving the hub.

## Why
Without a gate, Wi‑Fi/Wired rows jump in above VPN as devices stream in (noticed during mobile-data dogfood).

## Note
Slightly changes stock hub open timing (loader until first list). Prefer that over thrash; open to skeleton rows if you want.

Independent of the modem backend PR (#2094). Related design: #2093.

## Test
- [ ] `just check`
- [ ] Open Network & wireless twice — no row jump

Refs: https://github.com/pop-os/cosmic-settings/issues/2093

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the DCO and certify my contribution under its conditions.