### PR TITLE
fix(search): preserve scroll position with context drawer

### DIFF
--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -63,6 +63,7 @@ pub struct SettingsApp {
     pages: page::Binder<crate::pages::Message>,
     search_active: bool,
     search_id: cosmic::widget::Id,
+    search_scroll_id: cosmic::iced::id::Id,
     search_input: String,
     search_selections: Vec<(page::Entity, section::Entity)>,
     context_title: Option<String>,
@@ -205,6 +206,7 @@ impl cosmic::Application for SettingsApp {
             pages: page::Binder::default(),
             search_active: false,
             search_id: cosmic::widget::Id::unique(),
+            search_scroll_id: cosmic::iced::id::Id::new("COSMIC_search_results_scrollable"),
             search_input: String::new(),
             search_selections: Vec::default(),
             context_title: None,
@@ -1208,6 +1210,7 @@ impl SettingsApp {
 
         self.page_container(settings::view_column(sections))
             .apply(scrollable)
+            .apply(|w| id_container(w, self.search_scroll_id.clone()))
             .into()
     }
 


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Fixes #2156.

Give the search-results scrollable its own stable named identity so libcosmic can retain its widget state when opening or closing a context drawer restructures the view tree. The identity is separate from ordinary settings-page IDs, so their scroll positions are not shared.

## Verification
- `cargo fmt --all --check`
- `cargo check -p cosmic-settings --all-features`
- `cargo test -p cosmic-settings --all-features` (40 passed)
- `cargo clippy -p cosmic-settings --all-features`
- `git diff --check`
- Manually ran `cosmic-settings` from PR head `0a82827`, searched for `window`, scrolled to `Decrease keyboard brightness`, opened its context drawer, closed it, and confirmed the search results remained at the same scroll position.
