### PR TITLE
Added dav1d to flake and updated flake lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760533177,
-        "narHash": "sha256-OwM1sFustLHx+xmTymhucZuNhtq98fHIbfO8Swm5L8A=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "35f590344ff791e6b1d6d6b8f3523467c9217caf",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
             libinput
             libpulseaudio.dev
             pipewire.dev
+            dav1d
           ];
 
           RUST_SRC_PATH = rustPlatform.rustLibSrc;


### PR DESCRIPTION
Hello,

The nix flake wasn't compiling on my system due to an outdated nix flake lock and due to the flake missing the 'dav1d' package. I've included the of `cargo run --release` to the end of this PR.

To fix the issue, I've added the 'dav1d' package to the flake build dependencies and updated the nix flake lock.

Here are the logs:

Outdated flake lock:
```
[alexander@fedora-desktop]:~/dev/cosmic-settings$ cargo build --release
error: rustc 1.89.0 is not supported by the following packages:
  build_helpers@0.14.0 requires rustc 1.92
  cosmic-settings-a11y-manager-subscription@1.0.7 requires rustc 1.93
  cosmic-settings-accessibility-subscription@1.0.7 requires rustc 1.93
  cosmic-settings-bluetooth-subscription@1.0.7 requires rustc 1.93
  cosmic-settings-sound@0.1.0 requires rustc 1.93
  cosmic-settings-wallpaper@1.0.7 requires rustc 1.93
  iced@0.14.0 requires rustc 1.92
  iced@0.14.0 requires rustc 1.92
  iced@0.14.0 requires rustc 1.92
  iced_program@0.14.0 requires rustc 1.92
  libcosmic@1.0.0 requires rustc 1.93
  libcosmic@1.0.0 requires rustc 1.93
  libcosmic@1.0.0 requires rustc 1.93
  nmrs@3.4.2 requires rustc 1.90.0
  wgpu@28.0.0 requires rustc 1.92
  wgpu@28.0.0 requires rustc 1.92
  wgpu@28.0.0 requires rustc 1.92
```

