### PR TITLE
refactor(wifi): show available networks before saved networks

### DIFF
--- a/cosmic-settings/src/pages/networking/wifi.rs
+++ b/cosmic-settings/src/pages/networking/wifi.rs
@@ -1162,10 +1162,6 @@ fn devices_view() -> Section<crate::pages::Message> {
                     }
                 }
 
-                if has_known {
-                    view = view.push(known_networks);
-                }
-
                 // Build Visible Networks section (searchable when 15+ networks, filtered when user types)
                 let show_search = state.wireless_access_points.len() >= 15;
                 let search_query_lower = page.search_query.trim().to_lowercase();
@@ -1273,6 +1269,10 @@ fn devices_view() -> Section<crate::pages::Message> {
                     }
 
                     view = view.push(visible_section.spacing(spacing.space_xs));
+                }
+
+                if has_known {
+                    view = view.push(known_networks);
                 }
             };
 


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Summary

- Moves the visible networks section to render **before** the known networks section in the WiFi settings page.
- Currently available networks now appear at the top (sorted by signal strength).
- Saved/known networks appear below (sorted alphabetically).
- Matches the UX pattern of other distro DE settings apps where "available networks" take priority over "saved networks."
- Preserves the existing search bar behavior (shown when 15+ networks are visible).

## Motivation

Users opening the WiFi settings panel need to see nearby networks first — they're the primary action target. A long list of saved networks pushing available networks to the bottom was confusing and required scrolling.

## Test plan

- [ ] Open WiFi settings with several available networks and saved networks.
- [ ] Verify available networks section appears at the top.
- [ ] Verify saved networks section appears below.
- [ ] Verify search bar still appears when 15+ networks are in range and filters correctly.
- [ ] Verify connecting/disconnecting/forgetting still works for both sections.
