### PR TITLE
feat(desktop): make floating window rules configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,6 +1528,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "cosmic-bg-config",
+ "cosmic-client-toolkit",
  "cosmic-comp-config",
  "cosmic-config",
  "cosmic-idle-config",

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -19,6 +19,7 @@ jiff = "0.2"
 clap = { version = "4.6.4", features = ["derive"] }
 color-eyre = "0.6.5"
 cosmic-bg-config.workspace = true
+cosmic-client-toolkit = { git = "https://github.com/pop-os/cosmic-protocols", optional = true }
 cosmic-comp-config = { workspace = true, optional = true }
 cosmic-config.workspace = true
 cosmic-idle-config.workspace = true
@@ -183,7 +184,11 @@ page-region = [
 ]
 page-sound = ["dep:cosmic-settings-audio-client", "dep:cosmic-settings-sound"]
 page-users = ["xdg-portal", "dep:accounts-zbus", "dep:zbus", "dep:zbus_polkit"]
-page-window-management = ["cosmic-comp-config", "dep:cosmic-settings-config"]
+page-window-management = [
+    "cosmic-comp-config",
+    "dep:cosmic-client-toolkit",
+    "dep:cosmic-settings-config",
+]
 page-workspaces = ["cosmic-comp-config"]
 
 # Other features

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -676,6 +676,16 @@ impl cosmic::Application for SettingsApp {
                 }
 
                 #[cfg(feature = "page-window-management")]
