### PR TITLE
fix(network): bump nmrs to 3.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -289,7 +289,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2159,7 +2159,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2349,7 +2349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4516,7 +4516,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5079,9 +5079,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nmrs"
-version = "3.5.0"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84eac3f02c7970440ee58eeedc085b44ea4ad7161d7763457ae2389b415a84c8"
+checksum = "aa84a0ad51eda83c8817099a0b613847599c712d049e89d892cca53ed6c4a337"
 dependencies = [
  "async-trait",
  "base64",
@@ -5163,7 +5163,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6488,7 +6488,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6959,7 +6959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7209,10 +7209,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7637,7 +7637,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8301,7 +8301,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -54,7 +54,7 @@ locale1 = { git = "https://github.com/pop-os/dbus-settings-bindings", optional =
 sysinfo = { version = "=0.38.0", optional = true }
 mime-apps = { package = "cosmic-mime-apps", git = "https://github.com/pop-os/cosmic-mime-apps", features = ["tokio"], optional = true }
 notify = "8.2.0"
-nmrs = { version = "3.4.2", optional = true }
+nmrs = { version = "3.5.2", optional = true }
 regex = "1.13.1"
 ron = "0.12"
 rust-embed = "8.12.0"

--- a/cosmic-settings/src/pages/bluetooth/mod.rs
+++ b/cosmic-settings/src/pages/bluetooth/mod.rs
@@ -364,8 +364,8 @@ impl page::Page<crate::pages::Message> for Page {
                     .on_input(|value| Message::RenameDeviceInput(value))
                     .on_submit(|_| Message::RenameDeviceConfirm);
 
-                let rename_button =
-                    widget::button::suggested(fl!("rename")).on_press_maybe(is_valid.then_some(Message::RenameDeviceConfirm));
+                let rename_button = widget::button::suggested(fl!("rename"))
+                    .on_press_maybe(is_valid.then_some(Message::RenameDeviceConfirm));
 
                 let cancel_button =
                     widget::button::standard(fl!("cancel")).on_press(Message::RenameDeviceCancel);
@@ -660,7 +660,7 @@ impl Page {
 
                         _ => (),
                     }
-                },
+                }
 
                 Event::DeviceRenameFailed(path) => {
                     tracing::warn!("Failed to rename device {path}");
@@ -896,7 +896,11 @@ impl Page {
             Message::RenameDeviceConfirm => {
                 if let Some(Dialog::RenameDevice { path, name }) = self.dialog.take() {
                     if let Some(connection) = self.connection.clone() {
-                        return cosmic::task::future(rename_device(connection, path, name.trim().into()));
+                        return cosmic::task::future(rename_device(
+                            connection,
+                            path,
+                            name.trim().into(),
+                        ));
                     } else {
                         tracing::warn!("No DBus connection ready");
                     }

--- a/cosmic-settings/src/pages/networking/backend.rs
+++ b/cosmic-settings/src/pages/networking/backend.rs
@@ -620,11 +620,10 @@ async fn handle_request(nm: &NetworkManager, req: Request) -> Event {
         )
         .await
         .is_ok(),
-        Request::ActivateVpn(uuid) => {
-            nm.connect_by_uuid(uuid, ConnectByUuidConfig::default())
-                .await
-                .is_ok()
-        }
+        Request::ActivateVpn(uuid) => nm
+            .connect_by_uuid(uuid, ConnectByUuidConfig::default())
+            .await
+            .is_ok(),
         Request::Deactivate(uuid) => deactivate_by_uuid(nm, uuid).await.is_ok(),
         Request::Disconnect(ssid) => disconnect_wifi_by_ssid(nm, ssid).await.is_ok(),
         Request::Forget(ssid) => nm.forget(ssid).await.is_ok(),

--- a/cosmic-settings/src/pages/networking/backend.rs
+++ b/cosmic-settings/src/pages/networking/backend.rs
@@ -14,8 +14,8 @@ use nmrs::agent::{SecretAgent, SecretAgentFlags, SecretRequest, SecretResponder,
 use nmrs::raw::zbus;
 use nmrs::raw::zvariant::{Dict, OwnedObjectPath, OwnedValue, Str, Value};
 use nmrs::{
-    ActiveConnection, ConnectType, ConnectionOptions, EapOptions, NetworkEvent, NetworkManager,
-    SavedConnection, SettingsSummary, WifiKeyMgmt, WifiSecurity,
+    ActiveConnection, ConnectByUuidConfig, ConnectType, ConnectionOptions, EapOptions,
+    NetworkEvent, NetworkManager, SavedConnection, SettingsSummary, WifiKeyMgmt, WifiSecurity,
 };
 use secure_string::SecureString;
 use tokio::sync::oneshot;
@@ -620,7 +620,11 @@ async fn handle_request(nm: &NetworkManager, req: Request) -> Event {
         )
         .await
         .is_ok(),
-        Request::ActivateVpn(uuid) => nm.connect_vpn_by_uuid(uuid).await.is_ok(),
+        Request::ActivateVpn(uuid) => {
+            nm.connect_by_uuid(uuid, ConnectByUuidConfig::default())
+                .await
+                .is_ok()
+        }
         Request::Deactivate(uuid) => deactivate_by_uuid(nm, uuid).await.is_ok(),
         Request::Disconnect(ssid) => disconnect_wifi_by_ssid(nm, ssid).await.is_ok(),
         Request::Forget(ssid) => nm.forget(ssid).await.is_ok(),
@@ -907,7 +911,7 @@ async fn disconnect_wifi_by_ssid(nm: &NetworkManager, ssid: &str) -> Result<(), 
 }
 
 async fn deactivate_by_uuid(nm: &NetworkManager, uuid: &str) -> Result<(), Error> {
-    if nm.disconnect_vpn_by_uuid(uuid).await.is_ok() {
+    if nm.disconnect_by_uuid(uuid).await.is_ok() {
         return Ok(());
     }
 

--- a/cosmic-settings/src/pages/sound/applications.rs
+++ b/cosmic-settings/src/pages/sound/applications.rs
@@ -5,8 +5,7 @@ use super::model;
 use cosmic::desktop::{
     DesktopEntryCache, DesktopLookupContext, DesktopResolveOptions, resolve_desktop_entry,
 };
-use cosmic::iced::futures;
-use cosmic::iced::{self, Alignment, Length, window};
+use cosmic::iced::{self, Alignment, Length, futures, window};
 use cosmic::widget::space::horizontal as horizontal_space;
 use cosmic::{Apply, Element, surface, widget};
 use cosmic_config::{Config, ConfigGet};


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
------

Bump `nmrs` from 3.4.2 (lock 3.5.0) to 3.5.2 and migrate to non-deprecated connect/disconnect APIs.

The following issues are thus, now adressed:

- `connect`/`connect_to_bssid` auto-upgrade `WpaPsk` to `Sae` when the AP advertises SAE without PSK (nmrs 3.5.1).
- saved-profile lookup no longer aborts on other users' profiles (`Settings.PermissionDenied`), so known networks stop prompting for a password and failing to connect (nmrs 3.5.2). See #2184.
  
The local `connect_sae` workaround can be removed in a follow-up once this is confirmed working.

Note: the VPN-over-Ethernet classification fix (nmrs 3.4.2) was already picked up via the 3.5.0 lock; this bump adds the SAE upgrade on top.
