### PR TITLE
show display identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,7 @@ dependencies = [
  "secret-service",
  "secure-string",
  "serde",
+ "serde_json",
  "slab",
  "slotmap",
  "smithay-client-toolkit",

--- a/cosmic-settings/Cargo.toml
+++ b/cosmic-settings/Cargo.toml
@@ -62,6 +62,7 @@ sctk = { workspace = true, optional = true }
 secure-string = "0.3.0"
 secret-service = { version = "5.1.0", features = ["rt-tokio-crypto-rust"], optional = true }
 serde = { version = "1.0.229", features = ["derive"] }
+serde_json = { version = "1", optional = true }
 slab = "0.4.12"
 slotmap = "1.1.1"
 static_init = "1.0.4"
@@ -157,7 +158,7 @@ page-bluetooth = [
 ]
 page-date = ["dep:timedate-zbus", "dep:zbus"]
 page-default-apps = ["dep:cosmic-settings-config", "dep:mime-apps"]
-page-display = ["dep:udev"]
+page-display = ["dep:serde_json", "dep:udev", "dep:zbus"]
 page-input = [
     "cosmic-comp-config",
     "gettext",

--- a/cosmic-settings/src/app.rs
+++ b/cosmic-settings/src/app.rs
@@ -274,6 +274,12 @@ impl cosmic::Application for SettingsApp {
     }
 
     fn on_app_exit(&mut self) -> Option<Self::Message> {
+        #[cfg(feature = "page-display")]
+        if self.pages.page_id::<display::Page>() == Some(self.active_page)
+            && let Some(display) = self.pages.page_mut::<display::Page>()
+        {
+            _ = display.deactivate_display_identifiers();
+        }
         self.pages.on_leave(self.active_page);
         None
     }
@@ -952,11 +958,22 @@ impl SettingsApp {
         let current_page = self.active_page;
         self.active_page = page;
 
+        #[cfg(feature = "page-display")]
+        let display_page = self.pages.page_id::<display::Page>();
+        #[cfg(feature = "page-display")]
+        let mut identifier_tasks = Vec::new();
         let mut leave_task = iced::Task::none();
         let mut close_context_drawer_task = iced::Task::none();
 
         if current_page != page {
             self.loaded_pages.remove(&current_page);
+
+            #[cfg(feature = "page-display")]
+            if display_page == Some(current_page)
+                && let Some(display) = self.pages.page_mut::<display::Page>()
+            {
+                identifier_tasks.push(display.deactivate_display_identifiers().map(Into::into));
+            }
 
             close_context_drawer_task = self.close_context_drawer();
 
@@ -981,12 +998,22 @@ impl SettingsApp {
             .map(Message::PageMessage)
             .map(Into::into);
 
-        Task::batch(vec![
+        #[cfg(feature = "page-display")]
+        if display_page == Some(page)
+            && let Some(display) = self.pages.page_mut::<display::Page>()
+        {
+            identifier_tasks.push(display.activate_display_identifiers().map(Into::into));
+        }
+
+        let mut tasks = vec![
             leave_task,
             page_task,
             close_context_drawer_task,
             cosmic::task::future(async { Message::SetWindowTitle }),
-        ])
+        ];
+        #[cfg(feature = "page-display")]
+        tasks.extend(identifier_tasks);
+        Task::batch(tasks)
     }
 
     fn set_title(&mut self) -> Task<crate::Message> {

--- a/cosmic-settings/src/pages/display/mod.rs
+++ b/cosmic-settings/src/pages/display/mod.rs
@@ -20,11 +20,32 @@ use cosmic_settings_page::{self as page, Section, section};
 use futures::SinkExt;
 use indexmap::Equivalent;
 use slotmap::{Key, SecondaryMap, SlotMap};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::process::ExitStatus;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
+use zbus::zvariant::Value;
+
+#[zbus::proxy(
+    interface = "org.freedesktop.DbusActivation",
+    default_service = "com.system76.CosmicOnScreenDisplay",
+    default_path = "/com/system76/CosmicOnScreenDisplay"
+)]
+trait OsdActivation {
+    fn activate_action(
+        &self,
+        action_name: &str,
+        parameter: Vec<&str>,
+        platform_data: HashMap<&str, Value<'_>>,
+    ) -> zbus::Result<()>;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum DisplayIdentifierState {
+    Hidden,
+    Visible(Vec<String>),
+}
 
 static DPI_SCALES: &[u32] = &[50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300];
 
@@ -141,6 +162,8 @@ pub struct Page {
     active_display: OutputKey,
     randr_handle: Option<(oneshot::Sender<()>, cosmic::iced::task::Handle)>,
     hotplug_handle: Option<(oneshot::Sender<()>, cosmic::iced::task::Handle)>,
+    display_identifier_sender: Option<watch::Sender<DisplayIdentifierState>>,
+    display_identifiers_active: bool,
     config: Config,
     cache: ViewCache,
     // context: Option<ContextDrawer>,
@@ -166,6 +189,8 @@ impl Default for Page {
             active_display: OutputKey::default(),
             randr_handle: None,
             hotplug_handle: None,
+            display_identifier_sender: None,
+            display_identifiers_active: false,
             config: Config::default(),
             cache: ViewCache::default(),
             // context: None,
@@ -479,7 +504,56 @@ impl page::Page<crate::pages::Message> for Page {
 }
 
 impl Page {
+    pub fn activate_display_identifiers(&mut self) -> Task<app::Message> {
+        self.display_identifiers_active = true;
+        self.refresh_display_identifiers()
+    }
+
+    pub fn deactivate_display_identifiers(&mut self) -> Task<app::Message> {
+        self.display_identifiers_active = false;
+        if let Some(sender) = self.display_identifier_sender.as_ref()
+            && sender.send(DisplayIdentifierState::Hidden).is_err()
+        {
+            self.display_identifier_sender = None;
+        }
+        Task::none()
+    }
+
+    fn refresh_display_identifiers(&mut self) -> Task<app::Message> {
+        if !self.display_identifiers_active {
+            return Task::none();
+        }
+
+        let outputs = ordered_display_identifiers(
+            self.list
+                .outputs
+                .values()
+                .map(|output| (output.name.as_str(), output.enabled)),
+        );
+        let state = if outputs.is_empty() {
+            DisplayIdentifierState::Hidden
+        } else {
+            DisplayIdentifierState::Visible(outputs)
+        };
+
+        if let Some(sender) = self.display_identifier_sender.as_ref()
+            && sender.send(state.clone()).is_ok()
+        {
+            return Task::none();
+        }
+
+        let (sender, receiver) = watch::channel(state);
+        self.display_identifier_sender = Some(sender);
+        Task::stream(stream::channel(
+            1,
+            move |_emitter: futures::channel::mpsc::Sender<app::Message>| async move {
+                display_identifier_worker(receiver).await;
+            },
+        ))
+    }
+
     pub fn update(&mut self, message: Message) -> Task<app::Message> {
+        let mut identifier_task = Task::none();
         match message {
             Message::RandrResult(result) => {
                 if let Some(Err(why)) = Arc::into_inner(result) {
@@ -644,6 +718,7 @@ impl Page {
                 match Arc::into_inner(randr) {
                     Some(Ok(outputs)) => {
                         self.update_displays(outputs);
+                        identifier_task = self.refresh_display_identifiers();
                     }
 
                     Some(Err(why)) => {
@@ -662,13 +737,14 @@ impl Page {
         }
 
         self.last_pan = 0.5;
-        cosmic::iced::widget::scrollable::snap_to(
+        let snap_task = cosmic::iced::widget::scrollable::snap_to(
             self.display_arrangement_scrollable.clone(),
             RelativeOffset {
                 x: Some(0.5),
                 y: Some(0.5),
             },
-        )
+        );
+        Task::batch([identifier_task, snap_task])
     }
 
     // /// Displays the night light context drawer.
@@ -1455,6 +1531,96 @@ fn cache_rates(cached_rates: &mut Vec<String>, rates: &[u32]) {
                     cached_rates.push(format_dec(rate))
                 } else {
                     cached_rates.push(format!("{} Hz", round(rate)))
+                }
+            }
+        }
+    }
+}
+
+fn ordered_display_identifiers<'a>(
+    outputs: impl IntoIterator<Item = (&'a str, bool)>,
+) -> Vec<String> {
+    let names = outputs
+        .into_iter()
+        .filter_map(|(name, enabled)| enabled.then_some(name))
+        .collect::<std::collections::BTreeSet<_>>();
+
+    if names.len() < 2 {
+        Vec::new()
+    } else {
+        names.into_iter().map(str::to_owned).collect()
+    }
+}
+
+fn display_identifier_action(state: &DisplayIdentifierState) -> String {
+    match state {
+        DisplayIdentifierState::Hidden => "\"DismissDisplayIdentifiers\"".into(),
+        DisplayIdentifierState::Visible(outputs) => {
+            serde_json::json!({ "IdentifyDisplays": { "outputs": outputs } }).to_string()
+        }
+    }
+}
+
+async fn send_display_identifier_activation(
+    state: &DisplayIdentifierState,
+    connection: &mut Option<zbus::Connection>,
+) -> anyhow::Result<()> {
+    if connection.is_none() {
+        *connection = Some(zbus::Connection::session().await?);
+    }
+    let proxy = OsdActivationProxy::new(connection.as_ref().unwrap()).await?;
+    let action = display_identifier_action(state);
+    tokio::time::timeout(
+        std::time::Duration::from_millis(400),
+        proxy.activate_action(&action, Vec::new(), HashMap::new()),
+    )
+    .await??;
+    Ok(())
+}
+
+async fn display_identifier_worker(mut receiver: watch::Receiver<DisplayIdentifierState>) {
+    let mut state = receiver.borrow_and_update().clone();
+    let mut connection = None;
+    let mut reported_error = match send_display_identifier_activation(&state, &mut connection).await
+    {
+        Ok(()) => false,
+        Err(why) => {
+            tracing::warn!(
+                why = why.to_string(),
+                "failed to update cosmic-osd display identifiers"
+            );
+            connection = None;
+            true
+        }
+    };
+    let mut interval = tokio::time::interval(std::time::Duration::from_millis(500));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    interval.tick().await;
+
+    loop {
+        let should_send = tokio::select! {
+            result = receiver.changed() => {
+                if result.is_err() {
+                    return;
+                }
+                state = receiver.borrow_and_update().clone();
+                true
+            }
+            _ = interval.tick(), if matches!(state, DisplayIdentifierState::Visible(_)) => true,
+        };
+
+        if should_send {
+            match send_display_identifier_activation(&state, &mut connection).await {
+                Ok(()) => reported_error = false,
+                Err(why) => {
+                    connection = None;
+                    if !reported_error {
+                        tracing::warn!(
+                            why = why.to_string(),
+                            "failed to update cosmic-osd display identifiers"
+                        );
+                        reported_error = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The display identifiers OSDs where originally added in https://github.com/pop-os/cosmic-osd/pull/151 and as part of implementing https://github.com/pop-os/cosmic-settings/issues/885 . Unfortunately the related previous implementation in cosmic-settings https://github.com/pop-os/cosmic-settings/pull/1554 caused regressions and was reverted in https://github.com/pop-os/cosmic-settings/pull/1605 .

This new implementation instead passes cosmic-settings existing display ordering directly to cosmic-osd, avoiding the output-management feedback loop.

depends on https://github.com/pop-os/cosmic-osd/pull/229

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

