### PR TITLE
Mobile data page: session toggle, dual-SIM recovery, modem info

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -108,6 +108,8 @@ impl SettingsApp {
             PageCommands::Mouse => self.pages.page_id::<input::mouse::Page>(),
             #[cfg(feature = "page-networking")]
             PageCommands::Network => self.pages.page_id::<networking::Page>(),
+            #[cfg(feature = "page-networking")]
+            PageCommands::Mobile => self.pages.page_id::<networking::mobile::Page>(),
             #[cfg(feature = "wayland")]
             PageCommands::Panel => self.pages.page_id::<desktop::panel::Page>(),
             #[cfg(feature = "wayland")]
@@ -678,6 +680,13 @@ impl cosmic::Application for SettingsApp {
                 #[cfg(feature = "page-networking")]
                 crate::pages::Message::Wired(message) => {
                     if let Some(page) = self.pages.page_mut::<networking::wired::Page>() {
+                        return page.update(message).map(Into::into);
+                    }
+                }
+
+                #[cfg(feature = "page-networking")]
+                crate::pages::Message::Mobile(message) => {
+                    if let Some(page) = self.pages.page_mut::<networking::mobile::Page>() {
                         return page.update(message).map(Into::into);
                     }
                 }

--- a/cosmic-settings/src/main.rs
+++ b/cosmic-settings/src/main.rs
@@ -113,6 +113,9 @@ pub enum PageCommands {
     /// Network settings page
     #[cfg(feature = "page-networking")]
     Network,
+    /// Mobile data settings page
+    #[cfg(feature = "page-networking")]
+    Mobile,
     /// Panel settings page
     #[cfg(feature = "wayland")]
     Panel,

--- a/cosmic-settings/src/pages/mod.rs
+++ b/cosmic-settings/src/pages/mod.rs
@@ -103,6 +103,8 @@ pub enum Message {
     WindowManagement(desktop::window_management::Message),
     #[cfg(feature = "page-networking")]
     Wired(networking::wired::Message),
+    #[cfg(feature = "page-networking")]
+    Mobile(networking::mobile::Message),
     #[cfg(feature = "page-workspaces")]
     Workspaces(desktop::workspaces::Message),
 

--- a/cosmic-settings/src/pages/networking/backend.rs
+++ b/cosmic-settings/src/pages/networking/backend.rs
@@ -148,14 +148,19 @@ pub mod current_networks {
             name: String,
             ip_addresses: Vec<Ipv4Addr>,
         },
+        Mobile {
+            name: String,
+            ip_addresses: Vec<Ipv4Addr>,
+        },
     }
 
     impl ActiveConnectionInfo {
         pub fn name(&self) -> String {
             match self {
-                Self::Wired { name, .. } | Self::WiFi { name, .. } | Self::Vpn { name, .. } => {
-                    name.clone()
-                }
+                Self::Wired { name, .. }
+                | Self::WiFi { name, .. }
+                | Self::Vpn { name, .. }
+                | Self::Mobile { name, .. } => name.clone(),
             }
         }
     }
@@ -178,6 +183,8 @@ pub mod devices {
         Bluetooth,
         Vlan,
         WireGuard,
+        /// NM_DEVICE_TYPE_MODEM (GSM/CDMA/LTE WWAN). nmrs exposes this as Other(8).
+        Modem,
         Other(u32),
     }
 
@@ -190,6 +197,7 @@ pub mod devices {
                 nmrs::DeviceType::Loopback => Self::Loopback,
                 nmrs::DeviceType::Bluetooth => Self::Bluetooth,
                 nmrs::DeviceType::Vlan => Self::Vlan,
+                nmrs::DeviceType::Other(8) => Self::Modem,
                 nmrs::DeviceType::Other(v) => Self::Other(v),
                 _ => Self::Other(0),
             }
@@ -1168,6 +1176,17 @@ fn active_connection_infos(
                 name: vpn.id,
                 ip_addresses: parse_ipv4_list([vpn.ip4_address]),
             }),
+            ActiveConnection::Other(other)
+                if other
+                    .connection_type
+                    .as_deref()
+                    .is_some_and(|ty| ty == "gsm" || ty == "cdma") =>
+            {
+                Some(current_networks::ActiveConnectionInfo::Mobile {
+                    name: other.id,
+                    ip_addresses: parse_ipv4_list([other.ip4_address]),
+                })
+            }
             ActiveConnection::Other(_) => None,
             _ => None,
         })
@@ -1178,6 +1197,7 @@ fn active_connection_infos(
             current_networks::ActiveConnectionInfo::Vpn { name, .. } => format!("0{name}"),
             current_networks::ActiveConnectionInfo::Wired { name, .. } => format!("1{name}"),
             current_networks::ActiveConnectionInfo::WiFi { name, .. } => format!("2{name}"),
+            current_networks::ActiveConnectionInfo::Mobile { name, .. } => format!("3{name}"),
         };
         helper(a).cmp(&helper(b))
     });
@@ -1246,6 +1266,9 @@ fn saved_matches_device(
         devices::DeviceType::Ethernet => connection.connection_type == "802-3-ethernet",
         devices::DeviceType::Wifi => connection.connection_type == "802-11-wireless",
         devices::DeviceType::WireGuard => connection.connection_type == "wireguard",
+        devices::DeviceType::Modem => {
+            connection.connection_type == "gsm" || connection.connection_type == "cdma"
+        }
         _ => false,
     };
 
@@ -1253,7 +1276,7 @@ fn saved_matches_device(
         && connection
             .interface_name
             .as_deref()
-            .is_none_or(|name| name == interface)
+            .is_none_or(|name| name.is_empty() || name == interface)
 }
 
 fn active_connection_by_interface(
@@ -1284,6 +1307,20 @@ fn active_connection_by_interface(
                     id: vpn.id.clone(),
                     uuid: vpn.uuid.clone(),
                     state: devices::ActiveConnectionState::from(vpn.state),
+                });
+            }
+            ActiveConnection::Other(other)
+                if other.interface.as_deref() == Some(interface)
+                    && other
+                        .connection_type
+                        .as_deref()
+                        .is_some_and(|ty| ty == "gsm" || ty == "cdma") =>
+            {
+                return Some(ActiveConnectionRecord {
+                    path: slash_path(),
+                    id: other.id.clone(),
+                    uuid: other.uuid.clone(),
+                    state: devices::ActiveConnectionState::from(other.state),
                 });
             }
             _ => {}

