### PR TITLE
feat(printers): add printer setup tool to COSMIC Settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,6 +1479,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmic-printers-ui"
+version = "0.1.0"
+source = "git+https://github.com/Abd002/cosmic-printers.git#8ddb9f4dd59bf125710db98d75247caf652a397e"
+dependencies = [
+ "cosmic-settings-printers-client",
+ "cosmic-settings-printers-core",
+ "futures",
+ "i18n-embed",
+ "i18n-embed-fl",
+ "libcosmic",
+ "rust-embed",
+ "slab",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
 source = "git+https://github.com/pop-os/cosmic-protocols//?rev=e95d895#e95d89504513e1407f89a189aca328fbecc9eeef"
@@ -1533,6 +1550,7 @@ dependencies = [
  "cosmic-idle-config",
  "cosmic-mime-apps",
  "cosmic-panel-config",
+ "cosmic-printers-ui",
  "cosmic-protocols",
  "cosmic-randr",
  "cosmic-randr-shell",
@@ -1731,6 +1749,28 @@ dependencies = [
  "slab",
  "slotmap",
  "url",
+]
+
+[[package]]
+name = "cosmic-settings-printers-client"
+version = "0.1.0"
+source = "git+https://github.com/Abd002/cosmic-printers.git#8ddb9f4dd59bf125710db98d75247caf652a397e"
+dependencies = [
+ "cosmic-settings-printers-core",
+ "dirs",
+ "futures-util",
+ "serde",
+ "zlink",
+]
+
+[[package]]
+name = "cosmic-settings-printers-core"
+version = "0.1.0"
+source = "git+https://github.com/Abd002/cosmic-printers.git#8ddb9f4dd59bf125710db98d75247caf652a397e"
+dependencies = [
+ "nix",
+ "serde",
+ "zlink",
 ]
 
 [[package]]
@@ -5076,6 +5116,19 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases 0.2.2",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "nmrs"

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -35,6 +35,7 @@ cosmic-settings-bluetooth-subscription = { path = "../subscriptions/bluetooth", 
 cosmic-settings-sound = { path = "../pages/sound", optional = true }
 cosmic-settings-upower-subscription = { path = "../subscriptions/upower", optional = true }
 cosmic-settings-wallpaper = { path = "../pages/wallpapers" }
+cosmic-printers-ui = { git = "https://github.com/Abd002/cosmic-printers.git", optional = true }
 cosmic-settings-daemon-config = { git = "https://github.com/pop-os/cosmic-settings-daemon", optional = true }
 derive_setters = "0.1.9"
 dirs = "6.0.0"
@@ -135,6 +136,7 @@ linux = [
     "page-users",
     "page-window-management",
     "page-workspaces",
+    "page-printers",
     "xdg-portal",
     "wayland",
 ]
@@ -185,6 +187,7 @@ page-sound = ["dep:cosmic-settings-audio-client", "dep:cosmic-settings-sound"]
 page-users = ["xdg-portal", "dep:accounts-zbus", "dep:zbus", "dep:zbus_polkit"]
 page-window-management = ["cosmic-comp-config", "dep:cosmic-settings-config"]
 page-workspaces = ["cosmic-comp-config"]
+page-printers = ["dep:cosmic-printers-ui"]
 
 # Other features
 a11y = ["libcosmic/a11y"]

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -16,6 +16,8 @@ use crate::pages::input;
 use crate::pages::networking;
 #[cfg(feature = "page-power")]
 use crate::pages::power;
+#[cfg(feature = "page-printers")]
+use crate::pages::printers;
 #[cfg(feature = "page-sound")]
 use crate::pages::sound;
 use crate::pages::{self, applications, system, time};
@@ -117,6 +119,8 @@ impl SettingsApp {
             }
             #[cfg(feature = "page-power")]
             PageCommands::Power => self.pages.page_id::<power::Page>(),
+            #[cfg(feature = "page-printers")]
+            PageCommands::Printers => self.pages.page_id::<printers::Page>(),
             #[cfg(feature = "page-region")]
             PageCommands::RegionLanguage => self.pages.page_id::<time::region::Page>(),
             #[cfg(feature = "page-sound")]
@@ -230,6 +234,8 @@ impl cosmic::Application for SettingsApp {
         app.insert_page::<applications::Page>();
         app.insert_page::<time::Page>();
         app.insert_page::<system::Page>();
+        #[cfg(feature = "page-printers")]
+        app.insert_page::<printers::Page>();
 
         let active_id = match flags.sub_command {
             Some(p) => app.subtask_to_page(&p),
@@ -400,6 +406,36 @@ impl cosmic::Application for SettingsApp {
 
             Message::PageMessage(message) => match message {
                 crate::pages::Message::CloseContextDrawer => return self.close_context_drawer(),
+
+                // Shared printer screens do not own Settings page identities.
+                #[cfg(feature = "page-printers")]
+                crate::pages::Message::PrinterRequest(request) => {
+                    use cosmic_printers_ui::Request;
+
+                    return match request {
+                        Request::GoBack => match self.pages.page_id::<printers::Page>() {
+                            Some(entity) => cosmic::task::message(Message::PageMessage(
+                                crate::pages::Message::Page(entity),
+                            )),
+                            None => cosmic::Task::none(),
+                        },
+                        Request::ShowDetails => {
+                            match self.pages.page_id::<printers::details::Page>() {
+                                Some(entity) => cosmic::task::message(Message::PageMessage(
+                                    crate::pages::Message::Page(entity),
+                                )),
+                                None => cosmic::Task::none(),
+                            }
+                        }
+                        Request::ShowQueue => match self.pages.page_id::<printers::queue::Page>() {
+                            Some(entity) => {
+                                cosmic::task::message(Message::OpenContextDrawer(entity))
+                            }
+                            None => cosmic::Task::none(),
+                        },
+                        Request::Surface(action) => cosmic::task::message(Message::Surface(action)),
+                    };
+                }
 
                 #[cfg(feature = "page-accessibility")]
                 crate::pages::Message::Accessibility(message) => {
@@ -694,6 +730,27 @@ impl cosmic::Application for SettingsApp {
                 #[cfg(feature = "page-workspaces")]
                 crate::pages::Message::Workspaces(message) => {
                     if let Some(page) = self.pages.page_mut::<desktop::workspaces::Page>() {
+                        return page.update(message).map(Into::into);
+                    }
+                }
+
+                #[cfg(feature = "page-printers")]
+                crate::pages::Message::PrinterDetails(message) => {
+                    if let Some(page) = self.pages.page_mut::<printers::details::Page>() {
+                        return page.update(message).map(Into::into);
+                    }
+                }
+
+                #[cfg(feature = "page-printers")]
+                crate::pages::Message::PrinterQueue(message) => {
+                    if let Some(page) = self.pages.page_mut::<printers::queue::Page>() {
+                        return page.update(message).map(Into::into);
+                    }
+                }
+
+                #[cfg(feature = "page-printers")]
+                crate::pages::Message::Printers(message) => {
+                    if let Some(page) = self.pages.page_mut::<printers::Page>() {
                         return page.update(message).map(Into::into);
                     }
                 }

--- a/cosmic-settings/src/main.rs
+++ b/cosmic-settings/src/main.rs
@@ -122,6 +122,9 @@ pub enum PageCommands {
     /// Power settings page
     #[cfg(feature = "page-power")]
     Power,
+    /// Printers settings page
+    #[cfg(feature = "page-printers")]
+    Printers,
     /// Region & Language settings page
     #[cfg(feature = "page-region")]
     RegionLanguage,

--- a/cosmic-settings/src/pages/mod.rs
+++ b/cosmic-settings/src/pages/mod.rs
@@ -17,6 +17,8 @@ pub mod input;
 pub mod networking;
 #[cfg(feature = "page-power")]
 pub mod power;
+#[cfg(feature = "page-printers")]
+pub mod printers;
 #[cfg(feature = "page-sound")]
 pub mod sound;
 pub mod system;
@@ -82,6 +84,10 @@ pub enum Message {
     PanelApplet(desktop::panel::applets_inner::Message),
     #[cfg(feature = "page-power")]
     Power(power::Message),
+    #[cfg(feature = "page-printers")]
+    PrinterDetails(printers::details::Message),
+    #[cfg(feature = "page-printers")]
+    PrinterQueue(printers::queue::Message),
     #[cfg(feature = "page-region")]
     Region(time::region::Message),
     #[cfg(feature = "page-sound")]
@@ -107,6 +113,11 @@ pub enum Message {
     Wired(networking::wired::Message),
     #[cfg(feature = "page-workspaces")]
     Workspaces(desktop::workspaces::Message),
+    #[cfg(feature = "page-printers")]
+    Printers(printers::Message),
+    /// Navigation and surface requests that Settings must route.
+    #[cfg(feature = "page-printers")]
+    PrinterRequest(cosmic_printers_ui::Request),
 
     // Common page functionality
     CloseContextDrawer,

--- a/cosmic-settings/src/pages/printers/details.rs
+++ b/cosmic-settings/src/pages/printers/details.rs
@@ -1,0 +1,169 @@
+//! Adapts the shared printer-details screen to a Settings page.
+
+use cosmic::Element;
+use cosmic::iced::{Subscription, event, keyboard};
+use cosmic_printers_ui::strings;
+use cosmic_settings_page::{self as page, Section, section};
+use slotmap::SlotMap;
+
+pub use cosmic_printers_ui::details::Message;
+
+#[derive(Default)]
+pub struct Page {
+    entity: page::Entity,
+    pub(crate) ui: cosmic_printers_ui::details::State,
+}
+
+impl Page {
+    pub fn update(&mut self, message: Message) -> cosmic::app::Task<crate::Message> {
+        self.ui.update(message)
+    }
+}
+
+impl From<Message> for crate::pages::Message {
+    fn from(message: Message) -> Self {
+        crate::pages::Message::PrinterDetails(message)
+    }
+}
+
+impl From<Message> for crate::app::Message {
+    fn from(message: Message) -> Self {
+        crate::pages::Message::PrinterDetails(message).into()
+    }
+}
+
+impl page::AutoBind<crate::pages::Message> for Page {}
+
+impl page::Page<crate::pages::Message> for Page {
+    fn set_id(&mut self, entity: page::Entity) {
+        self.entity = entity;
+    }
+
+    fn info(&self) -> page::Info {
+        page::Info::new("printer-details", "printer-symbolic")
+            .title(strings::printer_details())
+            .description(strings::printer_details_description())
+    }
+
+    fn subscription(&self, _core: &cosmic::Core) -> Subscription<crate::pages::Message> {
+        event::listen_with(|event, _, _| match event {
+            cosmic::iced::Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
+                Some(crate::pages::Message::PrinterQueue(
+                    super::queue::Message::ModifiersChanged(modifiers),
+                ))
+            }
+            _ => None,
+        })
+    }
+
+    fn header(&self) -> Option<Element<'_, crate::pages::Message>> {
+        cosmic_printers_ui::details::header_view(&self.ui)
+            .map(|element| element.map(crate::pages::Message::PrinterDetails))
+    }
+
+    fn content(
+        &self,
+        sections: &mut SlotMap<section::Entity, Section<crate::pages::Message>>,
+    ) -> Option<page::Content> {
+        Some(vec![
+            sections.insert(default_and_queue()),
+            sections.insert(printer_information()),
+            sections.insert(printer_preferences()),
+            sections.insert(supplies()),
+            sections.insert(remove_printer()),
+            sections.insert(nothing_selected()),
+        ])
+    }
+
+    fn dialog(&self) -> Option<Element<'_, crate::pages::Message>> {
+        cosmic_printers_ui::details::dialog_view(&self.ui)
+            .map(|element| element.map(crate::pages::Message::PrinterDetails))
+    }
+}
+
+fn nothing_selected() -> Section<crate::pages::Message> {
+    Section::default()
+        // Not a setting, so it has no business in search results.
+        .search_ignore()
+        .show_while::<Page>(|page| !page.ui.has_printer())
+        .view::<Page>(|_binder, _page, _section| {
+            cosmic_printers_ui::details::nothing_selected_view()
+                .map(crate::pages::Message::PrinterDetails)
+        })
+}
+
+fn default_and_queue() -> Section<crate::pages::Message> {
+    crate::slab!(descriptions {
+        _set_default = strings::set_as_default_printer();
+        _queue = strings::printer_queue();
+    });
+
+    Section::default()
+        .title(strings::printer_details())
+        .descriptions(descriptions)
+        .show_while::<Page>(|page| page.ui.has_printer())
+        .view::<Page>(move |_binder, page, section| {
+            cosmic_printers_ui::details::default_and_queue_view(&page.ui, &section.title)
+                .map(crate::pages::Message::PrinterDetails)
+        })
+}
+
+fn printer_information() -> Section<crate::pages::Message> {
+    let [location, model, device_name, driver_version] = strings::printer_information_rows();
+    crate::slab!(descriptions {
+        _location_row = location;
+        _model_row = model;
+        _device_name_row = device_name;
+        _driver_version_row = driver_version;
+    });
+
+    Section::default()
+        .title(strings::printer_information())
+        .descriptions(descriptions)
+        .show_while::<Page>(|page| page.ui.has_printer())
+        .view::<Page>(move |_binder, page, section| {
+            cosmic_printers_ui::details::printer_information_view(&page.ui, &section.title)
+                .map(crate::pages::Message::PrinterDetails)
+        })
+}
+
+fn printer_preferences() -> Section<crate::pages::Message> {
+    let [paper_size, print_sides] = strings::printing_preferences_rows();
+    crate::slab!(descriptions {
+        _paper_size_row = paper_size;
+        _print_sides_row = print_sides;
+    });
+
+    Section::default()
+        .title(strings::printing_preferences())
+        .descriptions(descriptions)
+        .show_while::<Page>(|page| page.ui.has_printer())
+        .view::<Page>(move |_binder, page, section| {
+            cosmic_printers_ui::details::printer_preferences_view(
+                &page.ui,
+                &section.title,
+                crate::Message::from,
+            )
+            .map(crate::pages::Message::PrinterDetails)
+        })
+}
+
+fn supplies() -> Section<crate::pages::Message> {
+    Section::default()
+        .title(strings::supplies())
+        .show_while::<Page>(|page| page.ui.has_supplies())
+        .view::<Page>(|_binder, page, section| {
+            cosmic_printers_ui::details::supplies_view(&page.ui, &section.title)
+                .map(crate::pages::Message::PrinterDetails)
+        })
+}
+
+fn remove_printer() -> Section<crate::pages::Message> {
+    Section::default()
+        .title(strings::remove_printer())
+        .show_while::<Page>(|page| page.ui.can_remove_printer())
+        .view::<Page>(|_binder, page, _section| {
+            cosmic_printers_ui::details::remove_printer_view(&page.ui)
+                .map(crate::pages::Message::PrinterDetails)
+        })
+}

--- a/cosmic-settings/src/pages/printers/mod.rs
+++ b/cosmic-settings/src/pages/printers/mod.rs
@@ -1,0 +1,138 @@
+//! Adapts the shared printer screens to COSMIC Settings pages.
+
+pub mod details;
+pub mod queue;
+
+use cosmic::Element;
+use cosmic::iced::{Subscription, event, keyboard};
+use cosmic_printers_ui::strings;
+use cosmic_settings_page::{self as page, Section, section};
+use slotmap::SlotMap;
+
+pub use cosmic_printers_ui::list::Message;
+
+#[derive(Default)]
+pub struct Page {
+    entity: page::Entity,
+    pub(crate) ui: cosmic_printers_ui::list::State,
+}
+
+impl Page {
+    pub fn update(&mut self, message: Message) -> cosmic::app::Task<crate::Message> {
+        self.ui.update(message)
+    }
+}
+
+impl From<Message> for crate::pages::Message {
+    fn from(message: Message) -> Self {
+        crate::pages::Message::Printers(message)
+    }
+}
+
+impl From<Message> for crate::Message {
+    fn from(message: Message) -> Self {
+        crate::Message::PageMessage(message.into())
+    }
+}
+
+/// Required because task mapping does not chain `From` conversions.
+impl From<cosmic_printers_ui::add_printer::Message> for crate::Message {
+    fn from(message: cosmic_printers_ui::add_printer::Message) -> Self {
+        crate::Message::from(Message::AddPrinter(message))
+    }
+}
+
+impl From<cosmic_printers_ui::Request> for crate::pages::Message {
+    fn from(request: cosmic_printers_ui::Request) -> Self {
+        crate::pages::Message::PrinterRequest(request)
+    }
+}
+
+impl From<cosmic_printers_ui::Request> for crate::Message {
+    fn from(request: cosmic_printers_ui::Request) -> Self {
+        crate::Message::PageMessage(request.into())
+    }
+}
+
+impl page::Page<crate::pages::Message> for Page {
+    fn set_id(&mut self, entity: page::Entity) {
+        self.entity = entity;
+    }
+
+    fn info(&self) -> page::Info {
+        page::Info::new("printers", "printer-symbolic").title(strings::printers())
+    }
+
+    fn header(&self) -> Option<Element<'_, crate::pages::Message>> {
+        Some(cosmic_printers_ui::list::page_header().map(crate::pages::Message::Printers))
+    }
+
+    fn dialog(&self) -> Option<Element<'_, crate::pages::Message>> {
+        self.ui.add_printer_dialog().map(|dialog| {
+            cosmic_printers_ui::add_printer::dialog(dialog)
+                .map(Message::AddPrinter)
+                .map(crate::pages::Message::Printers)
+        })
+    }
+
+    fn on_enter(&mut self) -> cosmic::Task<crate::pages::Message> {
+        cosmic::task::message(crate::pages::Message::Printers(Message::Refresh))
+    }
+
+    fn subscription(&self, _core: &cosmic::Core) -> Subscription<crate::pages::Message> {
+        Subscription::batch([
+            Subscription::run(printer_events).map(crate::pages::Message::Printers),
+            // The queue is a drawer, so the visible printer page forwards modifiers to it.
+            event::listen_with(|event, _, _| match event {
+                cosmic::iced::Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
+                    Some(crate::pages::Message::PrinterQueue(
+                        queue::Message::ModifiersChanged(modifiers),
+                    ))
+                }
+                _ => None,
+            }),
+        ])
+    }
+
+    fn content(
+        &self,
+        sections: &mut SlotMap<section::Entity, Section<crate::pages::Message>>,
+    ) -> Option<page::Content> {
+        Some(vec![
+            sections.insert(default_printer_section()),
+            sections.insert(printers_section()),
+        ])
+    }
+}
+
+impl page::AutoBind<crate::pages::Message> for Page {
+    fn sub_pages(page: page::Insert<crate::pages::Message>) -> page::Insert<crate::pages::Message> {
+        page.sub_page::<details::Page>().sub_page::<queue::Page>()
+    }
+}
+
+fn printer_events() -> impl cosmic::iced::futures::Stream<Item = Message> {
+    cosmic_printers_ui::list::printer_events_subscription(cosmic_printers_ui::Backend::default())
+}
+
+fn default_printer_section() -> Section<crate::pages::Message> {
+    crate::slab!(descriptions {
+        _default_printer = strings::default_printer();
+    });
+
+    Section::default()
+        .title(strings::default_printer())
+        .descriptions(descriptions)
+        .view::<Page>(move |_binder, page, _section| {
+            cosmic_printers_ui::list::default_printer_view(&page.ui, crate::Message::from)
+                .map(crate::pages::Message::Printers)
+        })
+}
+
+fn printers_section() -> Section<crate::pages::Message> {
+    Section::default()
+        .title(strings::printers())
+        .view::<Page>(|_binder, page, _section| {
+            cosmic_printers_ui::list::printers_view(&page.ui).map(crate::pages::Message::Printers)
+        })
+}

--- a/cosmic-settings/src/pages/printers/queue.rs
+++ b/cosmic-settings/src/pages/printers/queue.rs
@@ -1,0 +1,72 @@
+//! Adapts the shared print queue to a Settings context drawer.
+
+use cosmic::app::context_drawer::ContextDrawer;
+use cosmic_settings_page::{self as page, Section, section};
+use slotmap::SlotMap;
+
+pub use cosmic_printers_ui::queue::Message;
+
+#[derive(Default)]
+pub struct Page {
+    entity: page::Entity,
+    pub(crate) ui: cosmic_printers_ui::queue::State,
+}
+
+impl Page {
+    pub fn update(&mut self, message: Message) -> cosmic::app::Task<crate::Message> {
+        self.ui.update(message)
+    }
+}
+
+impl From<Message> for crate::pages::Message {
+    fn from(message: Message) -> Self {
+        crate::pages::Message::PrinterQueue(message)
+    }
+}
+
+impl From<Message> for crate::app::Message {
+    fn from(message: Message) -> Self {
+        crate::pages::Message::PrinterQueue(message).into()
+    }
+}
+
+impl page::AutoBind<crate::pages::Message> for Page {}
+
+impl page::Page<crate::pages::Message> for Page {
+    fn set_id(&mut self, entity: page::Entity) {
+        self.entity = entity;
+    }
+
+    fn info(&self) -> page::Info {
+        page::Info::new("printer-queue", "printer-symbolic")
+            .title(cosmic_printers_ui::strings::printer_queue())
+            .description(cosmic_printers_ui::strings::printer_queue_description())
+    }
+
+    fn content(
+        &self,
+        _sections: &mut SlotMap<section::Entity, Section<crate::pages::Message>>,
+    ) -> Option<page::Content> {
+        None
+    }
+
+    fn context_drawer(&self) -> Option<ContextDrawer<'_, crate::pages::Message>> {
+        if !self.ui.has_printer() {
+            return None;
+        }
+
+        Some(
+            cosmic::app::context_drawer(
+                cosmic_printers_ui::queue::queue_view(&self.ui)
+                    .map(crate::pages::Message::PrinterQueue),
+                crate::pages::Message::CloseContextDrawer,
+            )
+            .title(cosmic_printers_ui::strings::printer_queue()),
+        )
+    }
+
+    fn on_context_drawer_close(&mut self) -> cosmic::Task<crate::pages::Message> {
+        self.ui.clear_selection();
+        cosmic::Task::none()
+    }
+}


### PR DESCRIPTION
## PR Description

This PR adds a Printers page to COSMIC Settings using the shared [`cosmic-printers-ui`](https://github.com/Abd002/cosmic-printers) library.

It supports:

- Discovering IPP printers and adding legacy printers through Printer Applications.
- Group printers by common source: same physical hardware, same remote host, or same Printer Application.
- Viewing printer information, preferences, and supply levels.
- Viewing and managing print jobs.
- Opening printer web interfaces.
- Receiving live updates from the printer backend.

Printer operations are handled through Varlink by the related `cosmic-settings-daemon` integration, which communicates with the printing backend and provides printer state updates and management APIs to the UI.

### Demo
https://github.com/user-attachments/assets/0abfc16b-3e51-4fb1-9e8e-8fd27370e0a4

### How to test

Prerequisites: A Linux system with [CUPS](https://github.com/OpenPrinting/cups) installed and running, the [CUPS 3 client library (`libcups3`)](https://github.com/OpenPrinting/libcups) and its development files, and [`cosmic-settings-daemon`](https://github.com/pop-os/cosmic-settings-daemon/pull/188) running with the printer Varlink service available.

Once the prerequisites are available, run:

```sh
just run
```
Open the **Printers** page and test printer discovery, configuration, details, and queue management.

### TODO

- [ ] Add manual printer setup via IP address/hostname for undiscovered printers.
- [ ] Support user-only and system-wide printer profiles.

---

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.