### PR TITLE
Adding toggle switch to date settings page to show/hide day of week

### DIFF
--- a/cosmic-settings/src/pages/time/date.rs
+++ b/cosmic-settings/src/pages/time/date.rs
@@ -36,6 +36,7 @@ pub struct Page {
     first_day_of_week: usize,
     military_time: bool,
     show_seconds: bool,
+    show_weekday: bool,
     ntp_enabled: bool,
     show_date_in_top_panel: bool,
     timezone_context: bool,
@@ -73,6 +74,16 @@ impl Default for Page {
                 false
             });
 
+        let show_weekday = cosmic_applet_config
+            .get("show_weekday")
+            .unwrap_or_else(|err| {
+                if err.is_err() {
+                    error!(?err, "Failed to read config 'show_weekday'");
+                }
+
+                false
+            });
+
         let first_day_of_week = cosmic_applet_config
             .get("first_day_of_week")
             .unwrap_or_else(|err| {
@@ -103,6 +114,7 @@ impl Default for Page {
             local_time: None,
             military_time,
             show_seconds,
+            show_weekday,
             ntp_enabled: false,
             show_date_in_top_panel,
             timezone: None,
@@ -213,6 +225,15 @@ impl Page {
 
                 if let Err(err) = self.cosmic_applet_config.set("show_seconds", enable) {
                     error!(?err, "Failed to set config 'show_seconds'");
+                }
+            }
+
+            Message::ShowWeekday(enable) => {
+                self.show_weekday = enable;
+                self.update_local_time();
+
+                if let Err(err) = self.cosmic_applet_config.set("show_weekday", enable) {
+                    error!(?err, "Failed to set config 'show_weekday'");
                 }
             }
 
@@ -357,6 +378,7 @@ pub enum Message {
     Error(String),
     MilitaryTime(bool),
     ShowSeconds(bool),
+    ShowWeekday(bool),
     None,
     FirstDayOfWeek(usize),
     Refresh(Info),
@@ -395,6 +417,7 @@ fn format() -> Section<crate::pages::Message> {
     crate::slab!(descriptions {
         military = fl!("time-format", "twenty-four");
         show_seconds = fl!("time-format", "show-seconds");
+        show_weekday = fl!("time-format", "show-weekday");
         first = fl!("time-format", "first");
         show_date = fl!("time-format", "show-date");
     });
@@ -414,6 +437,11 @@ fn format() -> Section<crate::pages::Message> {
                 .add(
                     settings::item::builder(&section.descriptions[show_seconds])
                         .toggler(page.show_seconds, Message::ShowSeconds),
+                )
+                // Show abbreviated day of week
+                .add(
+                    settings::item::builder(&section.descriptions[show_weekday])
+                        .toggler(page.show_weekday, Message::ShowWeekday),
                 )
                 // First day of week
                 .add(

--- a/cosmic-settings/src/pages/time/date.rs
+++ b/cosmic-settings/src/pages/time/date.rs
@@ -21,7 +21,9 @@ use tracing::error;
 
 crate::cache_dynamic_lazy! {
     static WEEKDAYS: [String; 4] = [fl!("time-format", "friday"), fl!("time-format", "saturday"), fl!("time-format", "sunday"), fl!("time-format", "monday")];
-}
+    static SHOW_WEEKDAY: String = fl!("time-format", "show-weekday");
+    static SHOW_SECONDS: String = fl!("time-format", "show-seconds");
+    static SHOW_DATE: String = fl!("time-format", "date");}
 
 #[derive(Debug, Clone)]
 pub struct Info {
@@ -40,6 +42,7 @@ pub struct Page {
     ntp_enabled: bool,
     show_date_in_top_panel: bool,
     timezone_context: bool,
+    date_time_applet_context: bool,
     local_time: Option<DateTime<Gregorian>>,
     timezone: Option<usize>,
     timezone_list: Vec<String>,
@@ -119,6 +122,7 @@ impl Default for Page {
             show_date_in_top_panel,
             timezone: None,
             timezone_context: false,
+            date_time_applet_context: false,
             timezone_list: Vec::new(),
             timezone_search: String::new(),
         }
@@ -195,6 +199,15 @@ impl page::Page<crate::pages::Message> for Page {
                 .title(fl!("time-zone"))
                 .header(search),
             );
+        } else if self.date_time_applet_context {
+            return Some(
+                cosmic::app::context_drawer(
+                    self.date_time_applet_view()
+                        .map(crate::pages::Message::from),
+                    crate::pages::Message::CloseContextDrawer,
+                )
+                .title(fl!("date-time-applet-settings-title")),
+            );
         }
 
         None
@@ -243,6 +256,11 @@ impl Page {
                 if let Err(err) = self.cosmic_applet_config.set("first_day_of_week", weekday) {
                     error!(?err, "Failed to set config 'first_day_of_week'");
                 }
+            }
+
+            Message::DateAndTimeContext => {
+                self.date_time_applet_context = true;
+                return cosmic::task::message(crate::app::Message::OpenContextDrawer(self.entity));
             }
 
             Message::ShowDate(enable) => {
@@ -363,6 +381,25 @@ impl Page {
             .map(crate::pages::Message::DateAndTime)
     }
 
+    fn date_time_applet_view(&self) -> Element<'_, crate::pages::Message> {
+        let mut list = widget::list_column();
+
+        list = list.add(
+            settings::item::builder(&*SHOW_DATE)
+                        .toggler(self.show_date_in_top_panel, Message::ShowDate)
+        )
+        .add(
+            settings::item::builder(&*SHOW_WEEKDAY)
+                .toggler(self.show_weekday, Message::ShowWeekday),
+        )
+        .add(
+            settings::item::builder(&*SHOW_SECONDS)
+                        .toggler(self.show_seconds, Message::ShowSeconds));
+
+        list.apply(Element::from)
+            .map(crate::pages::Message::DateAndTime)
+    }
+
     fn update_local_time(&mut self) {
         self.local_time = Some(update_local_time());
 
@@ -385,6 +422,7 @@ pub enum Message {
     ShowDate(bool),
     Timezone(usize),
     TimezoneContext,
+    DateAndTimeContext,
     TimezoneSearch(String),
     UpdateTime,
     Surface(surface::Action),
@@ -416,10 +454,8 @@ fn date() -> Section<crate::pages::Message> {
 fn format() -> Section<crate::pages::Message> {
     crate::slab!(descriptions {
         military = fl!("time-format", "twenty-four");
-        show_seconds = fl!("time-format", "show-seconds");
-        show_weekday = fl!("time-format", "show-weekday");
         first = fl!("time-format", "first");
-        show_date = fl!("time-format", "show-date");
+        date_time_applet_settings_label = fl!("date-time-applet-settings-label");
     });
 
     Section::default()
@@ -432,16 +468,6 @@ fn format() -> Section<crate::pages::Message> {
                 .add(
                     settings::item::builder(&section.descriptions[military])
                         .toggler(page.military_time, Message::MilitaryTime),
-                )
-                // Show seconds in time format
-                .add(
-                    settings::item::builder(&section.descriptions[show_seconds])
-                        .toggler(page.show_seconds, Message::ShowSeconds),
-                )
-                // Show abbreviated day of week
-                .add(
-                    settings::item::builder(&section.descriptions[show_weekday])
-                        .toggler(page.show_weekday, Message::ShowWeekday),
                 )
                 // First day of week
                 .add(
@@ -472,11 +498,13 @@ fn format() -> Section<crate::pages::Message> {
                         ),
                     ),
                 )
-                // Date on top panel toggle
+                // Show a Context Drawer which contains settings for how the Date and Time applet displays the date.
                 .add(
-                    settings::item::builder(&section.descriptions[show_date])
-                        .toggler(page.show_date_in_top_panel, Message::ShowDate),
-                )
+                    crate::widget::go_next_with_item(
+                        &section.descriptions[date_time_applet_settings_label],
+                        "",
+                        Message::DateAndTimeContext,
+                ))
                 .apply(cosmic::Element::from)
                 .map(crate::pages::Message::DateAndTime)
         })

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -955,6 +955,7 @@ time-zone = Time zone
 time-format = Date & time format
     .twenty-four = 24-hour time
     .show-seconds = Show seconds
+    .show-weekday = Show day of week
     .first = First day of week
     .show-date = Show date in the time applet
     .friday = Friday

--- a/i18n/en/cosmic_settings.ftl
+++ b/i18n/en/cosmic_settings.ftl
@@ -954,14 +954,17 @@ time-zone = Time zone
 
 time-format = Date & time format
     .twenty-four = 24-hour time
-    .show-seconds = Show seconds
-    .show-weekday = Show day of week
+    .show-seconds = Seconds
+    .show-weekday = Day of week
     .first = First day of week
-    .show-date = Show date in the time applet
+    .date = Date
     .friday = Friday
     .saturday = Saturday
     .sunday = Sunday
     .monday = Monday
+
+date-time-applet-settings-title = Date & time applet
+date-time-applet-settings-label = Date & time applet settings
 
 time-region = Region & language
 


### PR DESCRIPTION
This new toggle switch allows users to show/hide a 3 letter abbreviated day of the week just before the date in the time applet. If you create the following file: `~/.config/cosmic/com.system76.CosmicAppletTime/v1/show_weekday` with the contents "true" then you see the day of week show up in the time applet, so the goal of this toggle switch is to expose that existing underlying functionality.

Here's a screenshot containing the new toggle switch:
<img width="706" height="687" alt="Image" src="https://github.com/user-attachments/assets/c9accaea-4ff0-4e99-90eb-a7e7cc9cf3df" />

And here is the difference shown in the time applet:
<img width="403" height="89" alt="Image" src="https://github.com/user-attachments/assets/aa926729-d763-451b-a5ac-1b066c1a4fe2" />

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

