### PR TITLE
i18n(is): complete Icelandic translation to 100% parity

### DIFF
--- a/i18n/is/cosmic_settings.ftl
+++ b/i18n/is/cosmic_settings.ftl
@@ -128,3 +128,780 @@ vpn-error = VPN-villa
             [password] lykilorð
             [password-flags] lykilorðaflögg
         } með nmcli
+
+xdg-entry-comment = Stillingaforrit fyrir COSMIC-skjáborðið
+xdg-entry-keywords = COSMIC;Settings;Stillingar;
+xdg-entry-about = Um kerfið
+xdg-entry-about-comment = Heiti tækis, upplýsingar um vélbúnað, sjálfgefnar stillingar stýrikerfis
+xdg-entry-about-keywords = COSMIC;About;Um kerfið;Kerfisupplýsingar;
+xdg-entry-a11y = Aðgengi
+xdg-entry-a11y-comment = Skjálesari, stækkunargler, háskerpa og litasíur
+xdg-entry-a11y-keywords = COSMIC;Accessibility;A11y;Screen;Reader;Magnifier;Contrast;Color;Aðgengi;Skjálesari;Stækkunargler;Birtuskil;Litur;
+xdg-entry-appearance = Útlit
+xdg-entry-appearance-comment = Áherslulitir og þemu
+xdg-entry-appearance-keywords = COSMIC;Accent;Color;Icon;Font;Theme;Útlit;Áherslulitur;Litur;Táknmynd;Letur;Þema;
+xdg-entry-applications = Forrit
+xdg-entry-applications-comment = Sjálfgefin forrit, ræsiforrit og samhæfnistillingar fyrir X11-forrit
+xdg-entry-applications-keywords = COSMIC;Default;Application;Startup;X11;Compatibility;Forrit;Sjálfgefið;Ræsing;Samhæfni;
+xdg-entry-bluetooth-comment = Sýsla með Bluetooth-tæki
+xdg-entry-bluetooth-keywords = COSMIC;Bluetooth;
+xdg-entry-date-time = Dagsetning og tími
+xdg-entry-date-time-comment = Tímabelti, sjálfvirkar klukkustillingar og tímasnið
+xdg-entry-date-time-keywords = COSMIC;Time;Zone;Tími;Dagsetning;Tímabelti;
+xdg-entry-default-apps = Sjálfgefin forrit
+xdg-entry-default-apps-comment = Sjálfgefinn vafri, tölvupóstforrit, skráavafri og önnur forrit
+xdg-entry-default-apps-keywords = COSMIC;Default;Application;Sjálfgefin forrit;Vafri;Tölvupóstur;
+xdg-entry-desktop = Skjáborð
+xdg-entry-desktop-comment = Veggfóður, útlit, stika, dokka, gluggastjórnun og stillingar vinnusvæða
+xdg-entry-desktop-keywords = COSMIC;Desktop;Skjáborð;
+xdg-entry-displays = Skjáir
+xdg-entry-displays-comment = Sýsla með stillingar skjáa
+xdg-entry-displays-keywords = COSMIC;Display;Skjár;Skjáir;
+xdg-entry-dock = Dokka
+xdg-entry-dock-comment = Valfrjáls stika fyrir forrit og smáforrit
+xdg-entry-dock-keywords = COSMIC;Dock;Panel;Applet;Dokka;Stika;Smáforrit;
+xdg-entry-input = Inntakstæki
+xdg-entry-input-comment = Stillingar fyrir lyklaborð og mús
+xdg-entry-input-keywords = COSMIC;Input;Keyboard;Mouse;Mice;Inntak;Lyklaborð;Mús;
+xdg-entry-keyboard = Lyklaborð
+xdg-entry-keyboard-comment = Inntaksgjafar, skipting, innsláttur sértákna, flýtilyklar
+xdg-entry-keyboard-keywords = COSMIC;Keyboard;Input;Source;Shortcuts;Lyklaborð;Inntak;Flýtilyklar;
+xdg-entry-mouse = Mús
+xdg-entry-mouse-comment = Hraði músar, hröðun og eðlilegt skrun
+xdg-entry-mouse-keywords = COSMIC;Mouse;Acceleration;Scrolling;Mús;Hröðun;Skrun;
+xdg-entry-network = Net og þráðlausar tengingar
+xdg-entry-network-comment = Sýsla með nettengingar
+xdg-entry-network-keywords = COSMIC;Network;Wireless;WiFi;VPN;Net;Þráðlaust;
+xdg-entry-notifications = Tilkynningar
+xdg-entry-notifications-comment = Ekki ónáða, tilkynningar á lásskjá og stillingar fyrir hvert forrit
+xdg-entry-notifications-keywords = COSMIC;Notification;Lock;Tilkynningar;Lásskjár;
+xdg-entry-panel = Stika
+xdg-entry-panel-comment = Aðalkerfisstika fyrir valmyndir og smáforrit
+xdg-entry-panel-keywords = COSMIC;Panel;Applet;Stika;Smáforrit;
+xdg-entry-power = Orka og rafhlaða
+xdg-entry-power-comment = Orkustillingar og valkostir fyrir orkusparnað
+xdg-entry-power-keywords = COSMIC;Power;Battery;Orka;Rafhlaða;
+xdg-entry-region-language = Svæði og tungumál
+xdg-entry-region-language-comment = Sníða dagsetningar, tíma og tölur eftir svæði þínu
+xdg-entry-region-language-keywords = COSMIC;Region;Language;Date;Format;Time;Locale;Localization;Svæði;Tungumál;Dagsetning;Snið;Staðfærsla;
+xdg-entry-sound = Hljóð
+xdg-entry-sound-comment = Hljóðstillingar fyrir tæki, viðvaranir og forrit
+xdg-entry-sound-keywords = COSMIC;Sound;Audio;Alert;Pipewire;Hljóð;Viðvörun;
+xdg-entry-startup-apps = Ræsiforrit
+xdg-entry-startup-apps-comment = Stilltu forrit sem keyra við innskráningu
+xdg-entry-startup-apps-keywords = COSMIC;Startup;Application;Ræsing;Ræsiforrit;
+xdg-entry-system = Kerfi og notendareikningar
+xdg-entry-system-comment = Kerfisupplýsingar, notendareikningar og uppfærslur á fastbúnaði
+xdg-entry-system-keywords = COSMIC;System;Info;Accounts;Firmware;Kerfi;Upplýsingar;Notendareikningar;Fastbúnaður;
+xdg-entry-time-language = Tími og tungumál
+xdg-entry-time-language-comment = Sýsla með dagsetningu, tíma, svæði og tungumál kerfisins
+xdg-entry-time-language-keywords = COSMIC;System;Time;Date;Region;Language;Tími;Dagsetning;Svæði;Tungumál;
+xdg-entry-touchpad = Snertiflötur
+xdg-entry-touchpad-comment = Hraði snertiflatar, smellivalkostir og bendingar
+xdg-entry-touchpad-keywords = COSMIC;Touchpad;Gesture;Snertiflötur;Bendingar;
+xdg-entry-users = Notendur
+xdg-entry-users-comment = Auðkenning og notendareikningar
+xdg-entry-users-keywords = COSMIC;User;Account;Notendur;Notandareikningur;
+xdg-entry-vpn-comment = VPN-tengingar og tengingarsnið
+xdg-entry-vpn-keywords = COSMIC;VPN;Network;Connection;OpenVPN;OpenConnect;Net;Tenging;
+xdg-entry-wallpaper = Veggfóður
+xdg-entry-wallpaper-comment = Veggfóðursmyndir, litir og valkostir skyggnusýningar
+xdg-entry-wallpaper-keywords = COSMIC;Wallpaper;Background;Slideshow;Veggfóður;Bakgrunnur;Skyggnusýning;
+xdg-entry-window-management = Gluggastjórnun
+xdg-entry-window-management-comment = Aðgerð Super-lykils, valkostir fyrir gluggastýringu og fleiri valkostir fyrir reitaröðun glugga
+xdg-entry-window-management-keywords = COSMIC;Window;Management;Tiling;Super;Key;Gluggar;Gluggastjórnun;Reitaröðun;
+xdg-entry-wired = Þráðlögn
+xdg-entry-wired-comment = Þráðtengingar og tengingarsnið
+xdg-entry-wired-keywords = COSMIC;Wired;LAN;Network;Connection;Þráðlögn;Net;Tenging;Snúra;
+xdg-entry-wireless = Wi-Fi
+xdg-entry-wireless-comment = Wi-Fi-tengingar og tengingarsnið
+xdg-entry-wireless-keywords = COSMIC;WiFi;Wi-Fi;Network;Connection;Þráðlaust net;Tenging;
+xdg-entry-workspaces = Vinnusvæði
+xdg-entry-workspaces-comment = Stefna vinnusvæða, yfirlit og hegðun með mörgum skjám
+xdg-entry-workspaces-keywords = COSMIC;Workspace;Orientation;Overview;Monitor;Vinnusvæði;Yfirlit;Skjár;
+xdg-entry-x11-applications = Samhæfni X11-forrita
+xdg-entry-x11-applications-comment = Kvörðun X11-forrita, aðalskjár og altækir flýtilyklar
+xdg-entry-x11-applications-keywords = COSMIC;X11;Application;Game;Compatibility;Forrit;Leikur;Samhæfni;
+
+## Net og þráðlausar tengingar
+
+network-name = Nafn á neti
+qr-code-unavailable = QR-kóði ekki tiltækur
+scan-to-connect-description = Skannaðu QR-kóðann til að tengjast þessu neti.
+share = Deila neti
+wired = Þráðtengt
+    .adapter = Þráðtengdur búnaður { $id }
+    .connections = Þráðtengdar tengingar
+    .devices = Þráðtengd tæki
+    .remove = Fjarlægja tengisnið
+wifi = Wi-Fi
+    .adapter = Wi-Fi búnaður { $id }
+    .forget = Gleyma þessu neti
+wireguard-dialog = Bæta við WireGuard tæki
+    .description = Veldu nafn á tæki fyrir WireGuard uppsetninguna.
+
+## Networking: Online accounts
+online-accounts = Netreikningar
+    .desc = Bæta við reikningum, IMAP og SMTP, innskráningum fyrirtækja
+
+# Bluetooth
+enable = Virkja
+bluetooth = Bluetooth
+    .status = Þetta kerfi er sýnilegt sem { $aliases } á meðan Bluetooth stillingar eru opnar.
+    .connected = Tengt
+    .connecting = Tengist
+    .disconnecting = Aftengist
+    .connect = Tengjast
+    .disconnect = Aftengjast
+    .forget = Gleyma
+    .dbus-error = Villa kom upp í samskiptum við DBus: { $why }
+    .disabled = Slökkt er á Bluetooth þjónustunni
+    .inactive = Bluetooth þjónustan er ekki virk
+    .unknown = Ekki tókst að ræsa Bluetooth þjónustuna. Er BlueZ uppsett?
+bluetooth-paired = Áður tengd tæki
+    .connect = Tengjast
+    .battery = { $percentage }% rafhlaða
+bluetooth-confirm-pin = Staðfesta Bluetooth PIN
+    .description = Staðfestu að eftirfarandi PIN passi við það sem birtist á { $device }
+bluetooth-display-passkey = Bluetooth pörun
+    .description = Sláðu inn eftirfarandi aðgangslykil á { $device } og ýttu svo á Enter
+bluetooth-display-pin = Bluetooth pörun
+    .description = Sláðu inn eftirfarandi PIN á { $device } og ýttu svo á Enter
+accessibility = Aðgengi
+    .vision = Sjón
+    .on = Kveikt
+    .off = Slökkt
+    .unavailable = Ekki tiltækt
+    .screen-reader = Skjálesari
+    .high-contrast = Háskerpustilling
+    .invert-colors = Snúa við litum
+    .color-filters = Litasíur
+magnifier = Stækkunargler
+    .controls = Eða notaðu þessa flýtilykla: { $zoom_in ->
+             [zero] {""}
+            *[other] {""}
+                {$zoom_in} til að þysja inn,
+        }{ $zoom_out ->
+             [zero] {""}
+            *[other] {""}
+                {$zoom_out} til að þysja út,
+        }
+        Super + skruna með músinni
+    .scroll_controls = Virkja aðdrátt með mús eða snertifleti með Super + skrun
+    .show_overlay = Sýna yfirlag stækkunarglersins
+    .increment = Aðdráttarþrep
+    .signin = Ræsa stækkunargler við innskráningu
+    .applet = Kveikja/slökkva á stækkunargleri í smáforriti á stikunni
+    .movement = Aðdráttarsýn færist
+    .continuous = Samfellt með bendli
+    .onedge = Þegar bendill nær brún
+    .centered = Til að halda bendli miðjuðum
+color-filter = Tegund litasíu
+    .unknown = Óþekkt sía virk
+    .greyscale = Grátónar
+    .deuteranopia = Grænt/Rautt (grænublinda, Deuteranopia)
+    .protanopia = Rautt/Grænt (rauðublinda, Protanopia)
+    .tritanopia = Blátt/Gult (blárublinda, Tritanopia)
+
+## Desktop
+desktop = Skjáborð
+
+## Desktop: Wallpaper
+wallpaper = Veggfóður
+    .change = Skipta um mynd á
+    .fit = Aðlögun veggfóðurs
+    .folder-dialog = Velja veggfóðursmöppu
+    .image-dialog = Velja veggfóðursmynd
+    .plural = Veggfóður
+    .same = Sama veggfóður á öllum skjáum
+    .slide = Skyggnusýning
+x-minutes = { $number } { $number ->
+    [one] mínúta
+    *[other] mínútur
+}
+x-hours = { $number } { $number ->
+    [one] klukkustund
+    *[other] klukkustundir
+}
+shadows-floating = Fljótandi gluggar
+    .clip = Samræma við horn kerfisins og beita skuggum
+shadows-tiling = Reitaraðaðir gluggar
+    .clip = Samræma við horn kerfisins
+    .shadow = Beita skuggum
+enable-export = Beita núverandi þema á GNOME forrit
+    .desc = Ekki styðja öll verkfærasöfn sjálfvirk skipti. Endurræsa gæti þurft forrit sem eru ekki COSMIC eftir þemabreytingu.
+icon-theme = Táknmyndaþema
+    .desc = Beitir öðru safni táknmynda á forrit
+text-tint = Litblær á texta viðmóts
+    .desc = Notað til að leiða út textaliti viðmóts sem hafa nægileg birtuskil á mismunandi flötum
+style = Stíll
+    .round = Ávalt
+    .slightly-round = Örlítið ávalt
+    .square = Ferkantað
+    .frosted-glass = Frostað gler
+    .frosted-system-interface = Kerfisviðmót
+    .frosted-system-interface-desc = Beitir frostuðu gleri á ræsi, forritasafn, yfirlit vinnusvæða og stýringar á skjá
+    .frosted-windows = Gluggar
+    .frosted-windows-desc = Beitir frostuðu gleri á glugga og valmyndir
+    .frosted-panels = Stikur
+    .frosted-panels-desc = Beitir frostuðu gleri á stiku og dokku
+    .frosted-applets = Smáforrit
+    .frosted-applets-desc = Beitir frostuðu gleri á valmyndir smáforrita á stiku og dokku
+    .frosted-thickness = Þykkt frosts
+    .less = minna
+    .more = meira
+    .glass-opacity = Ógegnsæi glers
+interface-density = Þéttleiki viðmóts
+    .comfortable = Þægilegt
+    .compact = Þjappað
+    .spacious = Rúmgott
+window-management-appearance = Gluggastjórnun
+    .active-hint = Stærð vísbendingar á virkum glugga
+    .gaps = Bil í kringum reitaraðaða glugga
+
+### Experimental
+icons-and-toolkit = Þema táknmynda og verkfærasafns
+monospace-font = Jafnbreitt letur
+shadow-and-corners = Skuggi og horn glugga
+
+## Desktop: Notifications
+notifications = Tilkynningar
+
+## Desktop: Panel
+panel = Stika
+center-segment = Miðjuhluti
+place-here = Setja smáforrit hér
+end-segment = Endahluti
+large = Stórt
+no-applets-found = Engin smáforrit fundust...
+panel-bottom = Neðst
+panel-left = Vinstri
+panel-right = Hægri
+panel-top = Efst
+search-applets = Leita í smáforritum...
+small = Lítið
+start-segment = Upphafshluti
+panel-appearance = Útlit
+    .match = Samræma við skjáborð
+    .light = Ljóst
+    .dark = Dökkt
+panel-behavior-and-position = Hegðun og staðsetning
+    .autohide = Fela stiku sjálfkrafa
+    .dock-autohide = Fela dokku sjálfkrafa
+    .position = Staðsetning á skjá
+    .display = Sýna á skjá
+panel-style = Stíll
+    .anchor-gap = Bil milli stiku og skjábrúna
+    .dock-anchor-gap = Bil milli dokku og skjábrúna
+    .extend = Teygja stiku að skjábrúnum
+    .dock-extend = Teygja dokku að skjábrúnum
+    .appearance = Útlit
+    .size = Stærð
+    .background-opacity = Ógegnsæi bakgrunns
+panel-applets = Uppsetning
+    .dock-desc = Setja upp smáforrit dokku
+    .desc = Setja upp smáforrit stiku
+panel-missing = Uppsetningu stiku vantar
+    .desc = Uppsetningarskrá stiku vantar vegna notkunar á sérsniðinni uppsetningu eða hún er skemmd.
+    .fix = Endurstilla á sjálfgildi
+
+## Desktop: Dock
+dock = Dokka
+
+## Desktop: Window management
+window-management = Gluggastjórnun
+super-key = Aðgerð Super-lykils
+    .launcher = Opna ræsi
+    .workspaces = Opna vinnusvæði
+    .applications = Opna forrit
+    .none = Ekkert
+edge-gravity = Fljótandi gluggar dragast að nálægum brúnum
+window-controls = Gluggastýringar
+    .maximize = Sýna hámörkunarhnapp
+    .minimize = Sýna lágmörkunarhnapp
+    .active-window-hint = Sýna vísbendingu á virkum glugga
+focus-navigation = Fókusflakk
+    .focus-follows-cursor = Fókus fylgir bendli
+    .focus-follows-cursor-delay = Töf á að fókus fylgi bendli í ms
+    .cursor-follows-focus = Bendill fylgir fókus
+
+## Desktop: Workspaces
+workspaces = Vinnusvæði
+workspaces-overview = Yfirlit vinnusvæða
+    .action-on-typing = Aðgerð við innslátt
+    .none = Ekkert
+    .launcher = Opna ræsi
+    .applications = Opna forrit
+workspaces-behavior = Hegðun vinnusvæða
+    .dynamic = Breytileg vinnusvæði
+    .dynamic-desc = Fjarlægir tóm vinnusvæði sjálfkrafa.
+    .fixed = Fastur fjöldi vinnusvæða
+    .fixed-desc = Bæta við eða fjarlægja vinnusvæði í yfirlitinu.
+workspaces-multi-behavior = Hegðun með mörgum skjáum
+    .span = Vinnusvæði ná yfir alla skjái
+    .separate = Skjáir hafa aðskilin vinnusvæði
+workspaces-overview-thumbnails = Smámyndir í yfirliti vinnusvæða
+    .show-number = Sýna númer vinnusvæðis
+    .show-name = Sýna nafn vinnusvæðis
+workspaces-orientation = Stefna vinnusvæða
+    .vertical = Lóðrétt
+    .horizontal = Lárétt
+hot-corner = Heitt horn
+    .top-left-corner = Virkja heitt horn efst til vinstri fyrir vinnusvæði
+workspaces-navigation = Flakk
+    .wraparound = Fara á milli fyrsta og síðasta vinnusvæðis með flýtilyklum og bendingum
+
+## Displays
+
+-requires-restart = Krefst endurræsingar
+color = Litur
+    .depth = Litadýpt
+    .profile = Litasnið
+    .sidebar = Litasnið
+    .temperature = Lithiti
+display = Skjáir
+    .arrangement = Uppröðun skjáa
+    .arrangement-desc = Dragðu skjái til að endurraða þeim
+    .enable = Virkja skjá
+    .external = { $size } { $output } ytri skjár
+    .laptop = { $size } fartölvuskjár
+    .options = Skjávalkostir
+    .refresh-rate = Endurnýjunartíðni
+    .resolution = Upplausn
+    .scale = Kvarði
+    .additional-scale-options = Frekari kvörðunarvalkostir
+mirroring = Speglun
+    .id = Speglun { $id }
+    .dont = Ekki spegla
+    .mirror = Spegla { $display }
+    .project = Varpa á { $display ->
+        [all] alla skjái
+        *[other] { $display }
+    }
+    .project-count = Varpa á { $count} { $count ->
+        [1] annan skjá
+        *[other] aðra skjái
+    }
+night-light = Næturljós
+    .auto = Sjálfvirkt (frá sólsetri til sólarupprásar)
+    .desc = Draga úr bláu ljósi með hlýrri litum
+orientation = Stefna
+    .standard = Staðlað
+    .rotate-90 = Snúa 90°
+    .rotate-180 = Snúa 180°
+    .rotate-270 = Snúa 270°
+vrr = Breytileg endurnýjunartíðni
+    .enabled = Virkt
+    .force = Alltaf
+    .auto = Sjálfvirkt
+    .disabled = Óvirkt
+scheduling = Tímasetning
+    .manual = Handvirk tímasetning
+dialog = Svargluggi
+    .title = Halda þessum skjástillingum?
+    .keep-changes = Halda breytingum
+    .change-prompt = Breytingar á stillingum verða sjálfkrafa afturkallaðar eftir { $time } sekúndur.
+    .revert-settings = Afturkalla stillingar
+
+## Sound
+sound = Hljóð
+sound-output = Úttak
+    .volume = Hljóðstyrkur úttaks
+    .device = Úttakstæki
+    .level = Úttaksstig
+    .config = Uppsetning
+    .balance = Jafnvægi
+    .left = Vinstri
+    .right = Hægri
+sound-input = Inntak
+    .volume = Hljóðstyrkur inntaks
+    .device = Inntakstæki
+    .level = Inntaksstig
+amplification = Mögnun
+    .desc = Leyfir að hækka hljóðstyrk í 150%
+sound-alerts = Viðvaranir
+    .volume = Hljóðstyrkur viðvarana
+    .sound = Hljóð viðvarana
+sound-applications = Forrit
+    .desc = Hljóðstyrkur og stillingar forrita
+
+# No speaker, headphones, or microphone plugged into sound card port
+sound-device-port-unplugged = Ótengt
+sound-hd-audio = HD hljóð
+sound-usb-audio = USB hljóð
+
+# Profiles for sound card devices
+sound-device-profiles = Tækjasnið
+
+# Power & Battery settings page
+battery = Rafhlaða
+  .minute = { $value } { $value ->
+        [one] mínúta
+       *[other] mínútur
+  }
+  .hour = { $value } { $value ->
+        [one] klukkustund
+       *[other] klukkustundir
+  }
+  .day = { $value } { $value ->
+        [one] dagur
+       *[other] dagar
+  }
+  .less-than-minute = Minna en mínúta
+  .and = og
+  .remaining-time = { $time } þar til hún { $action ->
+        [full] fullhleðst
+       *[other] tæmist
+   }
+connected-devices = Tengd tæki
+  .unknown = Óþekkt tæki
+power-mode = Orkustilling
+    .battery = Lengri rafhlöðuending
+    .battery-desc = Minni orkunotkun og hljóðlaus afköst
+    .balanced = Jafnvægi
+    .balanced-desc = Hljóðlát afköst og hófleg orkunotkun
+    .performance = Mikil afköst
+    .performance-desc = Hámarksafköst og orkunotkun
+    .no-backend = Bakendi fannst ekki. Settu upp system76-power eða power-profiles-daemon.
+
+power-saving = Orkusparnaðarvalkostir
+    .turn-off-screen-after = Slökkva á skjánum eftir
+    .auto-suspend = Sjálfvirk svæfing
+    .auto-suspend-ac = Sjálfvirk svæfing þegar tengt við rafmagn
+    .auto-suspend-battery = Sjálfvirk svæfing á rafhlöðu
+
+## Input
+acceleration-desc = Stillir næmni hreyfingar sjálfkrafa eftir hraða
+disable-while-typing = Gera óvirkt við innslátt
+input-devices = Inntakstæki
+primary-button = Aðalhnappur
+    .desc = Stillir röð efnislegra hnappa
+    .left = Vinstri
+    .right = Hægri
+scrolling = Skrun
+    .two-finger = Skruna með tveimur fingrum
+    .edge = Skruna meðfram brúninni með einum fingri
+    .speed = Skrunhraði
+    .natural = Náttúrulegt skrun
+    .natural-desc = Skruna innihaldinu í stað sýnarinnar
+
+## Input: Keyboard
+slow = Hægt
+fast = Hratt
+short = Stutt
+long = Langt
+keyboard = Lyklaborð
+keyboard-sources = Inntaksveitur
+    .desc = Skipta má um inntaksveitur með lyklasamsetningunni Super+Bil. Þessu má breyta í flýtilyklastillingum lyklaborðsins.
+    .move-up = Færa upp
+    .move-down = Færa niður
+    .settings = Stillingar
+    .view-layout = Skoða lyklaborðsskipan
+    .remove = Fjarlægja
+    .add = Bæta við inntaksveitu
+keyboard-special-char = Innsláttur sértákna
+    .alternate = Lykill fyrir aukatákn
+    .compose = Samsetningarlykill
+    .compose-desc = Samsetningarlykillinn gerir kleift að slá inn margvísleg tákn. Til að nota hann skaltu ýta á samsetningarlykilinn og síðan slá inn röð tákna. Til dæmis gefur samsetningarlykill fylgt eftir af C og o táknið ©, en samsetningarlykill fylgt eftir af a og ‘ gefur á.
+    .caps = Caps Lock-lykill
+    .ctrl = Control
+    .ctrl-right = Hægri Ctrl
+    .swap-with-ctrl = Skipta á við Control
+    .alt = Alt
+    .alt-left = Vinstri Alt
+    .alt-right = Hægri Alt
+    .super = Super
+    .super-left = Vinstri Super
+    .super-right = Hægri Super
+    .menu = Valmyndarlykill
+    .backspace = Backspace
+    .escape = Escape
+    .swap-with-escape = Skipta á við Escape
+    .print-screen = Print Screen
+    .scroll-lock = Scroll Lock
+    .none = Ekkert
+keyboard-typing-assist = Innsláttur
+    .repeat-rate = Endurtekningartíðni
+    .repeat-delay = Töf endurtekningar
+keyboard-numlock-boot = Numlock
+    .boot-state = Staða við ræsingu
+    .last-boot = Síðasta ræsing
+    .on = Kveikt
+    .off = Slökkt
+    .set = Stilla ræsistöðu Numlock
+added = Bætt við
+type-to-search = Skrifaðu til að leita...
+no-search-results = Engin net passa við leitina þína.
+show-extended-input-sources = Sýna útvíkkaðar inntaksveitur
+
+## Input: Keyboard: Shortcuts
+keyboard-shortcuts = Flýtilyklar lyklaborðs
+    .desc = Skoða og sérsníða flýtilykla
+add-another-keybinding = Bæta við annarri lyklabindingu
+command = Skipun
+custom = Sérsniðið
+debug = Villuleit
+disabled = Óvirkt
+input-source-switch = Skipta um tungumálainntaksveitu lyklaborðs
+migrate-workspace-prev = Flytja vinnusvæði á fyrra úttak
+migrate-workspace-next = Flytja vinnusvæði á næsta úttak
+migrate-workspace = Flytja vinnusvæði á úttak { $direction ->
+    *[down] niður
+    [left] vinstri
+    [right] hægri
+    [up] upp
+}
+navigate = Flakka
+shortcut-name = Heiti flýtilykils
+system-controls = Kerfisstýringar
+terminate = Stöðva
+toggle-stacking = Víxla stöflun glugga
+type-key-combination = Sláðu inn lyklasamsetningu
+custom-shortcuts = Sérsniðnir flýtilyklar
+    .add = Bæta við flýtilykli
+    .context = Bæta við sérsniðnum flýtilykli
+    .none = Engir sérsniðnir flýtilyklar
+modified = { $count } breytt
+nav-shortcuts = Flakk
+    .prev-output = Fókus á fyrra úttak
+    .next-output = Fókus á næsta úttak
+    .last-workspace = Fókus á síðasta vinnusvæði
+    .prev-workspace = Fókus á fyrra vinnusvæði
+    .next-workspace = Fókus á næsta vinnusvæði
+    .focus = Fókus á glugga { $direction ->
+        *[down] niður
+        [in] inn
+        [left] vinstri
+        [out] út
+        [right] hægri
+        [up] upp
+    }
+    .output = Skipta á úttak { $direction ->
+        *[down] niður
+        [left] vinstri
+        [right] hægri
+        [up] upp
+    }
+    .workspace = Skipta á vinnusvæði { $num }
+manage-windows = Sýsla með glugga
+    .close = Loka glugga
+    .maximize = Hámarka glugga
+    .fullscreen = Setja glugga í heilskjá
+    .minimize = Lágmarka glugga
+    .resize-inwards = Minnka stærð glugga inn á við
+    .resize-outwards = Stækka glugga út á við
+    .toggle-sticky = Víxla límdum glugga
+move-windows = Færa glugga
+    .direction = Færa glugga { $direction ->
+        *[down] niður
+        [left] vinstri
+        [right] hægri
+        [up] upp
+    }
+    .display = Færa glugga um einn skjá { $direction ->
+        *[down] niður
+        [left] vinstri
+        [right] hægri
+        [up] upp
+    }
+    .workspace = Færa glugga um eitt vinnusvæði { $direction ->
+        *[below] fyrir neðan
+        [left] vinstri
+        [right] hægri
+        [above] fyrir ofan
+    }
+    .workspace-num = Færa glugga á vinnusvæði { $num }
+    .prev-workspace = Færa glugga á fyrra vinnusvæði
+    .next-workspace = Færa glugga á næsta vinnusvæði
+    .last-workspace = Færa glugga á síðasta vinnusvæði
+    .next-display = Færa glugga á næsta skjá
+    .prev-display = Færa glugga á fyrri skjá
+    .send-to-prev-workspace = Færa glugga á fyrra vinnusvæði
+    .send-to-next-workspace = Færa glugga á næsta vinnusvæði
+system-shortcut = Kerfi
+    .app-library = Opna forritasafnið
+    .brightness-down = Minnka birtustig skjás
+    .brightness-up = Auka birtustig skjás
+    .display-toggle = Víxla innbyggðum skjá
+    .home-folder = Opna heimamöppu
+    .keyboard-brightness-down = Minnka birtu lyklaborðs
+    .keyboard-brightness-up = Auka birtu lyklaborðs
+    .launcher = Opna ræsinn
+    .log-out = Skrá út
+    .lock-screen = Læsa skjánum
+    .mute = Þagga hljóðúttak
+    .mute-mic = Þaggar hljóðnemainntak
+    .play-pause = Spila/gera hlé
+    .play-next = Næsta lag
+    .play-prev = Fyrra lag
+    .poweroff = Slökkva
+    .screenshot = Taka skjámynd
+    .suspend = Svæfa
+    .terminal = Opna skjáhermi
+    .touchpad-toggle = Víxla snertifleti
+    .volume-lower = Lækka hljóðstyrk úttaks
+    .volume-raise = Hækka hljóðstyrk úttaks
+    .web-browser = Opna vafra
+    .window-switcher = Skipta á milli opinna glugga
+    .window-switcher-previous = Skipta á milli opinna glugga í öfugri röð
+    .workspace-overview = Opna yfirlit vinnusvæða
+window-tiling = Reitaröðun glugga
+    .horizontal = Stilla á lárétta stefnu
+    .vertical = Stilla á lóðrétta stefnu
+    .swap-window = Víxla glugga
+    .toggle-tiling = Víxla reitaröðun glugga
+    .toggle-stacking = Víxla stöflun glugga
+    .toggle-floating = Víxla fljótandi glugga
+    .toggle-orientation = Víxla stefnu
+replace-shortcut-dialog = Skipta út flýtilykli?
+    .desc = { $shortcut } er notaður af { $name }. Ef þú skiptir honum út verður { $name } gert óvirkt.
+zoom-in = Þysja inn
+zoom-out = Þysja út
+
+## Input: Mouse
+mouse = Mús
+    .speed = Hraði músar
+    .acceleration = Virkja hröðun músar
+
+## Input: Touchpad
+click-behavior = Hegðun smells
+    .click-finger = Aukasmellur með tveimur fingrum og miðjusmellur með þremur fingrum
+    .button-areas = Aukasmellur í neðra hægra horni og miðjusmellur neðst í miðju
+pinch-to-zoom = Klípa til að þysja
+    .desc = Notaðu tvo fingur til að þysja inn í innihald, fyrir forrit sem styðja aðdrátt
+tap-to-click = Banka til að smella
+    .desc = Virkjar bank með einum fingri fyrir aðalsmell, með tveimur fingrum fyrir aukasmell og með þremur fingrum fyrir miðjusmell
+touchpad = Snertiflötur
+    .acceleration = Virkja hröðun snertiflatar
+    .speed = Hraði snertiflatar
+
+## Input: Gestures
+gestures = Bendingar
+    .four-finger-down = Fjögurra fingra strok niður
+    .four-finger-left = Fjögurra fingra strok til vinstri
+    .four-finger-right = Fjögurra fingra strok til hægri
+    .four-finger-up = Fjögurra fingra strok upp
+    .three-finger-any = Þriggja fingra strok í hvaða átt sem er
+switch-workspaces = Skipta um vinnusvæði
+    .horizontal = Fjögurra fingra strok til vinstri/hægri
+    .vertical = Fjögurra fingra strok upp/niður
+switch-between-windows = Skipta á milli glugga
+open-application-library = Opna forritasafn
+open-workspaces-view = Opna yfirlit vinnusvæða
+
+## Time & language
+time = Tími og tungumál
+time-date = Dagsetning og tími
+    .auto = Stilla sjálfvirkt
+    .auto-ntp = Dagsetning og tími uppfærast sjálfkrafa þegar tímabelti er stillt
+time-zone = Tímabelti
+    .auto = Sjálfvirkt tímabelti
+    .auto-info = Krefst staðsetningarþjónustu og nettengingar
+time-format = Snið dagsetningar og tíma
+    .twenty-four = 24 klukkustunda tími
+    .show-seconds = Sýna sekúndur
+    .first = Fyrsti dagur vikunnar
+    .show-date = Sýna dagsetningu í tímasmáforritinu
+    .friday = Föstudagur
+    .saturday = Laugardagur
+    .sunday = Sunnudagur
+    .monday = Mánudagur
+time-region = Svæði og tungumál
+formatting = Sniðmótun
+    .dates = Dagsetningar
+    .time = Tími
+    .date-and-time = Dagsetning og tími
+    .numbers = Tölur
+    .measurement = Mælieiningar
+    .paper = Pappír
+preferred-languages = Æskileg tungumál
+    .desc = Röð tungumálanna ræður hvaða tungumál er notað í notendaviðmótinu. Breytingar taka gildi við næstu innskráningu.
+add-language = Bæta við tungumáli
+    .context = Bæta við tungumáli
+install-additional-languages = Setja upp fleiri tungumál
+region = Svæði
+
+## Applications
+applications = Forrit
+
+## Applications: Default applications
+default-apps = Sjálfgefin forrit
+    .web-browser = Vafri
+    .file-manager = Skráastjóri
+    .mail-client = Póstforrit
+    .music = Tónlist
+    .video = Myndskeið
+    .photos = Ljósmyndir
+    .calendar = Dagatal
+    .terminal = Skjáhermir
+    .other-associations = Aðrar tengingar
+    .text-editor = Textaritill
+    .not-installed = Ekki uppsett
+
+
+## Applications: Startup applications
+startup-apps = Ræsiforrit
+    .add = Bæta við forriti
+    .user = Forrit sem ræsast þegar þú skráir þig inn
+    .none = Engum ræsiforritum bætt við
+    .remove-dialog-title = Fjarlægja { $name }?
+    .remove-dialog-description = Fjarlægja þetta ræsiforrit?
+    .add-startup-app = Bæta við ræsiforriti
+
+## Applications: Legacy applications
+legacy-applications = Samhæfni X11-forrita
+legacy-app-global-shortcuts = Altækir flýtilyklar í X11-forritum
+    .desc = Altækir flýtilyklar gera öðrum forritum kleift að þekkja lyklaslög og músarhnappaatburði sem framkvæmdir eru í forritum, fyrir eiginleika á borð við ýta-til-að-tala eða ýta-til-að-þagga. Sjálfgefið eru altækir flýtilyklar óvirkir í X11-forritum til að tryggja að önnur forrit geti ekki fylgst með lyklaborðs- og músaratburðum sem innihalda viðkvæmar upplýsingar.
+    .none = Engir lyklar
+    .modifiers = Breytilyklar (Super, Shift, Control, Alt)
+    .combination = Allir lyklar á meðan breytilyklarnir Super, Control eða Alt eru inni
+    .all = Allir lyklar
+    .mouse = Músarhnappaatburðir í X11-forritum
+legacy-app-scaling = Kvörðun forrita í X11-gluggakerfi
+    .scaled-gaming = Fínstilla fyrir leiki og heilskjásforrit
+    .gaming-description = X11-forrit gætu virst örlítið stærri/minni samanborið við Wayland-forrit
+    .scaled-applications = Fínstilla fyrir forrit
+    .applications-description = Leikir og heilskjá-X11-forrit gætu ekki passað við skjáupplausn þína
+    .scaled-compatibility = Hámarkssamhæfnisstilling
+    .compatibility-description = X11-forrit gætu virst óskýr á HiDPI-skjám
+    .preferred-display = Æskilegur skjár fyrir leiki og heilskjá-X11-forrit
+    .no-display = Enginn
+
+## System
+system = Kerfi og reikningar
+
+## System: About
+about = Um
+about-device = Heiti tækis
+    .desc = Þetta heiti birtist öðrum net- eða Bluetooth-tækjum
+about-hardware = Vélbúnaður
+    .model = Vélbúnaðargerð
+    .memory = Minni
+    .processor = Örgjörvi
+    .graphics = Skjákort
+    .disk-capacity = Diskrými
+about-os = Stýrikerfi
+    .os = Stýrikerfi
+    .os-architecture = Högun stýrikerfis
+    .kernel = Útgáfa kjarna
+    .desktop-environment = Skjáborðsumhverfi
+    .windowing-system = Gluggakerfi
+about-related = Tengdar stillingar
+    .support = Fá aðstoð
+
+## System: Firmware
+firmware = Fastbúnaður
+
+## System: Users
+users = Notendur
+    .admin = Stjórnandi
+    .standard = Venjulegur
+    .profile-add = Velja notandamynd
+administrator = Kerfisstjóri
+    .desc = Kerfisstjórar geta breytt stillingum fyrir alla notendur og bætt við eða fjarlægt aðra notendur
+add-user = Bæta við notanda
+change-password = Breyta lykilorði
+remove-user = Fjarlægja notanda
+full-name = Fullt nafn
+invalid-username = Ógilt notandanafn
+password-mismatch = Lykilorð og staðfesting verða að vera eins


### PR DESCRIPTION
Completes the Icelandic (`is`) localization to 100% key parity with `en`.

Terminology grounded in Íðorðabankinn (the TOLVA computing dictionary, Árnastofnun) and made consistent with COSMIC's existing Icelandic translations. Fluent placeables, selector keys, attributes, and proper nouns are preserved; only human-readable text was translated. Validated with `fluent.syntax` (no Junk) and full en/is key-parity checks.