### PR TITLE
fix: pass current refresh rate to cosmic-randr when changing monitor position

### DIFF
--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -1104,7 +1104,11 @@ impl Page {
                     .arg("--pos-y")
                     .arg(itoa::Buffer::new().format(y))
                     .arg("--refresh")
-                    .arg(format!("{}.{:03}", current.refresh_rate / 1000, current.refresh_rate % 1000))
+                    .arg(format!(
+                        "{}.{:03}",
+                        current.refresh_rate / 1000,
+                        current.refresh_rate % 1000
+                    ))
                     .arg(name)
                     .arg(itoa::Buffer::new().format(current.size.0))
                     .arg(itoa::Buffer::new().format(current.size.1));

--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -1104,7 +1104,7 @@ impl Page {
                     .arg("--pos-y")
                     .arg(itoa::Buffer::new().format(y))
                     .arg("--refresh")
-                    .arg((current.refresh_rate as f32 / 1000.0).ceil().to_string())
+                    .arg(format!("{}.{:03}", current.refresh_rate / 1000, current.refresh_rate % 1000))
                     .arg(name)
                     .arg(itoa::Buffer::new().format(current.size.0))
                     .arg(itoa::Buffer::new().format(current.size.1));

--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -1103,6 +1103,8 @@ impl Page {
                     .arg(itoa::Buffer::new().format(x))
                     .arg("--pos-y")
                     .arg(itoa::Buffer::new().format(y))
+                    .arg("--refresh")
+                    .arg((current.refresh_rate as f32 / 1000.0).ceil().to_string())
                     .arg(name)
                     .arg(itoa::Buffer::new().format(current.size.0))
                     .arg(itoa::Buffer::new().format(current.size.1));


### PR DESCRIPTION
Hello,

I've had a really strange and specific issue while using the COSMIC settings app where changing the display position _specifically_ on my secondary ASUS VG249 monitor would set the refresh rate of the monitor to 60hz even though it was already set to 144hz.

This seems to happen when constructing the `cosmic-randr` command to call. The command called sets only the position of the monitor which different monitors tend to handle differently. The low-level explanation is above me at the moment, but specifying the refresh rate explicitly in the constructed `cosmic-randr` command appears to fix the issue at best and does nothing at worst.

I thought that `cosmic-randr` was trying to select the refresh rate of the monitor's default mode, but that doesn't seem to hold on my TV as it's default mode is 3560x2560@60 (had it set to 2560x1440@120 in the demo) so in theory it should have set the refresh rate to 60, but that didn't happen. Any other ideas/theories are welcome!

Here's a demo of the issue along with a demo of the fixed build: https://github.com/user-attachments/assets/5ffa3d3d-a9c9-4e62-843d-a7af72be4061

Testers would be greatly appreciated if you're also seeing this issue yourself!

Should also fix the following quote within the description of the issue https://github.com/pop-os/cosmic-epoch/issues/1540:
> If you then click the offending monitor and try to reposition it, after the screen flashes black and comes back the refresh rate setting will have been changed back to 60 Hz.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Please let me know if any improvements need to be made!
-- Alex