### PR TITLE
Add a Window management toggle for system window headers

### DIFF
--- a/cosmic-settings/src/pages/desktop/window_management.rs
+++ b/cosmic-settings/src/pages/desktop/window_management.rs
@@ -5,7 +5,7 @@ use cosmic::iced::Length;
 use cosmic::widget::{self, settings};
 use cosmic::{Apply, Element, surface};
 
-use cosmic_comp_config::CosmicCompConfig;
+use cosmic_comp_config::{AppearanceConfig, CosmicCompConfig};
 use cosmic_config::{ConfigGet, ConfigSet};
 use cosmic_settings_config::{Action, Binding, Shortcuts, shortcuts};
 use cosmic_settings_page::{self as page, Section, section};
@@ -24,6 +24,7 @@ pub enum Message {
     ShowMaximizeButton(bool),
     ShowMinimizeButton(bool),
     SetEdgeSnapThreshold(u32),
+    ShowTitlebars(bool),
     Surface(surface::Action),
 }
 
@@ -37,6 +38,7 @@ pub struct Page {
     cursor_follows_focus: bool,
     show_active_hint: bool,
     edge_snap_threshold: u32,
+    appearance_conf: AppearanceConfig,
 }
 
 impl Default for Page {
@@ -86,6 +88,15 @@ impl Default for Page {
             })
             .unwrap_or(0);
 
+        let appearance_conf = comp_config
+            .get::<AppearanceConfig>("appearance_settings")
+            .unwrap_or_else(|err| {
+                if err.is_err() {
+                    error!(?err, "Failed to read config 'appearance_settings'");
+                }
+                AppearanceConfig::default()
+            });
+
         Page {
             super_key_selections: vec![
                 fl!("super-key", "launcher"),
@@ -101,6 +112,7 @@ impl Default for Page {
             cursor_follows_focus,
             show_active_hint,
             edge_snap_threshold,
+            appearance_conf,
         }
     }
 }
@@ -179,9 +191,21 @@ impl Page {
                     error!(?err, "Failed to set config 'active_hint'");
                 }
             }
+            Message::ShowTitlebars(value) => {
+                self.appearance_conf.show_titlebars = value;
+                if let Err(err) = self
+                    .comp_config
+                    .set("appearance_settings", self.appearance_conf)
+                {
+                    error!(?err, "Failed to set config 'appearance_settings'");
+                }
+            }
             Message::CompConfigUpdate(comp_config) => {
                 if comp_config.active_hint != self.show_active_hint {
                     self.show_active_hint = comp_config.active_hint;
+                }
+                if comp_config.appearance_settings != self.appearance_conf {
+                    self.appearance_conf = comp_config.appearance_settings;
                 }
             }
             Message::SetEdgeSnapThreshold(value) => {
@@ -231,6 +255,8 @@ pub fn window_management() -> Section<crate::pages::Message> {
         _applications = fl!("super-key", "applications");
         _none = fl!("super-key", "none");
         edge_gravity = fl!("edge-gravity");
+        system_window_headers = fl!("system-window-headers");
+        system_window_headers_desc = fl!("system-window-headers", "desc");
     });
 
     Section::default()
@@ -259,6 +285,11 @@ pub fn window_management() -> Section<crate::pages::Message> {
                         .toggler(page.edge_snap_threshold != 0, |is_enabled| {
                             Message::SetEdgeSnapThreshold(if is_enabled { 10 } else { 0 })
                         }),
+                )
+                .add(
+                    settings::item::builder(&descriptions[system_window_headers])
+                        .description(&descriptions[system_window_headers_desc])
+                        .toggler(page.appearance_conf.show_titlebars, Message::ShowTitlebars),
                 )
                 .apply(Element::from)
                 .map(crate::pages::Message::WindowManagement)

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -501,6 +501,9 @@ super-key = Super key action
 
 edge-gravity = Floating windows gravitate to nearby edges
 
+system-window-headers = Use system window headers when possible
+    .desc = Applications may use their own window headers in some cases
+
 window-controls = Window controls
     .maximize = Show maximize button
     .minimize = Show minimize button


### PR DESCRIPTION
UI for pop-os/cosmic-comp#2666, per @maria-komarova's [design comment](https://github.com/pop-os/cosmic-comp/pull/2666#issuecomment-5244614158) there. Part of pop-os/cosmic-epoch#275.

That PR adds `appearance_settings.show_titlebars` to `CosmicCompConfig` — when off, the compositor doesn't draw a header bar for windows that don't decorate themselves, and doesn't reserve `SSD_HEIGHT` for one. It deliberately shipped without UI until the field name settled. This is the UI.

### What it does

A toggle at the bottom of the top section on Settings > Desktop > Window management, under "Floating windows gravitate to nearby edges", with the copy from the design comment:

- Body: **Use system window headers when possible**
- Caption: *Applications may use their own window headers in some cases*

`AppearanceConfig` is read and written back whole rather than poking a single field, matching what the appearance page's corner-radius controls (`appearance/drawer.rs`) already do — so `clip_floating_windows`, `clip_tiled_windows` and `shadow_tiled_windows` survive a toggle. `CompConfigUpdate` syncs the struct too, so the control reflects changes made outside of Settings.

### Notes

- **Blocked on pop-os/cosmic-comp#2666.** `show_titlebars` only exists on that branch, so this won't build until it merges and `Cargo.lock` is bumped to pick up the new `cosmic-comp-config`. Verified locally against it with a `[patch]` pointing at that branch: `cargo check --features page-window-management` clean (the 4 warnings are pre-existing, in `startup_apps.rs` and `font_config.rs`), `cargo fmt --check` clean. Happy to add the lock bump here once the comp side lands, or leave it to a `chore: update dependencies`.
- If the field gets renamed during review over there (`ssd_enabled` was suggested), this is a one-line follow-up.
- English strings only; leaving the other locales to translators.

---

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