+                crate::pages::Message::FloatingWindowExceptions(message) => {
+                    if let Some(page) = self
+                        .pages
+                        .page_mut::<desktop::window_management::floating_window_exceptions::Page>(
+                    ) {
+                        return page.update(message).map(Into::into);
+                    }
+                }
+
+                #[cfg(feature = "page-window-management")]
                 crate::pages::Message::WindowManagement(message) => {
                     if let Some(page) = self.pages.page_mut::<desktop::window_management::Page>() {
                         return page.update(message).map(Into::into);

--- a/cosmic-settings/src/pages/desktop/window_management.rs
+++ b/cosmic-settings/src/pages/desktop/window_management.rs
@@ -12,10 +12,13 @@ use cosmic_settings_page::{self as page, Section, section};
 use slotmap::SlotMap;
 use tracing::error;
 
+pub mod floating_window_exceptions;
+
 #[derive(Clone, Debug)]
 pub enum Message {
     SuperKey(usize),
     CompConfigUpdate(Box<CosmicCompConfig>),
+    OpenFloatingWindowExceptions,
     SetFocusFollowsCursor(bool),
     SaveFocusFollowsCursorDelay(bool),
     SetFocusFollowsCursorDelay(String),
@@ -30,6 +33,7 @@ pub enum Message {
 pub struct Page {
     pub super_key_selections: Vec<String>,
     pub super_key_active: Option<usize>,
+    floating_window_exceptions: page::Entity,
     comp_config: cosmic_config::Config,
     focus_follows_cursor: bool,
     focus_follows_cursor_delay: u64,
@@ -94,6 +98,7 @@ impl Default for Page {
                 fl!("super-key", "none"),
             ],
             super_key_active: super_key_active_config(),
+            floating_window_exceptions: page::Entity::default(),
             comp_config,
             focus_follows_cursor,
             focus_follows_cursor_delay,
@@ -119,6 +124,11 @@ impl Page {
 
                 self.super_key_active = Some(id);
                 super_key_set(action);
+            }
+            Message::OpenFloatingWindowExceptions => {
+                return cosmic::task::message(crate::app::Message::Page(
+                    self.floating_window_exceptions,
+                ));
             }
             Message::SetFocusFollowsCursor(value) => {
                 self.focus_follows_cursor = value;
@@ -208,6 +218,7 @@ impl page::Page<crate::pages::Message> for Page {
             sections.insert(window_management()),
             sections.insert(window_controls()),
             sections.insert(focus_navigation()),
+            sections.insert(tiling()),
         ])
     }
 
@@ -221,7 +232,21 @@ impl page::Page<crate::pages::Message> for Page {
     }
 }
 
-impl page::AutoBind<crate::pages::Message> for Page {}
+impl page::AutoBind<crate::pages::Message> for Page {
+    fn sub_pages(
+        mut page: page::Insert<crate::pages::Message>,
+    ) -> page::Insert<crate::pages::Message> {
+        let floating_window_exceptions =
+            page.sub_page_with_id::<floating_window_exceptions::Page>();
+
+        page.model
+            .page_mut::<Page>()
+            .unwrap()
+            .floating_window_exceptions = floating_window_exceptions;
+
+        page
+    }
+}
 
 pub fn window_management() -> Section<crate::pages::Message> {
     crate::slab!(descriptions {
@@ -259,6 +284,33 @@ pub fn window_management() -> Section<crate::pages::Message> {
                         .toggler(page.edge_snap_threshold != 0, |is_enabled| {
                             Message::SetEdgeSnapThreshold(if is_enabled { 10 } else { 0 })
                         }),
+                )
+                .apply(Element::from)
+                .map(crate::pages::Message::WindowManagement)
+        })
+}
+
+pub fn tiling() -> Section<crate::pages::Message> {
+    crate::slab!(descriptions {
+        built_in_exceptions = fl!("floating-window-exceptions");
+        built_in_exceptions_desc = fl!("floating-window-exceptions", "description");
+    });
+
+    Section::default()
+        .title(fl!("window-tiling"))
+        .descriptions(descriptions)
+        .view::<Page>(move |_binder, _page, section| {
+            let descriptions = &section.descriptions;
+
+            settings::section()
+                .title(&section.title)
+                .add(
+                    widget::list::button(
+                        settings::item::builder(&descriptions[built_in_exceptions])
+                            .description(&descriptions[built_in_exceptions_desc])
+                            .control(widget::icon::from_name("go-next-symbolic")),
+                    )
+                    .on_press(Message::OpenFloatingWindowExceptions),
                 )
                 .apply(Element::from)
                 .map(crate::pages::Message::WindowManagement)

--- a/cosmic-settings/src/pages/desktop/window_management/floating_window_exceptions.rs
+++ b/cosmic-settings/src/pages/desktop/window_management/floating_window_exceptions.rs
@@ -2,23 +2,38 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use cosmic::app::{ContextDrawer, context_drawer};
+use cosmic::iced::{Alignment, Length};
 use cosmic::widget::{self, settings};
-use cosmic::{Apply, Element};
+use cosmic::{Apply, Element, Task};
+use cosmic_client_toolkit as cctk;
 use cosmic_config::{ConfigGet, ConfigSet};
 use cosmic_settings_config::window_rules::{self, PreciseApplicationException};
 use cosmic_settings_page::{self as page, Section, section};
+use regex::Regex;
 use slotmap::SlotMap;
+use std::collections::HashSet;
 use tracing::error;
 
 #[derive(Clone, Debug)]
 pub enum Message {
+    DeleteCustomExceptionAt(usize),
+    OpenAddCustomException,
     OpenBuiltInExceptions,
+    RunningWindowsLoaded(Vec<RunningWindow>),
+    SelectRunningWindow(usize),
     SetBuiltInExceptionEnabled(usize, bool),
 }
 
 #[derive(Clone, Copy, Debug)]
 enum ContextView {
+    AddCustomException,
     BuiltInExceptions,
+}
+
+#[derive(Clone, Debug)]
+pub struct RunningWindow {
+    app_id: String,
+    title: String,
 }
 
 pub struct Page {
@@ -26,6 +41,8 @@ pub struct Page {
     context_view: Option<ContextView>,
     window_rules_config: Option<cosmic_config::Config>,
     built_in_exceptions: Vec<PreciseApplicationException>,
+    custom_exceptions: Vec<PreciseApplicationException>,
+    running_windows: Option<Vec<RunningWindow>>,
 }
 
 impl Default for Page {
@@ -37,12 +54,18 @@ impl Default for Page {
             .as_ref()
             .map(load_built_in_exceptions)
             .unwrap_or_default();
+        let custom_exceptions = window_rules_config
+            .as_ref()
+            .map(|config| load_custom_exceptions(config, &built_in_exceptions))
+            .unwrap_or_default();
 
         Self {
             entity: page::Entity::default(),
             context_view: None,
             window_rules_config,
             built_in_exceptions,
+            custom_exceptions,
+            running_windows: None,
         }
     }
 }
@@ -50,9 +73,40 @@ impl Default for Page {
 impl Page {
     pub fn update(&mut self, message: Message) -> cosmic::Task<crate::app::Message> {
         match message {
+            Message::DeleteCustomExceptionAt(index) => {
+                self.delete_custom_exception_at(index);
+                cosmic::Task::none()
+            }
+            Message::OpenAddCustomException => {
+                self.running_windows = None;
+                self.context_view = Some(ContextView::AddCustomException);
+                cosmic::task::message(crate::app::Message::OpenContextDrawer(self.entity)).chain(
+                    Task::future(async {
+                        let windows = std::thread::spawn(load_running_windows)
+                            .join()
+                            .unwrap_or_default();
+                        crate::app::Message::PageMessage(
+                            crate::pages::Message::FloatingWindowExceptions(
+                                Message::RunningWindowsLoaded(windows),
+                            ),
+                        )
+                    }),
+                )
+            }
             Message::OpenBuiltInExceptions => {
                 self.context_view = Some(ContextView::BuiltInExceptions);
                 cosmic::task::message(crate::app::Message::OpenContextDrawer(self.entity))
+            }
+            Message::RunningWindowsLoaded(windows) => {
+                self.running_windows = Some(windows);
+                cosmic::Task::none()
+            }
+            Message::SelectRunningWindow(index) => {
+                if self.save_running_window_exception(index) {
+                    cosmic::task::message(crate::pages::Message::CloseContextDrawer)
+                } else {
+                    cosmic::Task::none()
+                }
             }
             Message::SetBuiltInExceptionEnabled(index, enabled) => {
                 self.set_built_in_exception_enabled(index, enabled);
@@ -72,6 +126,11 @@ impl Page {
             .window_rules_config
             .as_ref()
             .map(load_built_in_exceptions)
+            .unwrap_or_default();
+        self.custom_exceptions = self
+            .window_rules_config
+            .as_ref()
+            .map(|config| load_custom_exceptions(config, &self.built_in_exceptions))
             .unwrap_or_default();
     }
 
@@ -111,6 +170,118 @@ impl Page {
         }
 
         self.reload_built_in_exceptions();
+    }
+
+    fn delete_custom_exception_at(&mut self, index: usize) {
+        let Some(exception) = self.custom_exceptions.get(index).cloned() else {
+            return;
+        };
+        let Some(config) = self.window_rules_config.as_ref() else {
+            return;
+        };
+
+        let mut custom = config
+            .get::<Vec<PreciseApplicationException>>("tiling_exception_custom")
+            .unwrap_or_default();
+        custom.retain(|custom_exception| {
+            custom_exception.appid != exception.appid || custom_exception.title != exception.title
+        });
+
+        if let Err(err) = config.set("tiling_exception_custom", custom) {
+            error!(?err, "Failed to set config tiling_exception_custom");
+            return;
+        }
+
+        self.reload_built_in_exceptions();
+    }
+
+    fn save_running_window_exception(&mut self, index: usize) -> bool {
+        let Some(window) = self
+            .running_windows
+            .as_ref()
+            .and_then(|windows| windows.get(index))
+        else {
+            return false;
+        };
+        let Some(config) = self.window_rules_config.as_ref() else {
+            return false;
+        };
+
+        let appid = regex::escape(window.app_id.trim());
+        let title = regex::escape(window.title.trim());
+        let new_exception = PreciseApplicationException {
+            appid,
+            title,
+            enabled: true,
+        };
+
+        let mut custom = config
+            .get::<Vec<PreciseApplicationException>>("tiling_exception_custom")
+            .unwrap_or_default();
+
+        if is_built_in_exception(&new_exception, &self.built_in_exceptions) {
+            custom.retain(|exception| {
+                exception.appid != new_exception.appid || exception.title != new_exception.title
+            });
+        } else if !custom.iter().any(|exception| {
+            exception.appid == new_exception.appid && exception.title == new_exception.title
+        }) {
+            custom.push(new_exception);
+        }
+
+        if let Err(err) = config.set("tiling_exception_custom", custom) {
+            error!(?err, "Failed to set config tiling_exception_custom");
+            return false;
+        }
+
+        self.reload_built_in_exceptions();
+        true
+    }
+
+    fn running_windows_drawer(&self) -> Element<'_, crate::pages::Message> {
+        let mut section = settings::section().title("");
+
+        if let Some(running_windows) = &self.running_windows {
+            let available_windows = running_windows
+                .iter()
+                .enumerate()
+                .filter(|(_, window)| !self.window_has_enabled_exception(window))
+                .collect::<Vec<_>>();
+
+            if available_windows.is_empty() {
+                section = section.add(widget::text::body(fl!(
+                    "floating-window-exceptions",
+                    "running-empty"
+                )));
+            } else {
+                for (index, window) in available_windows {
+                    let title = if window.title.is_empty() {
+                        &window.app_id
+                    } else {
+                        &window.title
+                    };
+                    section = section.add(
+                        widget::list::button(
+                            settings::item::builder(title)
+                                .description(&window.app_id)
+                                .control(widget::icon::from_name("list-add-symbolic")),
+                        )
+                        .on_press(Message::SelectRunningWindow(index)),
+                    );
+                }
+            }
+        }
+
+        section
+            .apply(Element::from)
+            .map(crate::pages::Message::FloatingWindowExceptions)
+    }
+
+    fn window_has_enabled_exception(&self, window: &RunningWindow) -> bool {
+        self.built_in_exceptions
+            .iter()
+            .chain(self.custom_exceptions.iter())
+            .any(|exception| exception.enabled && window_matches_exception(window, exception))
     }
 
     fn built_in_exceptions_drawer(&self) -> Element<'_, crate::pages::Message> {
@@ -161,7 +332,10 @@ impl page::Page<crate::pages::Message> for Page {
         &self,
         sections: &mut SlotMap<section::Entity, Section<crate::pages::Message>>,
     ) -> Option<page::Content> {
-        Some(vec![sections.insert(built_in_exceptions())])
+        Some(vec![
+            sections.insert(custom_exceptions()),
+            sections.insert(built_in_exceptions()),
+        ])
     }
 
     fn info(&self) -> page::Info {
@@ -174,6 +348,11 @@ impl page::Page<crate::pages::Message> for Page {
 
     fn context_drawer(&self) -> Option<ContextDrawer<'_, crate::pages::Message>> {
         Some(match self.context_view? {
+            ContextView::AddCustomException => context_drawer(
+                self.running_windows_drawer(),
+                crate::pages::Message::CloseContextDrawer,
+            )
+            .title(fl!("floating-window-exceptions", "add-custom")),
             ContextView::BuiltInExceptions => context_drawer(
                 self.built_in_exceptions_drawer(),
                 crate::pages::Message::CloseContextDrawer,
@@ -216,6 +395,59 @@ fn built_in_exceptions() -> Section<crate::pages::Message> {
         })
 }
 
+fn custom_exceptions() -> Section<crate::pages::Message> {
+    crate::slab!(descriptions {
+        description = fl!("floating-window-exceptions", "select-description");
+        select = fl!("floating-window-exceptions", "select");
+    });
+
+    Section::default()
+        .descriptions(descriptions)
+        .view::<Page>(move |_binder, page, section| {
+            let descriptions = &section.descriptions;
+
+            let mut content = widget::column::with_capacity(3)
+                .spacing(24)
+                .align_x(Alignment::Center)
+                .push(
+                    widget::text::body(&descriptions[description])
+                        .width(Length::Fill)
+                        .align_x(Alignment::Center),
+                )
+                .push(
+                    widget::button::suggested(&descriptions[select])
+                        .on_press(Message::OpenAddCustomException),
+                );
+
+            if !page.custom_exceptions.is_empty() {
+                let mut settings_section = settings::section();
+                for (index, exception) in page.custom_exceptions.iter().enumerate() {
+                    let name = custom_exception_name(exception);
+                    settings_section = settings_section.add(
+                        settings::item::builder(name).control(
+                            widget::button::icon(widget::icon::from_name("edit-delete-symbolic"))
+                                .extra_small()
+                                .on_press(Message::DeleteCustomExceptionAt(index)),
+                        ),
+                    );
+                }
+                content = content.push(settings_section);
+            }
+
+            content
+                .apply(Element::from)
+                .map(crate::pages::Message::FloatingWindowExceptions)
+        })
+}
+
+fn custom_exception_name(exception: &PreciseApplicationException) -> String {
+    if exception.title == ".*" || exception.title.is_empty() {
+        exception.appid.clone()
+    } else {
+        exception.title.clone()
+    }
+}
+
 fn load_built_in_exceptions(config: &cosmic_config::Config) -> Vec<PreciseApplicationException> {
     let defaults = config
         .get::<Vec<window_rules::DefaultApplicationException>>("tiling_exception_defaults")
@@ -241,4 +473,183 @@ fn load_built_in_exceptions(config: &cosmic_config::Config) -> Vec<PreciseApplic
     }
 
     exceptions
+}
+
+fn load_custom_exceptions(
+    config: &cosmic_config::Config,
+    built_in_exceptions: &[PreciseApplicationException],
+) -> Vec<PreciseApplicationException> {
+    config
+        .get::<Vec<PreciseApplicationException>>("tiling_exception_custom")
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|exception| !is_built_in_exception(exception, built_in_exceptions))
+        .collect()
+}
+
+fn is_built_in_exception(
+    exception: &PreciseApplicationException,
+    built_in_exceptions: &[PreciseApplicationException],
+) -> bool {
+    built_in_exceptions
+        .iter()
+        .any(|built_in| built_in.appid == exception.appid && built_in.title == exception.title)
+}
+
+fn regex_matches(pattern: &str, value: &str) -> bool {
+    Regex::new(pattern.trim()).is_ok_and(|regex| regex.is_match(value))
+}
+
+fn window_matches_exception(
+    window: &RunningWindow,
+    exception: &PreciseApplicationException,
+) -> bool {
+    regex_matches(&exception.appid, &window.app_id)
+        && regex_matches(&exception.title, &window.title)
+}
+
+fn load_running_windows() -> Vec<RunningWindow> {
+    use cctk::sctk::{
+        output::{OutputHandler, OutputState},
+        registry::{ProvidesRegistryState, RegistryState},
+    };
+    use cctk::toplevel_info::{ToplevelInfoHandler, ToplevelInfoState};
+    use cctk::wayland_client::{
+        Connection, QueueHandle, globals::registry_queue_init, protocol::wl_output,
+    };
+    use cctk::wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1;
+
+    struct AppData {
+        output_state: OutputState,
+        registry_state: RegistryState,
+        toplevel_info_state: ToplevelInfoState,
+        done: bool,
+    }
+
+    impl AppData {
+        fn windows(&self) -> Vec<RunningWindow> {
+            let mut seen = HashSet::new();
+            let mut windows = self
+                .toplevel_info_state
+                .toplevels()
+                .filter(|info| !info.app_id.is_empty() || !info.title.is_empty())
+                .filter_map(|info| {
+                    let app_id = info.app_id.trim().to_string();
+                    let title = info.title.trim().to_string();
+                    if seen.insert((app_id.clone(), title.clone())) {
+                        Some(RunningWindow { app_id, title })
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            windows.sort_by(|a, b| a.app_id.cmp(&b.app_id).then_with(|| a.title.cmp(&b.title)));
+            windows
+        }
+    }
+
+    impl ProvidesRegistryState for AppData {
+        fn registry(&mut self) -> &mut RegistryState {
+            &mut self.registry_state
+        }
+
+        cctk::sctk::registry_handlers!(OutputState);
+    }
+
+    impl OutputHandler for AppData {
+        fn output_state(&mut self) -> &mut OutputState {
+            &mut self.output_state
+        }
+
+        fn new_output(
+            &mut self,
+            _conn: &Connection,
+            _qh: &QueueHandle<Self>,
+            _output: wl_output::WlOutput,
+        ) {
+        }
+
+        fn update_output(
+            &mut self,
+            _conn: &Connection,
+            _qh: &QueueHandle<Self>,
+            _output: wl_output::WlOutput,
+        ) {
+        }
+
+        fn output_destroyed(
+            &mut self,
+            _conn: &Connection,
+            _qh: &QueueHandle<Self>,
+            _output: wl_output::WlOutput,
+        ) {
+        }
+    }
+
+    impl ToplevelInfoHandler for AppData {
+        fn toplevel_info_state(&mut self) -> &mut ToplevelInfoState {
+            &mut self.toplevel_info_state
+        }
+
+        fn new_toplevel(
+            &mut self,
+            _conn: &Connection,
+            _qh: &QueueHandle<Self>,
+            _toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        ) {
+        }
+
+        fn update_toplevel(
+            &mut self,
+            _conn: &Connection,
+            _qh: &QueueHandle<Self>,
+            _toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        ) {
+        }
+
+        fn toplevel_closed(
+            &mut self,
+            _conn: &Connection,
+            _qh: &QueueHandle<Self>,
+            _toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        ) {
+        }
+
+        fn info_done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {
+            self.done = true;
+        }
+    }
+
+    cctk::sctk::delegate_output!(AppData);
+    cctk::sctk::delegate_registry!(AppData);
+    cctk::delegate_toplevel_info!(AppData);
+
+    let Ok(conn) = Connection::connect_to_env() else {
+        return Vec::new();
+    };
+    let Ok((globals, mut event_queue)) = registry_queue_init(&conn) else {
+        return Vec::new();
+    };
+    let qh = event_queue.handle();
+    let registry_state = RegistryState::new(&globals);
+    let Some(toplevel_info_state) = ToplevelInfoState::try_new(&registry_state, &qh) else {
+        return Vec::new();
+    };
+
+    let mut app_data = AppData {
+        output_state: OutputState::new(&globals, &qh),
+        registry_state,
+        toplevel_info_state,
+        done: false,
+    };
+
+    while !app_data.done {
+        if let Err(err) = event_queue.blocking_dispatch(&mut app_data) {
+            error!(?err, "Failed to read running windows");
+            break;
+        }
+    }
+
+    app_data.windows()
 }

--- a/cosmic-settings/src/pages/desktop/window_management/floating_window_exceptions.rs
+++ b/cosmic-settings/src/pages/desktop/window_management/floating_window_exceptions.rs
@@ -1,0 +1,244 @@
+// Copyright 2026 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use cosmic::app::{ContextDrawer, context_drawer};
+use cosmic::widget::{self, settings};
+use cosmic::{Apply, Element};
+use cosmic_config::{ConfigGet, ConfigSet};
+use cosmic_settings_config::window_rules::{self, PreciseApplicationException};
+use cosmic_settings_page::{self as page, Section, section};
+use slotmap::SlotMap;
+use tracing::error;
+
+#[derive(Clone, Debug)]
+pub enum Message {
+    OpenBuiltInExceptions,
+    SetBuiltInExceptionEnabled(usize, bool),
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ContextView {
+    BuiltInExceptions,
+}
+
+pub struct Page {
+    entity: page::Entity,
+    context_view: Option<ContextView>,
+    window_rules_config: Option<cosmic_config::Config>,
+    built_in_exceptions: Vec<PreciseApplicationException>,
+}
+
+impl Default for Page {
+    fn default() -> Self {
+        let window_rules_config = window_rules::context()
+            .inspect_err(|err| error!(?err, "Failed to load window rules config"))
+            .ok();
+        let built_in_exceptions = window_rules_config
+            .as_ref()
+            .map(load_built_in_exceptions)
+            .unwrap_or_default();
+
+        Self {
+            entity: page::Entity::default(),
+            context_view: None,
+            window_rules_config,
+            built_in_exceptions,
+        }
+    }
+}
+
+impl Page {
+    pub fn update(&mut self, message: Message) -> cosmic::Task<crate::app::Message> {
+        match message {
+            Message::OpenBuiltInExceptions => {
+                self.context_view = Some(ContextView::BuiltInExceptions);
+                cosmic::task::message(crate::app::Message::OpenContextDrawer(self.entity))
+            }
+            Message::SetBuiltInExceptionEnabled(index, enabled) => {
+                self.set_built_in_exception_enabled(index, enabled);
+                cosmic::Task::none()
+            }
+        }
+    }
+
+    fn reload_built_in_exceptions(&mut self) {
+        if self.window_rules_config.is_none() {
+            self.window_rules_config = window_rules::context()
+                .inspect_err(|err| error!(?err, "Failed to load window rules config"))
+                .ok();
+        }
+
+        self.built_in_exceptions = self
+            .window_rules_config
+            .as_ref()
+            .map(load_built_in_exceptions)
+            .unwrap_or_default();
+    }
+
+    fn set_built_in_exception_enabled(&mut self, index: usize, enabled: bool) {
+        let Some(exception) = self.built_in_exceptions.get(index).cloned() else {
+            return;
+        };
+        let Some(config) = self.window_rules_config.as_ref() else {
+            return;
+        };
+
+        let mut custom = config
+            .get::<Vec<PreciseApplicationException>>("tiling_exception_custom")
+            .unwrap_or_default();
+
+        if enabled {
+            custom.retain(|custom_exception| {
+                custom_exception.appid != exception.appid
+                    || custom_exception.title != exception.title
+            });
+        } else if let Some(existing) = custom
+            .iter_mut()
+            .find(|existing| existing.appid == exception.appid && existing.title == exception.title)
+        {
+            existing.enabled = false;
+        } else {
+            custom.push(PreciseApplicationException {
+                appid: exception.appid,
+                title: exception.title,
+                enabled: false,
+            });
+        }
+
+        if let Err(err) = config.set("tiling_exception_custom", custom) {
+            error!(?err, "Failed to set config tiling_exception_custom");
+            return;
+        }
+
+        self.reload_built_in_exceptions();
+    }
+
+    fn built_in_exceptions_drawer(&self) -> Element<'_, crate::pages::Message> {
+        let mut section = settings::section().title("");
+
+        for (index, exception) in self.built_in_exceptions.iter().enumerate() {
+            let description = if exception.title == ".*" {
+                fl!("floating-window-exceptions", "all-titles")
+            } else {
+                format!(
+                    "{}: {}",
+                    fl!("floating-window-exceptions", "title-pattern"),
+                    exception.title
+                )
+            };
+
+            section = section.add(
+                settings::item::builder(&exception.appid)
+                    .description(description)
+                    .toggler(exception.enabled, move |enabled| {
+                        Message::SetBuiltInExceptionEnabled(index, enabled)
+                    }),
+            );
+        }
+
+        widget::column::with_capacity(2)
+            .push(widget::text::body(fl!(
+                "floating-window-exceptions",
+                "built-in-description"
+            )))
+            .push(section)
+            .apply(Element::from)
+            .map(crate::pages::Message::FloatingWindowExceptions)
+    }
+}
+
+impl page::Page<crate::pages::Message> for Page {
+    fn set_id(&mut self, entity: page::Entity) {
+        self.entity = entity;
+    }
+
+    fn on_enter(&mut self) -> cosmic::Task<crate::pages::Message> {
+        self.reload_built_in_exceptions();
+        cosmic::Task::none()
+    }
+
+    fn content(
+        &self,
+        sections: &mut SlotMap<section::Entity, Section<crate::pages::Message>>,
+    ) -> Option<page::Content> {
+        Some(vec![sections.insert(built_in_exceptions())])
+    }
+
+    fn info(&self) -> page::Info {
+        page::Info::new(
+            "floating-window-exceptions",
+            "preferences-window-management-symbolic",
+        )
+        .title(fl!("floating-window-exceptions"))
+    }
+
+    fn context_drawer(&self) -> Option<ContextDrawer<'_, crate::pages::Message>> {
+        Some(match self.context_view? {
+            ContextView::BuiltInExceptions => context_drawer(
+                self.built_in_exceptions_drawer(),
+                crate::pages::Message::CloseContextDrawer,
+            )
+            .title(fl!("floating-window-exceptions", "built-in")),
+        })
+    }
+
+    fn on_context_drawer_close(&mut self) -> cosmic::Task<crate::pages::Message> {
+        self.context_view = None;
+        cosmic::Task::none()
+    }
+}
+
+impl page::AutoBind<crate::pages::Message> for Page {}
+
+fn built_in_exceptions() -> Section<crate::pages::Message> {
+    crate::slab!(descriptions {
+        title = fl!("floating-window-exceptions", "built-in");
+        description = fl!("floating-window-exceptions", "built-in-description");
+    });
+
+    Section::default()
+        .descriptions(descriptions)
+        .view::<Page>(move |_binder, _page, section| {
+            let descriptions = &section.descriptions;
+
+            settings::section()
+                .title(&section.title)
+                .add(
+                    widget::list::button(
+                        settings::item::builder(&descriptions[title])
+                            .description(&descriptions[description])
+                            .control(widget::icon::from_name("go-next-symbolic")),
+                    )
+                    .on_press(Message::OpenBuiltInExceptions),
+                )
+                .apply(Element::from)
+                .map(crate::pages::Message::FloatingWindowExceptions)
+        })
+}
+
+fn load_built_in_exceptions(config: &cosmic_config::Config) -> Vec<PreciseApplicationException> {
+    let defaults = config
+        .get::<Vec<window_rules::DefaultApplicationException>>("tiling_exception_defaults")
+        .unwrap_or_else(|err| {
+            error!(?err, "Failed to read config tiling_exception_defaults");
+            Vec::new()
+        });
+    let custom = config
+        .get::<Vec<PreciseApplicationException>>("tiling_exception_custom")
+        .unwrap_or_default();
+
+    let mut exceptions = defaults
+        .into_iter()
+        .flat_map(window_rules::DefaultApplicationException::expand)
+        .collect::<Vec<_>>();
+
+    for custom_exception in custom {
+        if let Some(exception) = exceptions.iter_mut().find(|exception| {
+            exception.appid == custom_exception.appid && exception.title == custom_exception.title
+        }) {
+            exception.enabled = custom_exception.enabled;
+        }
+    }
+
+    exceptions
+}

--- a/cosmic-settings/src/pages/mod.rs
+++ b/cosmic-settings/src/pages/mod.rs
@@ -102,6 +102,8 @@ pub enum Message {
     #[cfg(feature = "page-networking")]
     WiFi(networking::wifi::Message),
     #[cfg(feature = "page-window-management")]
+    FloatingWindowExceptions(desktop::window_management::floating_window_exceptions::Message),
+    #[cfg(feature = "page-window-management")]
     WindowManagement(desktop::window_management::Message),
     #[cfg(feature = "page-networking")]
     Wired(networking::wired::Message),

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -414,7 +414,7 @@ style = Style
     .less = less
     .more = more
     .glass-opacity = Glass opacity
-    
+
 interface-density = Interface density
     .comfortable = Comfortable
     .compact = Compact
@@ -492,6 +492,13 @@ dock = Dock
 ## Desktop: Window management
 
 window-management = Window management
+
+floating-window-exceptions = Floating window exceptions
+    .description = List of windows to keep floating when tiling is enabled.
+    .built-in = Built-in exceptions
+    .built-in-description = System exceptions based on validated user reports.
+    .all-titles = All window titles
+    .title-pattern = Window title
 
 super-key = Super key action
     .launcher = Open Launcher

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -497,6 +497,10 @@ floating-window-exceptions = Floating window exceptions
     .description = List of windows to keep floating when tiling is enabled.
     .built-in = Built-in exceptions
     .built-in-description = System exceptions based on validated user reports.
+    .add-custom = Add from running apps and windows
+    .select = Select
+    .select-description = Add exceptions by selecting currently running applications and windows.
+    .running-empty = No additional running apps or windows found
     .all-titles = All window titles
     .title-pattern = Window title
 


### PR DESCRIPTION
This PR makes the compositor's system rules configurable and adds a UI for creating custom exceptions according to the layout described in: https://github.com/pop-os/cosmic-settings/issues/438.

Depends on:
- [ ] https://github.com/pop-os/cosmic-protocols/pull/86

Backend
---
User config:  `~/.config/cosmic/com.system76.CosmicSettings.WindowRules/v1/tiling_exception_custom`

When the user changes the default value of a system rule, a new entry is added to the users config:
```RON
[
    (
        appid: "my.custom.rule",
        title: "My Custom Application",
        enabled: false,
    ),
    (
        appid: "",
        title: "wl-clipboard",
        enabled: false,
    ),
]
```
When the user resets the value to its default, the corresponding entry is removed from the users config, while custom rules are preserved:
```RON
[
    (
        appid: "my.custom.rule",
        title: "My Custom Application",
        enabled: false,
    ),
]
```

UI
---
**Window management**
<img width="829" height="757" alt="image" src="https://github.com/user-attachments/assets/e3a66d1a-c138-4391-9ec2-b98a57172d7b" />


**Floating window exceptions - without custom exceptions**
<img width="836" height="304" alt="image" src="https://github.com/user-attachments/assets/19c21dc7-3e3b-47ce-992c-0f1ae49a0b05" />

**Floating window exceptions - with custom exceptions**
<img width="836" height="416" alt="image" src="https://github.com/user-attachments/assets/dc75b547-18e7-48d9-b3b1-765cd2c7e6af" />

**Floating window exceptions - custom exception selection**
<img width="946" height="470" alt="image" src="https://github.com/user-attachments/assets/64e4d3ee-984d-49fa-bb04-13a2a1b7eb4d" />

**Floating window exceptions - custom exception selection, no entries**
<img width="946" height="621" alt="image" src="https://github.com/user-attachments/assets/1430c0cd-9d05-4eee-aea7-e930b5d5b58e" />

**Built-in exceptions**
<img width="946" height="2358" alt="image" src="https://github.com/user-attachments/assets/fb975b6f-27c4-4bab-a347-5f7c3e37a809" />

---
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

