### PR TITLE
docs (QA): Add Sound page tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -48,7 +48,10 @@ This document provides a regression testing checklist for COSMIC Settings and th
 
 ### Sound
 
-TBD after devices/profiles are fixed.
+- [ ] Output & Input volume sliders work independently
+- [ ] Output balance slider works & doesn't get reset by volume slider
+- [ ] Amplification toggles work as expected
+- [ ] Device profiles can be changed & reflect as expected on the main Sound page
 
 ### Power & Battery
 


### PR DESCRIPTION
https://github.com/pop-os/cosmic-settings/issues/2097 really should have been caught by QA. It appears only the standard regression testing checklist was performed for https://github.com/pop-os/cosmic-settings/pull/2063, even though that PR only modified the Sound page, and we had nothing in the standard checklist for the Sound page.

To rectify that, this adds a few basic smoke tests for the Sound page in the standard checklist, to hopefully prevent this from happening again. (I know we've had this particular problem pop up at least once before, too, so both sliders working independently is a good thing to have in the checklist.)

---

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

