### PR TITLE
don't display buttons related to nm-connection-editor when it's not a…

### DIFF
--- a/cosmic-settings/src/pages/networking/mod.rs
+++ b/cosmic-settings/src/pages/networking/mod.rs
@@ -21,7 +21,7 @@ use self::backend::devices::{DeviceState, DeviceType};
 
 pub type SecretSender = Arc<tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<SecureString>>>>;
 
-static NM_CONNECTION_EDITOR: &str = "nm-connection-editor";
+pub static NM_CONNECTION_EDITOR: &str = "nm-connection-editor";
 
 #[derive(Debug, Default)]
 pub struct Page {

--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -18,6 +18,7 @@ use futures::{SinkExt, StreamExt};
 use secure_string::SecureString;
 use tokio::sync::Mutex;
 
+use super::{NM_CONNECTION_EDITOR};
 use super::backend as network_manager;
 use super::backend::available_wifi::{AccessPoint, NetworkType};
 use super::backend::current_networks::ActiveConnectionInfo;
@@ -137,6 +138,7 @@ pub struct Page {
     qr_drawer: Option<QRCodeDrawer>,
     /// Search query for filtering WiFi networks
     search_query: String,
+    connection_editor_available: bool,
 }
 
 #[derive(Debug)]
@@ -164,7 +166,7 @@ impl page::Page<crate::pages::Message> for Page {
         &self,
         sections: &mut slotmap::SlotMap<section::Entity, Section<crate::pages::Message>>,
     ) -> Option<page::Content> {
-        Some(vec![sections.insert(devices_view())])
+        Some(vec![sections.insert(devices_view(self.connection_editor_available))])
     }
 
     fn dialog(&'_ self) -> Option<Element<'_, crate::pages::Message>> {
@@ -278,19 +280,25 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn header_view(&self) -> Option<cosmic::Element<'_, crate::pages::Message>> {
-        Some(
-            widget::button::standard(fl!("add-network"))
-                .trailing_icon(icon::from_name("window-pop-out-symbolic"))
-                .on_press(Message::AddNetwork)
-                .apply(widget::container)
-                .width(Length::Fill)
-                .align_x(Alignment::End)
-                .apply(Element::from)
-                .map(crate::pages::Message::WiFi),
-        )
+        if self.connection_editor_available {
+            Some(
+                widget::button::standard(fl!("add-network"))
+                    .trailing_icon(icon::from_name("window-pop-out-symbolic"))
+                    .on_press(Message::AddNetwork)
+                    .apply(widget::container)
+                    .width(Length::Fill)
+                    .align_x(Alignment::End)
+                    .apply(Element::from)
+                    .map(crate::pages::Message::WiFi),
+            )
+        } else {
+            None
+        }
     }
 
     fn on_enter(&mut self) -> cosmic::Task<crate::pages::Message> {
+        self.connection_editor_available = which::which(NM_CONNECTION_EDITOR).is_ok();
+
         let (tx, rx) = tokio::sync::mpsc::channel(4);
         self.secret_tx = Some(tx);
         if self.nm_task.is_none() {
@@ -886,7 +894,7 @@ fn escape_wifi_qr_string(s: &str) -> String {
         .replace('"', "\\\"")
 }
 
-fn devices_view() -> Section<crate::pages::Message> {
+fn devices_view(connection_editor_available: bool) -> Section<crate::pages::Message> {
     crate::slab!(descriptions {
         airplane_mode_txt = fl!("airplane-on");
         connect_txt = fl!("connect");
@@ -1013,10 +1021,12 @@ fn devices_view() -> Section<crate::pages::Message> {
                                                 &section.descriptions[disconnect_txt],
                                             )
                                         }))
-                                        .push(popup_button(
-                                            Message::Settings(network.ssid.clone()),
-                                            &section.descriptions[settings_txt],
-                                        ))
+                                        .push_maybe(connection_editor_available.then(|| {
+                                            popup_button(
+                                                Message::Settings(network.ssid.clone()),
+                                                &section.descriptions[settings_txt],
+                                            )
+                                        }))
                                         .push_maybe(is_known.then(|| {
                                             popup_button(
                                                 Message::QRCodeRequest(network.ssid.clone()),
@@ -1118,10 +1128,12 @@ fn devices_view() -> Section<crate::pages::Message> {
                                                 &section.descriptions[disconnect_txt],
                                             )
                                         }))
-                                        .push(popup_button(
-                                            Message::Settings(network.ssid.clone()),
-                                            &section.descriptions[settings_txt],
-                                        ))
+                                        .push_maybe(connection_editor_available.then(|| {
+                                            popup_button(
+                                                Message::Settings(network.ssid.clone()),
+                                                &section.descriptions[settings_txt],
+                                            )
+                                        }))
                                         .push_maybe(is_known.then(|| {
                                             popup_button(
                                                 Message::QRCodeRequest(network.ssid.clone()),

--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, LazyLock};
 use anyhow::Context;
 use cosmic::app::ContextDrawer;
 use cosmic::iced::core::text::Wrapping;
+use cosmic::iced::core::Widget;
 use cosmic::iced::widget::operation::focus_next;
 use cosmic::iced::{Alignment, Length};
 use cosmic::widget::space::horizontal;
@@ -1111,19 +1112,20 @@ fn devices_view(connection_editor_available: bool) -> Section<crate::pages::Mess
                                 .into()
                         };
 
-                        let view_more_button =
-                            widget::button::icon(widget::icon::from_name("view-more-symbolic"));
+                        let view_more: Option<Element<_>> =
+                            if (is_connected || connection_editor_available || is_known) {
+                                let view_more_button =
+                                    widget::button::icon(widget::icon::from_name("view-more-symbolic"));
 
-                        let view_more: Element<_> = if page
-                            .view_more_popup
-                            .as_deref()
-                            .is_some_and(|id| id == network.ssid.as_ref())
-                        {
-                            widget::popover(view_more_button.on_press(Message::ViewMore(None)))
-                                .position(widget::popover::Position::Bottom)
-                                .on_close(Message::ViewMore(None))
-                                .popup(
-                                    widget::column::with_capacity(4)
+                                let view_more  = if page
+                                    .view_more_popup
+                                    .as_deref()
+                                    .is_some_and(|id| id == network.ssid.as_ref())
+                                {
+                                    widget::popover(view_more_button.on_press(Message::ViewMore(None)))
+                                        .position(widget::popover::Position::Bottom)
+                                        .on_close(Message::ViewMore(None))
+                                        .popup(widget::column::with_capacity(4)
                                         .push_maybe(is_connected.then(|| {
                                             popup_button(
                                                 Message::Disconnect(network.ssid.clone()),
@@ -1151,14 +1153,18 @@ fn devices_view(connection_editor_available: bool) -> Section<crate::pages::Mess
                                         .width(Length::Fixed(200.0))
                                         .apply(widget::container)
                                         .padding(cosmic::theme::spacing().space_xxs)
-                                        .class(cosmic::theme::Container::Dropdown),
-                                )
-                                .into()
-                        } else {
-                            view_more_button
-                                .on_press(Message::ViewMore(Some(network.ssid.clone())))
-                                .into()
-                        };
+                                        .class(cosmic::theme::Container::Dropdown))
+                                        .into()
+                                } else {
+                                    view_more_button
+                                        .on_press(Message::ViewMore(Some(network.ssid.clone())))
+                                        .into()
+                                };
+
+                                Some(view_more)
+                            } else {
+                                None
+                            };
 
                         let controls = widget::row::with_capacity(2)
                             .push(connect)

--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -18,7 +18,7 @@ use futures::{SinkExt, StreamExt};
 use secure_string::SecureString;
 use tokio::sync::Mutex;
 
-use super::{NM_CONNECTION_EDITOR};
+use super::NM_CONNECTION_EDITOR;
 use super::backend as network_manager;
 use super::backend::available_wifi::{AccessPoint, NetworkType};
 use super::backend::current_networks::ActiveConnectionInfo;
@@ -166,7 +166,9 @@ impl page::Page<crate::pages::Message> for Page {
         &self,
         sections: &mut slotmap::SlotMap<section::Entity, Section<crate::pages::Message>>,
     ) -> Option<page::Content> {
-        Some(vec![sections.insert(devices_view(self.connection_editor_available))])
+        Some(vec![
+            sections.insert(devices_view(self.connection_editor_available)),
+        ])
     }
 
     fn dialog(&'_ self) -> Option<Element<'_, crate::pages::Message>> {

--- a/cosmic-settings/src/pages/networking/wired.rs
+++ b/cosmic-settings/src/pages/networking/wired.rs
@@ -13,6 +13,7 @@ use cosmic::{Apply, Element, Task};
 use cosmic_settings_page::{self as page, Section, section};
 use futures::{SinkExt, StreamExt};
 
+use super::{NM_CONNECTION_EDITOR};
 use super::backend as network_manager;
 use super::backend::NetworkManagerState;
 use super::backend::current_networks::ActiveConnectionInfo;
@@ -89,6 +90,7 @@ pub struct Page {
     withheld_devices: Option<Vec<Arc<network_manager::devices::DeviceInfo>>>,
     /// Withhold active connections update if the view more popup is shown.
     withheld_active_conns: Option<Vec<ActiveConnectionInfo>>,
+    connection_editor_available: bool
 }
 
 #[derive(Debug)]
@@ -141,19 +143,25 @@ impl page::Page<crate::pages::Message> for Page {
     }
 
     fn header_view(&self) -> Option<cosmic::Element<'_, crate::pages::Message>> {
-        Some(
-            widget::button::standard(fl!("add-network", "profile"))
-                .trailing_icon(icon::from_name("window-pop-out-symbolic"))
-                .on_press(Message::AddNetwork)
-                .apply(widget::container)
-                .width(Length::Fill)
-                .align_x(Alignment::End)
-                .apply(Element::from)
-                .map(crate::pages::Message::Wired),
-        )
+        if self.connection_editor_available {
+            Some(
+                widget::button::standard(fl!("add-network", "profile"))
+                    .trailing_icon(icon::from_name("window-pop-out-symbolic"))
+                    .on_press(Message::AddNetwork)
+                    .apply(widget::container)
+                    .width(Length::Fill)
+                    .align_x(Alignment::End)
+                    .apply(Element::from)
+                    .map(crate::pages::Message::Wired),
+            )
+        } else {
+            None
+        }
     }
 
     fn on_enter(&mut self) -> cosmic::Task<crate::pages::Message> {
+        self.connection_editor_available = which::which(NM_CONNECTION_EDITOR).is_ok();
+
         if self.nm_task.is_none() {
             return cosmic::task::future(async move {
                 nmrs::NetworkManager::new()
@@ -516,10 +524,12 @@ impl Page {
                                             disconnect_txt,
                                         )
                                     }))
-                                    .push(popup_button(
-                                        Message::Settings(connection.uuid.clone()),
-                                        settings_txt,
-                                    ))
+                                    .push_maybe(self.connection_editor_available.then(|| {
+                                        popup_button(
+                                            Message::Settings(connection.uuid.clone()),
+                                            settings_txt,
+                                        )
+                                    }))
                                     .push_maybe(has_multiple_connection_profiles.then(|| {
                                         popup_button(
                                             Message::RemoveProfileRequest(connection.uuid.clone()),

--- a/cosmic-settings/src/pages/networking/wired.rs
+++ b/cosmic-settings/src/pages/networking/wired.rs
@@ -13,7 +13,7 @@ use cosmic::{Apply, Element, Task};
 use cosmic_settings_page::{self as page, Section, section};
 use futures::{SinkExt, StreamExt};
 
-use super::{NM_CONNECTION_EDITOR};
+use super::NM_CONNECTION_EDITOR;
 use super::backend as network_manager;
 use super::backend::NetworkManagerState;
 use super::backend::current_networks::ActiveConnectionInfo;
@@ -90,7 +90,7 @@ pub struct Page {
     withheld_devices: Option<Vec<Arc<network_manager::devices::DeviceInfo>>>,
     /// Withhold active connections update if the view more popup is shown.
     withheld_active_conns: Option<Vec<ActiveConnectionInfo>>,
-    connection_editor_available: bool
+    connection_editor_available: bool,
 }
 
 #[derive(Debug)]

--- a/cosmic-settings/src/pages/networking/wired.rs
+++ b/cosmic-settings/src/pages/networking/wired.rs
@@ -505,47 +505,53 @@ impl Page {
                             .into()
                     };
 
-                    let view_more_button =
-                        widget::button::icon(widget::icon::from_name("view-more-symbolic"));
+                    let view_more: Option<Element<_>> = if (is_connected || self.connection_editor_available || has_multiple_connection_profiles) {
+                        let view_more_button =
+                            widget::button::icon(widget::icon::from_name("view-more-symbolic"));
 
-                    let view_more: Option<Element<_>> = if self
-                        .view_more_popup
-                        .as_deref()
-                        .is_some_and(|id| id == connection.uuid.as_ref())
-                    {
-                        widget::popover(view_more_button.on_press(Message::ViewMore(None)))
-                            .position(widget::popover::Position::Bottom)
-                            .on_close(Message::ViewMore(None))
-                            .popup(
-                                widget::column::with_capacity(3)
-                                    .push_maybe(is_connected.then(|| {
-                                        popup_button(
-                                            Message::Deactivate(connection.uuid.clone()),
-                                            disconnect_txt,
-                                        )
-                                    }))
-                                    .push_maybe(self.connection_editor_available.then(|| {
-                                        popup_button(
-                                            Message::Settings(connection.uuid.clone()),
-                                            settings_txt,
-                                        )
-                                    }))
-                                    .push_maybe(has_multiple_connection_profiles.then(|| {
-                                        popup_button(
-                                            Message::RemoveProfileRequest(connection.uuid.clone()),
-                                            remove_txt,
-                                        )
-                                    }))
-                                    .width(Length::Fixed(200.0))
-                                    .apply(widget::container)
-                                    .padding(cosmic::theme::spacing().space_xxs)
-                                    .class(cosmic::theme::Container::Dropdown),
-                            )
-                            .apply(|e| Some(Element::from(e)))
+                        let view_more = if self
+                            .view_more_popup
+                            .as_deref()
+                            .is_some_and(|id| id == connection.uuid.as_ref())
+                        {
+                            widget::popover(view_more_button.on_press(Message::ViewMore(None)))
+                                .position(widget::popover::Position::Bottom)
+                                .on_close(Message::ViewMore(None))
+                                .popup(
+                                    widget::column::with_capacity(3)
+                                        .push_maybe(is_connected.then(|| {
+                                            popup_button(
+                                                Message::Deactivate(connection.uuid.clone()),
+                                                disconnect_txt,
+                                            )
+                                        }))
+                                        .push_maybe(self.connection_editor_available.then(|| {
+                                            popup_button(
+                                                Message::Settings(connection.uuid.clone()),
+                                                settings_txt,
+                                            )
+                                        }))
+                                        .push_maybe(has_multiple_connection_profiles.then(|| {
+                                            popup_button(
+                                                Message::RemoveProfileRequest(connection.uuid.clone()),
+                                                remove_txt,
+                                            )
+                                        }))
+                                        .width(Length::Fixed(200.0))
+                                        .apply(widget::container)
+                                        .padding(cosmic::theme::spacing().space_xxs)
+                                        .class(cosmic::theme::Container::Dropdown),
+                                )
+                                .into()
+                        } else {
+                            view_more_button
+                                .on_press(Message::ViewMore(Some(connection.uuid.clone())))
+                                .into()
+                        };
+
+                        Some(view_more)
                     } else {
-                        view_more_button
-                            .on_press(Message::ViewMore(Some(connection.uuid.clone())))
-                            .apply(|e| Some(Element::from(e)))
+                        None
                     };
 
                     let controls = widget::row::with_capacity(2)


### PR DESCRIPTION
…vailable

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