Missing `dav1d` package:
```
[alexander@fedora-desktop]:~/dev/cosmic-settings$ cargo run --release
   Compiling [lots of packages I'm ommitting to save space]
error: failed to run custom build command for `dav1d-sys v0.8.3`

Caused by:
  process didn't exit successfully: `/home/alexander/dev/cosmic-settings/target/release/build/dav1d-sys-ad5f30d34b5faf0d/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=/home/alexander/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dav1d-sys-0.8.3/Cargo.toml
  cargo:rerun-if-env-changed=DAV1D_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr

  thread 'main' (103968) panicked at /home/alexander/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dav1d-sys-0.8.3/build.rs:82:10:
  called `Result::unwrap()` on an `Err` value: PkgConfig(
  pkg-config exited with status code 1
  > PKG_CONFIG_PATH=/nix/store/3hn5apbk6daalvsv60yqp838ksnk1afb-systemd-minimal-261.1-dev/lib/pkgconfig:/nix/store/3hn5apbk6daalvsv60yqp838ksnk1afb-systemd-minimal-261.1-dev/share/pkgconfig:/nix/store/k3xfi5kna47grqcnxmcrmr93zzkqxb95-bash-interactive-5.3p15-dev/lib/pkgconfig:/nix/store/xb0m5rc3gi06vkqgy7imdj10s1185cf6-libxkbcommon-1.13.2-dev/lib/pkgconfig:/nix/store/dyf771n6s2n4916xc3wg7lgqszlip9si-freetype-2.14.3-dev/lib/pkgconfig:/nix/store/h4si9iyvqy1aaqy4piqw0pj2c6snmz69-zlib-1.3.2-dev/share/pkgconfig:/nix/store/7974cqzg21vw1wj2jf54a3kk5vh7i8y6-bzip2-1.0.8-dev/lib/pkgconfig:/nix/store/hp5mxa6dpwd2dd6kvm7jvfm98wpl4iif-brotli-1.2.0-dev/lib/pkgconfig:/nix/store/q7c0q3hxgkwafjb62d3iw6mx7qfxa9jq-libpng-apng-1.6.58-dev/lib/pkgconfig:/nix/store/lgcl3yxy6n928zys56y69828bz1xmbp9-fontconfig-2.18.2-dev/lib/pkgconfig:/nix/store/yhscx6h8vwvc2xnfcn6jlv2zhss2r128-expat-2.8.2-dev/lib/pkgconfig:/nix/store/25z81mr9anpamdwv7lizq5l56hhq6kmi-libinput-1.31.3-dev/lib/pkgconfig:/nix/store/w4mlx4zfv6nwxdc3br14rs1ghy9f9fbk-systemd-minimal-libs-261.1-dev/lib/pkgconfig:/nix/store/w4mlx4zfv6nwxdc3br14rs1ghy9f9fbk-systemd-minimal-libs-261.1-dev/share/pkgconfig:/nix/store/8s82ww3p9rhxzviry8ak3s1c240r09k1-libpulseaudio-17.0-dev/lib/pkgconfig:/nix/store/b4jvpvm1acv93xbr85yix1wqjlfgjr6d-libcap-2.78-dev/lib/pkgconfig:/nix/store/cx05rqvqsccfv9ijhjr287czgq2nyyzb-pipewire-1.6.8-dev/lib/pkgconfig PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags dav1d 'dav1d >= 1.3.0'

  pkg-config output:
    Package dav1d was not found in the pkg-config search path.
    Perhaps you should add the directory containing `dav1d.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'dav1d' found
    Package dav1d was not found in the pkg-config search path.
    Perhaps you should add the directory containing `dav1d.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'dav1d' found

  The system library `dav1d` required by crate `dav1d-sys` was not found.
  The file `dav1d.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  PKG_CONFIG_PATH contains the following:
      - /nix/store/3hn5apbk6daalvsv60yqp838ksnk1afb-systemd-minimal-261.1-dev/lib/pkgconfig
      - /nix/store/3hn5apbk6daalvsv60yqp838ksnk1afb-systemd-minimal-261.1-dev/share/pkgconfig
      - /nix/store/k3xfi5kna47grqcnxmcrmr93zzkqxb95-bash-interactive-5.3p15-dev/lib/pkgconfig
      - /nix/store/xb0m5rc3gi06vkqgy7imdj10s1185cf6-libxkbcommon-1.13.2-dev/lib/pkgconfig
      - /nix/store/dyf771n6s2n4916xc3wg7lgqszlip9si-freetype-2.14.3-dev/lib/pkgconfig
      - /nix/store/h4si9iyvqy1aaqy4piqw0pj2c6snmz69-zlib-1.3.2-dev/share/pkgconfig
      - /nix/store/7974cqzg21vw1wj2jf54a3kk5vh7i8y6-bzip2-1.0.8-dev/lib/pkgconfig
      - /nix/store/hp5mxa6dpwd2dd6kvm7jvfm98wpl4iif-brotli-1.2.0-dev/lib/pkgconfig
      - /nix/store/q7c0q3hxgkwafjb62d3iw6mx7qfxa9jq-libpng-apng-1.6.58-dev/lib/pkgconfig
      - /nix/store/lgcl3yxy6n928zys56y69828bz1xmbp9-fontconfig-2.18.2-dev/lib/pkgconfig
      - /nix/store/yhscx6h8vwvc2xnfcn6jlv2zhss2r128-expat-2.8.2-dev/lib/pkgconfig
      - /nix/store/25z81mr9anpamdwv7lizq5l56hhq6kmi-libinput-1.31.3-dev/lib/pkgconfig
      - /nix/store/w4mlx4zfv6nwxdc3br14rs1ghy9f9fbk-systemd-minimal-libs-261.1-dev/lib/pkgconfig
      - /nix/store/w4mlx4zfv6nwxdc3br14rs1ghy9f9fbk-systemd-minimal-libs-261.1-dev/share/pkgconfig
      - /nix/store/8s82ww3p9rhxzviry8ak3s1c240r09k1-libpulseaudio-17.0-dev/lib/pkgconfig
      - /nix/store/b4jvpvm1acv93xbr85yix1wqjlfgjr6d-libcap-2.78-dev/lib/pkgconfig
      - /nix/store/cx05rqvqsccfv9ijhjr287czgq2nyyzb-pipewire-1.6.8-dev/lib/pkgconfig

  HINT: you may need to install a package such as dav1d, dav1d-dev or dav1d-devel.
  )
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

- [x] I have disclosed use of any AI generated code in my commit messages.
No AI generated code here.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Please let me know if there's anything more I should do or change!
-- Alex

**edit**: forgot to accept the Developer Certificate of Origin, and needed to fix a typo, my bad!