### PR TITLE
fix: one pixel gap between outputs due to rounding error

### DIFF
--- a/cosmic-settings/src/pages/display/arrangement.rs
+++ b/cosmic-settings/src/pages/display/arrangement.rs
@@ -244,11 +244,13 @@ impl<Message: Clone> Widget<Message, cosmic::Theme, Renderer> for Arrangement<'_
                     if let Some(ref on_placement) = self.on_placement {
                         shell.publish(on_placement(
                             output_key,
-                            ((region.x - state.max_dimensions.0 - bounds.x) * UNIT_PIXELS) as i32,
+                            ((region.x - state.max_dimensions.0 - bounds.x) * UNIT_PIXELS).round()
+                                as i32,
                             ((region.y
                                 - (state.max_dimensions.1 / VERTICAL_DISPLAY_OVERHEAD)
                                 - bounds.y)
-                                * UNIT_PIXELS) as i32,
+                                * UNIT_PIXELS)
+                                .round() as i32,
                         ));
                     }
 


### PR DESCRIPTION
Round rather than truncate: converting widget units back to output pixels accumulates f32 error, and a truncating cast turns a fraction of a pixel into a full pixel of gap/overlap between displays that were snapped flush.

I notice this when testing https://github.com/pop-os/cosmic-comp/pull/2442 with `lan-mouse`. `lan-mouse` would transfer my cursor to another machine when moving between my monitors (because of the gap between monitors). Arguably `lan-mouse` should be smarter, but the gap shouldn't be there either.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