--- a/cosmic-settings/src/pages/networking/mobile.rs
+++ b/cosmic-settings/src/pages/networking/mobile.rs
@@ -1,0 +1,978 @@
+// SPDX-FileCopyrightText: 2026 erik-balfe
+// SPDX-License-Identifier: GPL-3.0-only
+//
+// Mobile data page (Slice A): toggle, dual-SIM slot recovery, status.
+
+use std::sync::Arc;
+
+use anyhow::Context;
+ 
+use cosmic::widget::{self, icon};
+use cosmic::widget::space::horizontal as horizontal_space;
+use cosmic::{Apply, Element, Task};
+use cosmic_settings_page::{self as page, Section, section};
+use futures::{SinkExt, StreamExt};
+use zbus::zvariant::{ObjectPath, OwnedObjectPath};
+
+use super::backend as network_manager;
+use super::backend::NetworkManagerState;
+use super::backend::current_networks::ActiveConnectionInfo;
+use super::backend::devices::DeviceState;
+use super::nm_edit_connection;
+
+pub type ConnectionId = Arc<str>;
+
+#[derive(Clone, Debug)]
+pub enum Message {
+    Activate,
+    Deactivate,
+    CancelDialog,
+    Error(String),
+    NetworkManager(network_manager::Event),
+    NetworkManagerConnect(nmrs::NetworkManager),
+    Refresh,
+    RemoveProfileRequest(ConnectionId),
+    RemoveProfile(ConnectionId),
+    SelectDevice(Arc<network_manager::devices::DeviceInfo>),
+    Settings(ConnectionId),
+    SetPrimarySimSlot(u32),
+    SlotReady(ModemSnapshot),
+    UpdateState(NetworkManagerState),
+    UpdateDevices(Vec<network_manager::devices::DeviceInfo>),
+    UpdateModem(ModemSnapshot),
+}
+
+impl From<Message> for crate::app::Message {
+    fn from(message: Message) -> Self {
+        crate::pages::Message::Mobile(message).into()
+    }
+}
+
+impl From<Message> for crate::pages::Message {
+    fn from(message: Message) -> Self {
+        crate::pages::Message::Mobile(message)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ModemSnapshot {
+    pub present: bool,
+    pub path: String,
+    pub state_failed_reason: String,
+    pub operator: String,
+    pub access_tech: String,
+    pub signal_percent: Option<u32>,
+    pub imei: String,
+    pub model: String,
+    pub primary_sim_slot: u32,
+    pub slots_with_sim: Vec<u32>,
+    pub active_slot_has_sim: bool,
+    pub active_sim_label: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum MobileDialog {
+    RemoveProfile(ConnectionId),
+}
+
+#[derive(Debug, Default)]
+pub struct Page {
+    entity: page::Entity,
+    nm_task: Option<tokio::sync::oneshot::Sender<()>>,
+    nm_state: Option<NmState>,
+    dialog: Option<MobileDialog>,
+    active_device: Option<Arc<network_manager::devices::DeviceInfo>>,
+    modem: ModemSnapshot,
+    busy: bool,
+    status_message: Option<String>,
+    /// First NM device list received (may be empty — still counts).
+    devices_loaded: bool,
+    /// First ModemManager snapshot received.
+    modem_loaded: bool,
+}
+
+#[derive(Debug)]
+pub struct NmState {
+    conn: nmrs::NetworkManager,
+    sender: futures::channel::mpsc::UnboundedSender<network_manager::Request>,
+    active_conns: Vec<ActiveConnectionInfo>,
+    devices: Vec<Arc<network_manager::devices::DeviceInfo>>,
+    airplane_mode: bool,
+}
+
+impl page::AutoBind<crate::pages::Message> for Page {}
+
+impl page::Page<crate::pages::Message> for Page {
+    fn set_id(&mut self, entity: page::Entity) {
+        self.entity = entity;
+    }
+
+    fn info(&self) -> cosmic_settings_page::Info {
+        page::Info::new("mobile", "network-cellular-symbolic")
+            .title(fl!("mobile-data"))
+            .description(fl!("xdg-entry-mobile-comment"))
+    }
+
+    fn content(
+        &self,
+        sections: &mut slotmap::SlotMap<section::Entity, Section<crate::pages::Message>>,
+    ) -> Option<page::Content> {
+        Some(vec![sections.insert(mobile_view())])
+    }
+
+    fn dialog(&'_ self) -> Option<Element<'_, crate::pages::Message>> {
+        self.dialog.as_ref().map(|dialog| match dialog {
+            MobileDialog::RemoveProfile(uuid) => {
+                let primary_action = widget::button::destructive(fl!("remove"))
+                    .on_press(Message::RemoveProfile(uuid.clone()));
+                let secondary_action =
+                    widget::button::standard(fl!("cancel")).on_press(Message::CancelDialog);
+
+                widget::dialog()
+                    .title(fl!("remove-connection-dialog"))
+                    .icon(icon::from_name("dialog-information").size(64))
+                    .body(fl!("remove-connection-dialog", "mobile-description"))
+                    .primary_action(primary_action)
+                    .secondary_action(secondary_action)
+                    .apply(Element::from)
+                    .map(crate::pages::Message::Mobile)
+            }
+        })
+    }
+
+    fn on_enter(&mut self) -> cosmic::Task<crate::pages::Message> {
+        if self.nm_task.is_none() {
+            return cosmic::Task::future(async move {
+                nmrs::NetworkManager::new()
+                    .await
+                    .context("failed to connect to NetworkManager")
+                    .map_or_else(
+                        |why| Message::Error(why.to_string()),
+                        Message::NetworkManagerConnect,
+                    )
+                    .apply(crate::pages::Message::Mobile)
+            });
+        }
+
+        Task::none()
+    }
+
+    fn on_leave(&mut self) -> Task<crate::pages::Message> {
+        // Keep modem snapshot + ready flags so re-open does not flash
+        // "No modem" → real content. Drop live NM sender only.
+        self.nm_state = None;
+        self.busy = false;
+        self.status_message = None;
+
+        if let Some(cancel) = self.nm_task.take() {
+            _ = cancel.send(());
+        }
+
+        Task::none()
+    }
+}
+
+impl Page {
+    fn page_ready(&self) -> bool {
+        self.devices_loaded && self.modem_loaded
+    }
+
+    pub fn update(&mut self, message: Message) -> Task<crate::app::Message> {
+        match message {
+            Message::NetworkManager(network_manager::Event::RequestResponse {
+                req,
+                state,
+                success,
+            }) => {
+                if !success {
+                    tracing::error!(request = ?req, "network-manager request failed");
+                    self.status_message = Some(fl!("mobile-data", "activate-failed"));
+                }
+                self.busy = false;
+                if let Some(NmState { ref conn, .. }) = self.nm_state {
+                    let conn = conn.clone();
+                    self.update_active_conns(state);
+                    return cosmic::Task::batch(vec![
+                        update_devices(conn.clone()),
+                        refresh_modem(),
+                    ]);
+                }
+            }
+
+            Message::UpdateDevices(devices) => {
+                self.update_devices(devices);
+                self.devices_loaded = true;
+            }
+
+            Message::UpdateState(state) => {
+                self.update_active_conns(state);
+            }
+
+            Message::UpdateModem(modem) => {
+                self.modem = modem;
+                self.modem_loaded = true;
+                self.busy = false;
+            }
+
+            Message::SelectDevice(device) => {
+                self.active_device = Some(device);
+            }
+
+            Message::NetworkManager(
+                network_manager::Event::ActiveConns | network_manager::Event::Devices,
+            ) => {
+                if let Some(NmState { ref conn, .. }) = self.nm_state {
+                    return cosmic::Task::batch(vec![
+                        update_state(conn.clone()),
+                        update_devices(conn.clone()),
+                        refresh_modem(),
+                    ]);
+                }
+            }
+
+            Message::NetworkManager(network_manager::Event::Init {
+                conn,
+                sender,
+                state,
+            }) => {
+                self.nm_state = Some(NmState {
+                    conn: conn.clone(),
+                    sender,
+                    devices: Vec::new(),
+                    airplane_mode: state.airplane_mode,
+                    active_conns: state
+                        .active_conns
+                        .into_iter()
+                        .filter(|info| matches!(info, ActiveConnectionInfo::Mobile { .. }))
+                        .collect(),
+                });
+
+                return cosmic::Task::batch(vec![update_devices(conn), refresh_modem()]);
+            }
+
+            Message::NetworkManager(_event) => {}
+
+            Message::Activate => {
+                return self.activate_mobile();
+            }
+
+            Message::Deactivate => {
+                if let Some(uuid) = self.active_mobile_uuid() {
+                    self.busy = true;
+                    if let Some(NmState { ref sender, .. }) = self.nm_state {
+                        _ = sender.unbounded_send(network_manager::Request::Deactivate(uuid));
+                    }
+                }
+            }
+
+            Message::RemoveProfileRequest(uuid) => {
+                self.dialog = Some(MobileDialog::RemoveProfile(uuid));
+            }
+
+            Message::RemoveProfile(uuid) => {
+                self.dialog = None;
+                if let Some(NmState { ref sender, .. }) = self.nm_state {
+                    _ = sender.unbounded_send(network_manager::Request::Remove(uuid));
+                }
+                if let Some(NmState { ref conn, .. }) = self.nm_state {
+                    return cosmic::Task::batch(vec![
+                        update_state(conn.clone()),
+                        update_devices(conn.clone()),
+                    ]);
+                }
+            }
+
+            Message::Settings(uuid) => {
+                return cosmic::task::future(async move {
+                    _ = nm_edit_connection(uuid.as_ref()).await;
+                    Message::Refresh
+                });
+            }
+
+            Message::SetPrimarySimSlot(slot) => {
+                self.busy = true;
+                self.status_message = Some(fl!("mobile-data", "switching-sim"));
+                let modem_path = self.modem.path.clone();
+                let conn = self.nm_state.as_ref().map(|s| s.conn.clone());
+                return cosmic::task::future(async move {
+                    match set_primary_sim_slot(&modem_path, slot).await {
+                        Ok(()) => {
+                            for _ in 0..30 {
+                                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                                let snap = modem_snapshot().await.unwrap_or_default();
+                                let nm_ready = if let Some(ref nm) = conn {
+                                    modem_nm_ready(nm).await
+                                } else {
+                                    snap.active_slot_has_sim
+                                };
+                                if snap.active_slot_has_sim && nm_ready {
+                                    return Message::SlotReady(snap);
+                                }
+                            }
+                            match modem_snapshot().await {
+                                Ok(s) if s.active_slot_has_sim => Message::SlotReady(s),
+                                Ok(s) => Message::UpdateModem(s),
+                                Err(why) => Message::Error(why),
+                            }
+                        }
+                        Err(why) => Message::Error(why),
+                    }
+                });
+            }
+
+            Message::SlotReady(snap) => {
+                self.modem = snap;
+                self.busy = false;
+                self.status_message = Some(fl!("mobile-data", "slot-ready"));
+                return self.activate_mobile();
+            }
+
+            Message::Refresh => {
+                if let Some(NmState { ref conn, .. }) = self.nm_state {
+                    return cosmic::Task::batch(vec![
+                        update_state(conn.clone()),
+                        update_devices(conn.clone()),
+                        refresh_modem(),
+                    ]);
+                }
+            }
+
+            Message::CancelDialog => {
+                self.dialog = None;
+            }
+
+            Message::Error(why) => {
+                tracing::error!(why);
+                self.busy = false;
+                self.status_message = Some(why);
+                // Don't trap the page on an infinite loader if MM/NM fails once.
+                self.devices_loaded = true;
+                self.modem_loaded = true;
+            }
+
+            Message::NetworkManagerConnect(conn) => {
+                return self.connect(conn);
+            }
+        }
+
+        Task::none()
+    }
+
+    fn connect(&mut self, conn: nmrs::NetworkManager) -> Task<crate::app::Message> {
+        if self.nm_task.is_none() {
+            let (canceller, task) =
+                crate::utils::forward_event_loop(move |mut sender| async move {
+                    let (tx, mut rx) = futures::channel::mpsc::channel(1);
+
+                    let watchers = std::pin::pin!(async move {
+                        network_manager::watch(conn, tx).await;
+                    });
+
+                    let forwarder = std::pin::pin!(async move {
+                        while let Some(message) = rx.next().await {
+                            _ = sender
+                                .send(crate::pages::Message::Mobile(Message::NetworkManager(
+                                    message,
+                                )))
+                                .await;
+                        }
+                    });
+
+                    futures::future::select(watchers, forwarder).await;
+                });
+
+            self.nm_task = Some(canceller);
+            return task.map(crate::app::Message::from);
+        }
+
+        Task::none()
+    }
+
+    fn update_devices(&mut self, devices: Vec<network_manager::devices::DeviceInfo>) {
+        if let Some(ref mut nm_state) = self.nm_state {
+            let devices: Vec<_> = devices.into_iter().map(Arc::new).collect();
+            nm_state.devices = devices;
+            if self.active_device.is_none() {
+                if let Some(first) = nm_state.devices.first() {
+                    self.active_device = Some(Arc::clone(first));
+                }
+            } else if let Some(active) = self.active_device.as_ref() {
+                self.active_device = nm_state
+                    .devices
+                    .iter()
+                    .find(|d| d.path == active.path)
+                    .map(Arc::clone);
+            }
+        }
+    }
+
+    fn update_active_conns(&mut self, state: NetworkManagerState) {
+        if let Some(ref mut nm_state) = self.nm_state {
+            nm_state.airplane_mode = state.airplane_mode;
+            nm_state.active_conns = state
+                .active_conns
+                .into_iter()
+                .filter(|info| matches!(info, ActiveConnectionInfo::Mobile { .. }))
+                .collect();
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.nm_state
+            .as_ref()
+            .is_some_and(|s| !s.active_conns.is_empty())
+            || self
+                .active_device
+                .as_ref()
+                .and_then(|d| d.active_connection.as_ref())
+                .is_some_and(|(_, st)| {
+                    matches!(
+                        st,
+                        network_manager::devices::ActiveConnectionState::Activated
+                            | network_manager::devices::ActiveConnectionState::Activating
+                    )
+                })
+    }
+
+    fn active_mobile_uuid(&self) -> Option<ConnectionId> {
+        let device = self.active_device.as_ref()?;
+        device
+            .active_connection
+            .as_ref()
+            .map(|(c, _)| c.uuid.clone())
+    }
+
+    fn preferred_profile(&self) -> Option<&network_manager::devices::KnownDeviceConnection> {
+        let device = self.active_device.as_ref()?;
+        device
+            .known_connections
+            .iter()
+            .find(|c| c.id == "mobile")
+            .or_else(|| device.known_connections.first())
+    }
+
+    fn activate_mobile(&mut self) -> Task<crate::app::Message> {
+        let Some(nm_state) = self.nm_state.as_ref() else {
+            return Task::none();
+        };
+        let Some(device) = self.active_device.as_ref() else {
+            self.status_message = Some(fl!("mobile-data", "no-modem"));
+            return Task::none();
+        };
+
+        if nm_state.airplane_mode {
+            self.status_message = Some(fl!("mobile-data", "airplane"));
+            return Task::none();
+        }
+
+        if !self.modem.active_slot_has_sim {
+            if let Some(slot) = self
+                .modem
+                .slots_with_sim
+                .iter()
+                .copied()
+                .find(|s| *s != self.modem.primary_sim_slot)
+            {
+                self.status_message = Some(fl!("mobile-data", "sim-other-slot", slot = slot));
+            } else {
+                self.status_message = Some(fl!("mobile-data", "no-sim"));
+            }
+            return Task::none();
+        }
+
+        if matches!(
+            device.state,
+            DeviceState::Unavailable | DeviceState::Unmanaged
+        ) {
+            self.status_message = Some(fl!("mobile-data", "device-unavailable"));
+            return Task::none();
+        }
+
+        let preferred = self.preferred_profile();
+        let preferred_uuid = preferred.map(|p| p.uuid.clone());
+        let preferred_id = preferred.map(|p| p.id.clone());
+
+        if let Some(conn) = device.available_connections.iter().find(|c| {
+            preferred_uuid
+                .as_ref()
+                .is_some_and(|u| c.uuid.as_ref() == u.as_ref())
+                || preferred_id.as_ref().is_some_and(|id| c.id == *id)
+                || c.id == "mobile"
+        }) {
+            self.busy = true;
+            _ = nm_state
+                .sender
+                .unbounded_send(network_manager::Request::Activate(
+                    device.path.clone(),
+                    conn.path.clone(),
+                ));
+            return Task::none();
+        }
+
+        self.status_message = Some(fl!("mobile-data", "no-profile"));
+        Task::none()
+    }
+}
+
+fn mobile_view() -> Section<crate::pages::Message> {
+    Section::default().view::<Page>(move |_binder, page, _section| {
+        let spacing = cosmic::theme::spacing();
+
+        // Gate content until first NM + MM snapshots — no "no modem" flash then jump.
+        if !page.page_ready() {
+            return widget::column::with_capacity(1)
+                .push(widget::settings::section().add(widget::settings::item_row(vec![
+                    widget::text::body(fl!("mobile-data", "loading")).into(),
+                ])))
+                .spacing(spacing.space_m)
+                .apply(Element::from)
+                .map(crate::pages::Message::Mobile);
+        }
+
+        let mut column = widget::column::with_capacity(8).spacing(spacing.space_m);
+
+        if let Some(msg) = page.status_message.as_ref() {
+            column = column.push(widget::text::body(msg.clone()));
+        }
+
+        // MM dual-SIM / no-SIM banners are independent of whether NM currently
+        // lists a gsm device (Unavailable while empty eSIM is primary).
+        if page.nm_state.as_ref().is_some_and(|s| s.airplane_mode) {
+            column = column.push(banner(fl!("mobile-data", "airplane")));
+        } else if !page.modem.present
+            && page.nm_state.as_ref().is_none_or(|s| s.devices.is_empty())
+        {
+            column = column.push(banner(fl!("mobile-data", "no-modem")));
+        } else if page.modem.present && !page.modem.active_slot_has_sim {
+            if let Some(slot) = page
+                .modem
+                .slots_with_sim
+                .iter()
+                .copied()
+                .find(|s| *s != page.modem.primary_sim_slot)
+            {
+                let hint = if page.modem.state_failed_reason == "esim-without-profiles" {
+                    fl!("mobile-data", "esim-empty-use-physical", slot = slot)
+                } else {
+                    fl!("mobile-data", "sim-other-slot", slot = slot)
+                };
+                column = column.push(
+                    widget::settings::section().add(widget::settings::item_row(vec![
+                        widget::text::body(hint).into(),
+                        horizontal_space().into(),
+                        widget::button::suggested(fl!("mobile-data", "use-slot", slot = slot))
+                            .on_press_maybe(
+                                (!page.busy).then_some(Message::SetPrimarySimSlot(slot)),
+                            )
+                            .into(),
+                    ])),
+                );
+            } else {
+                column = column.push(banner(fl!("mobile-data", "no-sim")));
+            }
+        }
+
+        let connected = page.is_connected();
+        let can_toggle = page.nm_state.as_ref().is_some_and(|s| !s.devices.is_empty())
+            && page.modem.active_slot_has_sim
+            && !page.nm_state.as_ref().is_some_and(|s| s.airplane_mode)
+            && !page.busy;
+
+        let toggle = {
+            let t = widget::toggler(connected);
+            if can_toggle {
+                t.on_toggle(|enable: bool| {
+                    if enable {
+                        Message::Activate
+                    } else {
+                        Message::Deactivate
+                    }
+                })
+            } else {
+                t
+            }
+        };
+
+        let status_label = if page.busy {
+            fl!("mobile-data", "working")
+        } else if connected {
+            fl!("connected")
+        } else {
+            fl!("network-device-state", "disconnected")
+        };
+
+        column = column.push(widget::settings::section().add(widget::settings::item_row(vec![
+            widget::column::with_capacity(2)
+                .push(widget::text::body(fl!("mobile-data")))
+                .push(widget::text::caption(status_label))
+                .into(),
+            horizontal_space().into(),
+            toggle.into(),
+        ])));
+
+        // Modem details
+        if page.modem.present {
+            let mut details = widget::settings::section().title(fl!("mobile-data", "details"));
+            if !page.modem.operator.is_empty() {
+                details = details.add(widget::settings::item(
+                    fl!("mobile-data", "operator"),
+                    widget::text::body(page.modem.operator.clone()),
+                ));
+            }
+            if !page.modem.access_tech.is_empty() {
+                details = details.add(widget::settings::item(
+                    fl!("mobile-data", "technology"),
+                    widget::text::body(page.modem.access_tech.clone()),
+                ));
+            }
+            if let Some(sig) = page.modem.signal_percent {
+                details = details.add(widget::settings::item(
+                    fl!("mobile-data", "signal"),
+                    widget::text::body(format!("{sig}%")),
+                ));
+            }
+            if !page.modem.active_sim_label.is_empty() {
+                details = details.add(widget::settings::item(
+                    fl!("mobile-data", "sim"),
+                    widget::text::body(page.modem.active_sim_label.clone()),
+                ));
+            }
+            if !page.modem.imei.is_empty() {
+                details = details.add(widget::settings::item(
+                    fl!("mobile-data", "imei"),
+                    widget::text::body(page.modem.imei.clone()),
+                ));
+            }
+            if !page.modem.model.is_empty() {
+                details = details.add(widget::settings::item(
+                    fl!("mobile-data", "model"),
+                    widget::text::body(page.modem.model.clone()),
+                ));
+            }
+            column = column.push(details);
+        }
+
+        // Profile actions
+        if let Some(profile) = page.preferred_profile() {
+            let uuid = profile.uuid.clone();
+            column = column.push(
+                widget::settings::section()
+                    .title(fl!("mobile-data", "profile"))
+                    .add(widget::settings::item(
+                        profile.id.clone(),
+                        widget::row::with_capacity(2)
+                            .spacing(spacing.space_s)
+                            .push(
+                                widget::button::standard(fl!("settings"))
+                                    .on_press(Message::Settings(uuid.clone())),
+                            )
+                            .push(
+                                widget::button::destructive(fl!("remove"))
+                                    .on_press(Message::RemoveProfileRequest(uuid)),
+                            ),
+                    )),
+            );
+        }
+
+        column
+            .apply(Element::from)
+            .map(crate::pages::Message::Mobile)
+    })
+}
+
+fn banner(text: String) -> Element<'static, Message> {
+    widget::settings::section()
+        .add(widget::text::body(text))
+        .into()
+}
+
+fn update_state(conn: nmrs::NetworkManager) -> Task<crate::app::Message> {
+    cosmic::task::future(async move {
+        match NetworkManagerState::new(&conn).await {
+            Ok(state) => Message::UpdateState(state),
+            Err(why) => Message::Error(why.to_string()),
+        }
+    })
+}
+
+fn update_devices(conn: nmrs::NetworkManager) -> Task<crate::app::Message> {
+    cosmic::task::future(async move {
+        let filter =
+            |device_type| matches!(device_type, network_manager::devices::DeviceType::Modem);
+
+        match network_manager::devices::list(&conn, filter).await {
+            Ok(devices) => Message::UpdateDevices(devices),
+            Err(why) => Message::Error(why.to_string()),
+        }
+    })
+}
+
+fn refresh_modem() -> Task<crate::app::Message> {
+    cosmic::task::future(async move {
+        match modem_snapshot().await {
+            Ok(s) => Message::UpdateModem(s),
+            Err(why) => Message::Error(why),
+        }
+    })
+}
+
+async fn modem_nm_ready(nm: &nmrs::NetworkManager) -> bool {
+    let filter =
+        |device_type| matches!(device_type, network_manager::devices::DeviceType::Modem);
+    match network_manager::devices::list(nm, filter).await {
+        Ok(devices) => devices.iter().any(|d| {
+            !matches!(
+                d.state,
+                DeviceState::Unavailable | DeviceState::Unmanaged | DeviceState::Unknown
+            )
+        }),
+        Err(_) => false,
+    }
+}
+
+async fn set_primary_sim_slot(modem_path: &str, slot: u32) -> Result<(), String> {
+    if modem_path.is_empty() {
+        return Err(fl!("mobile-data", "no-modem"));
+    }
+
+    let conn = zbus::Connection::system()
+        .await
+        .map_err(|e| e.to_string())?;
+    let path = ObjectPath::try_from(modem_path.to_string()).map_err(|e| e.to_string())?;
+    let proxy = zbus::Proxy::new(
+        &conn,
+        "org.freedesktop.ModemManager1",
+        path,
+        "org.freedesktop.ModemManager1.Modem",
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+
+    match proxy.call_method("SetPrimarySimSlot", &(slot,)).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let raw = e.to_string();
+            let lower = raw.to_ascii_lowercase();
+            if lower.contains("access denied")
+                || lower.contains("not authorized")
+                || lower.contains("denied")
+            {
+                Err(fl!("mobile-data", "slot-access-denied"))
+            } else {
+                Err(raw)
+            }
+        }
+    }
+}
+
+async fn modem_snapshot() -> Result<ModemSnapshot, String> {
+    use zbus::fdo::ObjectManagerProxy;
+    use zbus::Proxy;
+
+    let conn = zbus::Connection::system()
+        .await
+        .map_err(|e| e.to_string())?;
+    let om = ObjectManagerProxy::builder(&conn)
+        .destination("org.freedesktop.ModemManager1")
+        .map_err(|e| e.to_string())?
+        .path("/org/freedesktop/ModemManager1")
+        .map_err(|e| e.to_string())?
+        .build()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let managed = om.get_managed_objects().await.map_err(|e| e.to_string())?;
+    let mut snap = ModemSnapshot::default();
+
+    // Quectel/MBIM often only exports the Modem node on ObjectManager — SIM
+    // objects are reachable by path but not listed. Always probe SimSlots paths.
+    async fn sim_usable_label(conn: &zbus::Connection, path_str: &str) -> (bool, String) {
+        let Ok(path) = ObjectPath::try_from(path_str.to_string()) else {
+            return (false, String::new());
+        };
+        let Ok(proxy) = Proxy::new(
+            conn,
+            "org.freedesktop.ModemManager1",
+            path,
+            "org.freedesktop.ModemManager1.Sim",
+        )
+        .await
+        else {
+            return (false, String::new());
+        };
+
+        let sim_type = proxy
+            .get_property::<u32>("SimType")
+            .await
+            .unwrap_or(0);
+        let eid = proxy
+            .get_property::<String>("Eid")
+            .await
+            .unwrap_or_default();
+        let imsi = proxy
+            .get_property::<String>("Imsi")
+            .await
+            .unwrap_or_default();
+        let iccid = proxy
+            .get_property::<String>("SimIdentifier")
+            .await
+            .unwrap_or_default();
+        let op = proxy
+            .get_property::<String>("OperatorName")
+            .await
+            .unwrap_or_default();
+
+        // MMSimType: 1=physical, 2=esim
+        let is_esim = sim_type == 2 || !eid.is_empty();
+        let has_identity = !imsi.is_empty() || !iccid.is_empty();
+        let usable = if is_esim { has_identity } else { true };
+        let kind = if is_esim { "eSIM" } else { "physical" };
+        let label = if !op.is_empty() {
+            format!("{op} · {kind}")
+        } else if !imsi.is_empty() {
+            format!("{imsi} · {kind}")
+        } else {
+            kind.to_string()
+        };
+        (usable, label)
+    }
+
+    for (path, ifaces) in &managed {
+        let Some(modem) = ifaces.get("org.freedesktop.ModemManager1.Modem") else {
+            continue;
+        };
+        snap.present = true;
+        snap.path = path.to_string();
+
+        if let Some(v) = modem.get("Model") {
+            snap.model = owned_to_string(v);
+        }
+        if let Some(v) = modem.get("EquipmentIdentifier") {
+            snap.imei = owned_to_string(v);
+        }
+        if let Some(v) = modem.get("PrimarySimSlot") {
+            snap.primary_sim_slot = owned_to_u32(v);
+        }
+        if let Some(v) = modem.get("StateFailedReason") {
+            let code = owned_to_u32(v);
+            snap.state_failed_reason = match code {
+                0 => String::new(),
+                2 => "sim-missing".into(),
+                5 => "esim-without-profiles".into(),
+                n => n.to_string(),
+            };
+        }
+        if let Some(v) = modem.get("SignalQuality") {
+            if let Ok((pct, _recent)) = <(u32, bool)>::try_from(v.clone()) {
+                snap.signal_percent = Some(pct);
+            }
+        }
+        if let Some(v) = modem.get("AccessTechnologies") {
+            snap.access_tech = access_tech_label(owned_to_u32(v));
+        }
+
+        let mut slot_paths: Vec<(u32, String)> = Vec::new();
+        if let Some(v) = modem.get("SimSlots") {
+            if let Ok(slots) = <Vec<OwnedObjectPath>>::try_from(v.clone()) {
+                for (idx, slot_path) in slots.iter().enumerate() {
+                    let slot_n = (idx as u32) + 1;
+                    let path_str = slot_path.as_str().to_string();
+                    if !path_str.is_empty() && path_str != "/" {
+                        slot_paths.push((slot_n, path_str));
+                    }
+                }
+            }
+        }
+
+        for (slot_n, path_str) in &slot_paths {
+            let (usable, label) = sim_usable_label(&conn, path_str).await;
+            if usable {
+                snap.slots_with_sim.push(*slot_n);
+            }
+            if *slot_n == snap.primary_sim_slot {
+                snap.active_sim_label = label;
+                snap.active_slot_has_sim = usable;
+            }
+        }
+
+        if let Some(v) = modem.get("Sim") {
+            let sim_path = owned_to_string(v);
+            if !sim_path.is_empty() && sim_path != "/" {
+                let (usable, label) = sim_usable_label(&conn, &sim_path).await;
+                if !label.is_empty() {
+                    snap.active_sim_label = label;
+                }
+                if usable {
+                    snap.active_slot_has_sim = true;
+                }
+            }
+        }
+
+        // Failed reasons that mean the *active* slot cannot do data.
+        if snap.state_failed_reason == "esim-without-profiles"
+            || snap.state_failed_reason == "sim-missing"
+        {
+            snap.active_slot_has_sim = false;
+        }
+
+        if let Some(gpp) = ifaces.get("org.freedesktop.ModemManager1.Modem.Modem3gpp") {
+            if let Some(v) = gpp.get("OperatorName") {
+                let op = owned_to_string(v);
+                if !op.is_empty() {
+                    snap.operator = op;
+                }
+            }
+        }
+        if snap.operator.is_empty() && !snap.active_sim_label.is_empty() {
+            snap.operator = snap
+                .active_sim_label
+                .split(" · ")
+                .next()
+                .unwrap_or("")
+                .to_string();
+        }
+        break;
+    }
+
+    Ok(snap)
+}
+
+fn owned_to_string(v: &zbus::zvariant::OwnedValue) -> String {
+    if let Ok(s) = <&str>::try_from(&**v) {
+        return s.to_string();
+    }
+    if let Ok(s) = String::try_from(v.clone()) {
+        return s;
+    }
+    if let Ok(u) = u32::try_from(v.clone()) {
+        return u.to_string();
+    }
+    if let Ok(p) = <ObjectPath<'_>>::try_from(&**v) {
+        return p.as_str().to_string();
+    }
+    if let Ok(p) = OwnedObjectPath::try_from(v.clone()) {
+        return p.as_str().to_string();
+    }
+    String::new()
+}
+
+fn owned_to_u32(v: &zbus::zvariant::OwnedValue) -> u32 {
+    u32::try_from(v.clone()).unwrap_or(0)
+}
+
+fn access_tech_label(bits: u32) -> String {
+    const LTE: u32 = 1 << 14;
+    const HSPA: u32 = 1 << 9;
+    const UMTS: u32 = 1 << 5;
+    if bits & LTE != 0 {
+        "LTE".into()
+    } else if bits & HSPA != 0 {
+        "HSPA".into()
+    } else if bits & UMTS != 0 {
+        "3G".into()
+    } else if bits == 0 {
+        String::new()
+    } else {
+        format!("0x{bits:x}")
+    }
+}

--- a/cosmic-settings/src/pages/networking/mod.rs
+++ b/cosmic-settings/src/pages/networking/mod.rs
@@ -28,6 +28,9 @@ pub struct Page {
     entity: page::Entity,
     nm_task: Option<tokio::sync::oneshot::Sender<()>>,
     devices: Vec<Arc<network_manager::devices::DeviceInfo>>,
+    /// First device list has arrived (or was cached). Avoids painting VPN
+    /// alone then inserting Wi‑Fi/Wired above (layout shift).
+    devices_ready: bool,
     vpn: page::Entity,
     wifi: page::Entity,
     wired: page::Entity,
@@ -92,6 +95,22 @@ impl page::Page<crate::pages::Message> for Page {
         let device_list = Section::default().descriptions(descriptions).view::<Self>(
             move |_binder, page, section| {
                 let descs = &section.descriptions;
+
+                // Wait for the first NM device snapshot so Wi‑Fi/Wired and VPN
+                // rows paint together (no insert-above shift).
+                if !page.devices_ready {
+                    let loading = widget::column::with_capacity(1)
+                        .push(
+                            widget::settings::section().add(
+                                widget::settings::item_row(vec![
+                                    widget::text::body(fl!("network-and-wireless", "loading"))
+                                        .into(),
+                                ]),
+                            ),
+                        )
+                        .spacing(cosmic::theme::active().cosmic().spacing.space_s);
+                    return Element::from(loading).map(crate::pages::Message::Networking);
+                }
 
                 let multiple_wifi_adapters = page
                     .devices
@@ -242,8 +261,8 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn on_leave(&mut self) -> Task<crate::pages::Message> {
-        self.devices = Vec::new();
-
+        // Keep devices + devices_ready cached so re-opening the hub does not
+        // flash VPN alone and then re-insert Wi‑Fi/Wired.
         if let Some(cancel) = self.nm_task.take() {
             _ = cancel.send(());
         }
@@ -306,6 +325,7 @@ impl Page {
 
             Message::UpdateDevices(devices) => {
                 self.devices = devices;
+                self.devices_ready = true;
             }
         }
 

--- a/cosmic-settings/src/pages/networking/mod.rs
+++ b/cosmic-settings/src/pages/networking/mod.rs
@@ -5,6 +5,7 @@ pub mod backend;
 pub mod vpn;
 pub mod wifi;
 pub mod wired;
+pub mod mobile;
 
 use std::process::Stdio;
 use std::sync::Arc;
@@ -34,6 +35,7 @@ pub struct Page {
     vpn: page::Entity,
     wifi: page::Entity,
     wired: page::Entity,
+    mobile: page::Entity,
 }
 
 #[derive(Debug, Clone)]
@@ -90,6 +92,7 @@ impl page::Page<crate::pages::Message> for Page {
             wifi_desc = fl!("xdg-entry-wireless-comment");
             wired_desc = fl!("xdg-entry-wired-comment");
             vpn_desc = fl!("xdg-entry-vpn-comment");
+            mobile_desc = fl!("xdg-entry-mobile-comment");
         });
 
         let device_list = Section::default().descriptions(descriptions).view::<Self>(
@@ -221,9 +224,20 @@ impl page::Page<crate::pages::Message> for Page {
                         )
                     });
 
+                // Mobile is always listed (VPN-like). Modem presence is a page detail.
                 let device_list = wifi_devices
                     .chain(wired_devices)
                     .fold(widget::column([]), |column, device| column.push(device))
+                    .push(crate::widget::page_list_item(
+                        fl!("mobile-data"),
+                        &descs[mobile_desc],
+                        "",
+                        "network-cellular-symbolic",
+                        Message::OpenPage {
+                            page: page.mobile,
+                            device: None,
+                        },
+                    ))
                     .push(crate::widget::page_list_item(
                         fl!("vpn"),
                         &descs[vpn_desc],
@@ -278,11 +292,13 @@ impl page::AutoBind<crate::pages::Message> for Page {
         let vpn = page.sub_page_with_id::<vpn::Page>();
         let wifi = page.sub_page_with_id::<wifi::Page>();
         let wired = page.sub_page_with_id::<wired::Page>();
+        let mobile = page.sub_page_with_id::<mobile::Page>();
 
         let model = page.model.page_mut::<Self>().unwrap();
         model.vpn = vpn;
         model.wifi = wifi;
         model.wired = wired;
+        model.mobile = mobile;
 
         page
     }
@@ -389,7 +405,7 @@ impl Page {
     }
 }
 
-async fn nm_add_wired() -> Result<(), String> {
+pub(crate) async fn nm_add_wired() -> Result<(), String> {
     nm_connection_editor(&["--type=802-3-ethernet", "-c"]).await
 }
 
@@ -397,7 +413,7 @@ async fn nm_add_wifi() -> Result<(), String> {
     nm_connection_editor(&["--type=802-11-wireless", "-c"]).await
 }
 
-async fn nm_edit_connection(uuid: &str) -> Result<(), String> {
+pub(crate) async fn nm_edit_connection(uuid: &str) -> Result<(), String> {
     nm_connection_editor(&[&["--edit=", uuid].concat()]).await
 }
 

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -106,6 +106,7 @@ xdg-entry-users-comment = Authentication and user accounts
 xdg-entry-users-keywords = COSMIC;User;Account;
 
 xdg-entry-vpn-comment = VPN connections and connection profiles
+xdg-entry-mobile-comment = Cellular data, SIM, and mobile broadband
 xdg-entry-vpn-keywords = COSMIC;VPN;Network;Connection;OpenVPN;OpenConnect;
 
 xdg-entry-wallpaper = Wallpaper
@@ -187,6 +188,7 @@ network-device-state =
 remove-connection-dialog = Remove connection profile?
     .vpn-description = You'll need to enter a password again to use this network in the future.
     .wired-description = You'll need to recreate this profile to use it in the future.
+    .mobile-description = This removes the saved mobile connection profile from NetworkManager.
 
 vpn = VPN
     .connections = VPN connections
@@ -1076,3 +1078,28 @@ full-name = Full name
 invalid-username = Invalid username
 password-mismatch = Password and confirmation must match
 save = Save
+
+
+mobile-data = Mobile data
+    .loading = Loading mobile data…
+    .airplane = Airplane mode is on — mobile data is unavailable.
+    .no-modem = No mobile modem detected.
+    .no-sim = No SIM card detected.
+    .sim-other-slot = A SIM is available in slot { $slot }. Switch to use mobile data.
+    .esim-empty-use-physical = Active slot is an empty eSIM. Use physical SIM in slot { $slot }.
+    .use-slot = Use slot { $slot }
+    .switching-sim = Switching SIM slot…
+    .slot-ready = SIM slot ready
+    .slot-access-denied = System policy denied SIM slot switch. Install ModemManager D-Bus allow for SetPrimarySimSlot.
+    .device-unavailable = Modem device is not ready yet.
+    .no-profile = No mobile connection profile found.
+    .activate-failed = Failed to activate mobile data.
+    .working = Working…
+    .details = Modem
+    .operator = Operator
+    .technology = Technology
+    .signal = Signal
+    .sim = SIM
+    .imei = IMEI
+    .model = Model
+    .profile = Connection profile

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -146,6 +146,7 @@ disconnect = Disconnect
 forget = Forget
 known-networks = Known networks
 network-and-wireless = Network & wireless
+    .loading = Loading network devices…
 network-name = Network Name
 no-networks = No networks have been found.
 no-vpn = No VPN connections available.


### PR DESCRIPTION
## Summary
Mobile data page: session activate/deactivate, dual-SIM “Use slot N”, banners, modem/profile details. Always-on hub row (VPN-like).

## Why (non-obvious)
- Empty eSIM (no profiles) is not usable; trays often leave it primary → false No SIM
- Probe SIMs on SimSlots paths (ObjectManager may omit SIM nodes)
- Post-slot-switch: wait MM **and** NM
- `SetPrimarySimSlot` may be D-Bus-denied (Fedora) → clear error, not hang

## Non-goals
PIN · CreateGsm/APN · eSIM LPA · applet signal · multi-modem UI

## Stack
Includes commits from #2094 (backend) and #2095 (hub load gate) for a buildable branch. Prefer review order 2094 → 2095 → this; I can rebase after merges.

## Test
- [ ] `just check`
- [ ] Existing `gsm` profile: toggle session up/down
- [ ] Dual-SIM empty eSIM: recovery banner (policy permitting)

Refs: https://github.com/pop-os/cosmic-settings/issues/2093  
Screenshots on the issue.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the DCO and certify my contribution under its conditions.